### PR TITLE
docker related doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Running the initial demo (first cut of the service) uses Postgres in a Docker ru
 npm run pg:build
 ```
 
+Note: In case you have issues building or running it with Docker make sure you have a recent version of docker engine and docker compose.
+
 ###Start Postgres in a Docker container
 
 A Docker container with Postgres can be started with:


### PR DESCRIPTION
Although I had a docker version from february 2016 the `npm run pg:start` failed. The issue solved after I updated to latest docker engine and latest docker compose
