### PR TITLE
Reducer testing for Users and Teams

### DIFF
--- a/component/src/lib/sortByName.js
+++ b/component/src/lib/sortByName.js
@@ -1,5 +1,10 @@
+const options = {
+  localeMatcher: 'best fit',
+  usage: 'sort',
+  sensitivity: 'case',
+  caseFirst: 'upper'
+}
+
 export default (a, b) => {
-  if (a.name.toLowerCase() < b.name.toLowerCase()) return -1
-  if (a.name.toLowerCase() > b.name.toLowerCase()) return 1
-  return 0
+  return a.name.localeCompare(b.name, 'kf', options)
 }

--- a/component/test/reducers/teams.js
+++ b/component/test/reducers/teams.js
@@ -1,0 +1,139 @@
+import Lab from 'lab'
+import Code from 'code'
+
+import reducer from '../../src/reducers/teams'
+import { RECEIVE_TEAMS, RECEIVE_TEAM, DELETE_TEAM, UPDATE_TEAM, MAKE_TEAM } from '../../src/constants'
+
+const lab = exports.lab = Lab.script()
+
+lab.experiment('teams', () => {
+  const initialState = {
+    list: null
+  }
+
+  const mockedTeams = [{
+    id: 1,
+    name: 'AtEaM'
+  }, {
+    id: 2,
+    name: 'AnOtHeR'
+  }]
+
+  const mockedTeam = {
+    id: 1,
+    name: 'AtEaM',
+    policies: [{
+      id: 1,
+      name: 'ApOlIcY'
+    }],
+    users: [{
+      id: 1,
+      name: 'AuSeR'
+    }]
+  }
+
+  const stateWithSelected = {
+    list: mockedTeams,
+    selectedTeam: mockedTeam
+  }
+
+  const updatedTeam = {
+    id: 1,
+    name: 'AnUpDaTeDtEaM',
+    policies: [{
+      id: 2,
+      name: 'AnOtHeRpOlIcY'
+    }],
+    users: [{
+      id: 2,
+      name: 'AnOtHeRuSeR'
+    }]
+  }
+
+  const newTeam = {
+    id: 3,
+    name: 'AnEwTeAm',
+    policies: [],
+    users: []
+  }
+
+  lab.test('should return initial state', (done) => {
+    Code.expect(
+      reducer(undefined, {})
+    ).to.equal(
+      initialState
+    )
+
+    done()
+  })
+
+  lab.test('should handle RECEIVE_TEAMS', (done) => {
+    Code.expect(
+      reducer(initialState, {
+        type: RECEIVE_TEAMS,
+        teams: mockedTeams
+      })
+    ).to.equal({
+      list: mockedTeams
+    })
+
+    done()
+  })
+
+  lab.test('should handle RECEIVE_TEAM', (done) => {
+    Code.expect(
+      reducer(initialState, {
+        type: RECEIVE_TEAM,
+        team: mockedTeam
+      })
+    ).to.equal({
+      list: null,
+      selectedTeam: mockedTeam
+    })
+
+    done()
+  })
+
+  lab.test('should handle DELETE_TEAM', (done) => {
+    Code.expect(
+      reducer(stateWithSelected, {
+        type: DELETE_TEAM,
+        id: mockedTeam.id
+      })
+    ).to.equal({
+      list: [mockedTeams[1]],
+      selectedTeam: null
+    })
+
+    done()
+  })
+
+  lab.test('should handle UPDATE_TEAM', (done) => {
+    Code.expect(
+      reducer(stateWithSelected, {
+        type: UPDATE_TEAM,
+        team: updatedTeam
+      })
+    ).to.equal({
+      list: [updatedTeam, stateWithSelected.list[1]],
+      selectedTeam: updatedTeam
+    })
+
+    done()
+  })
+
+  lab.test('should handle MAKE_TEAM', (done) => {
+    Code.expect(
+      reducer(stateWithSelected, {
+        type: MAKE_TEAM,
+        team: newTeam
+      })
+    ).to.equal({
+      list: [newTeam, mockedTeams[1], mockedTeams[0]],
+      selectedTeam: newTeam
+    })
+
+    done()
+  })
+
+})

--- a/component/test/reducers/users.js
+++ b/component/test/reducers/users.js
@@ -2,7 +2,7 @@ import Lab from 'lab'
 import Code from 'code'
 
 import reducer from '../../src/reducers/users'
-import { RECEIVE_USERS, RECEIVE_USER, DELETE_USER } from '../../src/constants'
+import { RECEIVE_USERS, RECEIVE_USER, DELETE_USER, UPDATE_USER, MAKE_USER } from '../../src/constants'
 
 const lab = exports.lab = Lab.script()
 
@@ -35,6 +35,26 @@ lab.experiment('users', () => {
   const stateWithSelected = {
     list: mockedUsers,
     selectedUser: mockedUser
+  }
+
+  const updatedUser = {
+    id: 1,
+    name: 'AnUpDaTeDuSeR',
+    policies: [{
+      id: 2,
+      name: 'AnOtHeRpOlIcY'
+    }],
+    teams: [{
+      id: 2,
+      name: 'AnOtHeRtEaM'
+    }]
+  }
+
+  const newUser = {
+    id: 3,
+    name: 'AnEwUsEr',
+    policies: [],
+    teams: []
   }
 
   lab.test('should return initial state', (done) => {
@@ -88,5 +108,32 @@ lab.experiment('users', () => {
     done()
   })
 
-  // more to add.
+  lab.test('should handle UPDATE_USER', (done) => {
+    Code.expect(
+      reducer(stateWithSelected, {
+        type: UPDATE_USER,
+        user: updatedUser
+      })
+    ).to.equal({
+      list: [updatedUser, stateWithSelected.list[1]],
+      selectedUser: updatedUser
+    })
+
+    done()
+  })
+
+  lab.test('should handle MAKE_USER', (done) => {
+    Code.expect(
+      reducer(stateWithSelected, {
+        type: MAKE_USER,
+        user: newUser
+      })
+    ).to.equal({
+      list: [newUser, mockedUsers[1], mockedUsers[0]],
+      selectedUser: newUser
+    })
+
+    done()
+  })
+
 })


### PR DESCRIPTION
also now using stringlocalecompare for MAKE_USER and MAKE_TEAM (Upper case first to be consistent with DB responses)
