### PR TITLE
Runs psql commands in docker container. No need for psql client

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,6 @@ Test data can be added with:
 npm run pg:load-test-data
 ```
 
-Note: the scripts that initialize and load data into the database require you to have the Postgresql client installed on your machine.
-It is not necessary to have the full Postgresql database and dependencies installed.
-
 ###pgAdmin database access
 As the Postgresql docker container has its 5432 port forwarded on the local machine the database can be accessed with pgAdmin.
 

--- a/scripts/init/database/db_init.sh
+++ b/scripts/init/database/db_init.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-PGPASSWORD=postgres dropdb -h localhost -p 5432 -U postgres authorization
-PGPASSWORD=postgres createdb -h localhost -p 5432 -U postgres authorization
+docker exec -it labsauthorization_database_1 bash -c "PGPASSWORD=postgres dropdb -h localhost -p 5432 -U postgres authorization"
+docker exec -it labsauthorization_database_1 bash -c "PGPASSWORD=postgres createdb -h localhost -p 5432 -U postgres authorization"
 # by default the db has UTF8 character encoding with auto-commit
 
-PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres --echo-all -c "DROP USER IF EXISTS admin;"
-PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres --echo-all -c "CREATE USER admin WITH PASSWORD 'default';"
+docker exec -it labsauthorization_database_1 bash -c "PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres --echo-all -c \"DROP USER IF EXISTS admin;\""
+docker exec -it labsauthorization_database_1 bash -c "PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres --echo-all -c \"CREATE USER admin WITH PASSWORD 'default';\""
 # install new database
 node scripts/init/database/install_001.js;

--- a/scripts/init/database/db_load.sh
+++ b/scripts/init/database/db_load.sh
@@ -1,20 +1,21 @@
 #!/bin/bash
 # TODO: team_members, team_policies
 # TODO: statement_*
-PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d authorization <<EOF
+docker cp ./scripts/init/database/testdata labsauthorization_database_1:/testdata
+docker exec -it labsauthorization_database_1 bash -c "PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d authorization <<EOF
 SELECT 'Database installed, schemaversion = ' || MAX(version) from schemaversion;
-\cd './scripts/init/database/testdata'
+\cd '/testdata'
 \! pwd
 \COPY organizations(id, name, description) FROM 'organizations.csv' (FORMAT csv)
 \COPY users(name, org_id) FROM 'users.csv' (FORMAT csv)
 \COPY teams(name, description, team_parent_id, org_id) FROM 'teams.csv' (FORMAT csv)
 \COPY team_members(user_id, team_id) FROM 'team_members.csv' (FORMAT csv)
-EOF
+EOF"
 node scripts/init/database/testdata/loadPolicies.js
-PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d authorization <<EOF
-\cd './scripts/init/database/testdata'
+docker exec -it labsauthorization_database_1 bash -c "PGPASSWORD=postgres psql -h localhost -p 5432 -U postgres -d authorization <<EOF
+\cd './testdata'
 \! pwd
 \COPY ref_actions(action) FROM 'ref_actions.csv' (FORMAT csv)
 \COPY user_policies(user_id, policy_id) FROM 'user_policies.csv' (FORMAT csv)
 \COPY team_policies(team_id, policy_id) FROM 'team_policies.csv' (FORMAT csv)
-EOF
+EOF"


### PR DESCRIPTION
This should avoid installing the PostgreSQL client in local by running all commands directly inside the docker container.

Not sure if this is an overkill, let me know if it makes sense :)

/cc @irelandm 