### PR TITLE
Issue 108 tests for failure cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "pg": "^6.1.0"
   },
   "devDependencies": {
+    "mock-require": "^2.0.0",
     "postgrator": "^2.8.2",
     "pre-commit": "^1.1.3"
   }

--- a/service/lib/authorizeOps.js
+++ b/service/lib/authorizeOps.js
@@ -52,6 +52,7 @@ module.exports = function (userOps, policyOps, mu) {
     listAuthorizations: function listAuthorizations ({ userId, resource }, cb) {
       const data = []
       var actions = []
+      var errors = []
       // build the set of actions in the user's policy set
       // can't check per resource as requires wildcard processing
 
@@ -73,13 +74,15 @@ module.exports = function (userOps, policyOps, mu) {
         actions.forEach(action => {
           iam(policies, ({ process }) => {
             process(resource, action, (err, access) => {
-              if (err) return cb(mu.error.wrap(err))
+              if (err) return errors.push(err)
               if (access) {
                 data.push(action)
               }
             })
           })
         })
+
+        if (errors.length > 0) return cb(mu.error.wrap(errors.shift()))
         // return thE allowable actions
         cb(null, {actions: data})
       })

--- a/service/test/lib/policyOpsTest.js
+++ b/service/test/lib/policyOpsTest.js
@@ -3,6 +3,8 @@
 const mu = require('mu')()
 const test = require('tap').test
 const service = require('../../lib/service')
+const PolicyOps = require('../../lib/policyOps')
+const utils = require('../utils')
 
 var opts = {
   logLevel: 'warn',
@@ -65,4 +67,47 @@ test('read a specific policy', (t) => {
       })
     })
   })
+})
+
+test('should return an error if the db connection fails', (t) => {
+  t.plan(12)
+  var dbPool = {connect: function (cb) {
+    cb(new Error('connection error test'))
+  }}
+  var policyOps = PolicyOps(dbPool, mu)
+  var functionsUnderTest = ['listAllUserPolicies', 'listAllPolicies', 'listAllPoliciesDetails', 'readPolicyById']
+
+  functionsUnderTest.forEach((f) => {
+    policyOps[f]({userId: 1234}, utils.testError(t, 'connection error test'))
+  })
+})
+
+test('should return an error if the db query fails', (t) => {
+  t.plan(12)
+  var dbPool = {connect: function (cb) {
+    var client = {query: (sql, params, cb) => {
+      cb = cb || params
+      cb(new Error('query error test'))
+    }}
+    cb(undefined, client, () => {})
+  }}
+  var policyOps = PolicyOps(dbPool, mu)
+  var functionsUnderTest = ['listAllUserPolicies', 'listAllPolicies', 'listAllPoliciesDetails', 'readPolicyById']
+
+  functionsUnderTest.forEach((f) => {
+    policyOps[f]({userId: 1234}, utils.testError(t, 'query error test'))
+  })
+})
+
+test('readPolicyById should return an error if the query has row count 0', (t) => {
+  t.plan(3)
+  var dbPool = {connect: function (cb) {
+    var client = {query: (sql, params, cb) => {
+      cb(undefined, {rowCount: 0})
+    }}
+    cb(undefined, client, () => {})
+  }}
+  var policyOps = PolicyOps(dbPool, mu)
+
+  policyOps.readPolicyById([1], utils.testError(t, 'Not Found'))
 })

--- a/service/test/lib/teamOpsTest.js
+++ b/service/test/lib/teamOpsTest.js
@@ -4,6 +4,8 @@
 const mu = require('mu')()
 const test = require('tap').test
 const service = require('../../lib/service')
+const TeamOps = require('../../lib/teamOps')
+const utils = require('../utils')
 
 let testTeamId
 
@@ -27,7 +29,7 @@ test('list of all teams', (t) => {
     svc.listAllTeams({}, (err, result) => {
       t.error(err, 'should be no error')
       t.ok(result, 'result should be supplied')
-// TODO:      t.deepEqual(result, expectedUserList, 'data should be as expected')
+      // TODO:      t.deepEqual(result, expectedUserList, 'data should be as expected')
       svc.destroy({}, (err, result) => {
         t.error(err)
       })
@@ -41,7 +43,7 @@ test('list of org teams', (t) => {
     svc.listOrgTeams([1], (err, result) => {
       t.error(err, 'should be no error')
       t.ok(result, 'result should be supplied')
-// TODO:      t.deepEqual(result, expectedUserList, 'data should be as expected')
+      // TODO:      t.deepEqual(result, expectedUserList, 'data should be as expected')
       svc.destroy({}, (err, result) => {
         t.error(err)
       })
@@ -66,12 +68,14 @@ test('create a team', (t) => {
 })
 
 test('read a specific team', (t) => {
-  t.plan(4)
+  t.plan(6)
   service(opts, (svc) => {
-    svc.readTeamById([testTeamId], (err, result) => {
+    svc.readTeamById([1], (err, result) => {
       t.error(err, 'should be no error')
       t.ok(result, 'result should be supplied')
-      t.deepEqual(result.id, testTeamId, 'data should be as expected')
+      t.deepEqual(result.id, 1, 'data should be as expected')
+      t.deepEqual(result.users.length, 1, 'data should be as expected')
+      t.deepEqual(result.policies.length, 1, 'data should be as expected')
       svc.destroy({}, (err, result) => {
         t.error(err)
       })
@@ -103,4 +107,200 @@ test('delete a team', (t) => {
       })
     })
   })
+})
+
+test('should return an error if the db connection fails', (t) => {
+  t.plan(18)
+  var teamOps = TeamOps(utils.getDbPollConnectionError(), mu, () => {})
+  var functionsUnderTest = ['listAllTeams', 'listOrgTeams', 'createTeam', 'readTeamById', 'updateTeam', 'deleteTeamById']
+
+  functionsUnderTest.forEach((f) => {
+    teamOps[f]([1, 'test', 'description', [], []], utils.testError(t, 'Error: connection error test'))
+  })
+})
+
+test('should return an error if the first db query fails', (t) => {
+  t.plan(12)
+  var teamOps = TeamOps(utils.getDbPollFirstQueryError(), mu, () => {})
+  var functionsUnderTest = ['listAllTeams', 'listOrgTeams', 'createTeam', 'readTeamById']
+
+  functionsUnderTest.forEach((f) => {
+    teamOps[f]([1, 'test', 'description', [], []], utils.testError(t, 'Error: query error test'))
+  })
+})
+
+test('updateTeam should return an error if users is not an array', (t) => {
+  t.plan(3)
+  var dbPool = {}
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.updateTeam([1, 'test', 'description'], utils.testError(t, 'Bad Request'))
+})
+
+test('updateTeam should return an error if policies is not an array', (t) => {
+  t.plan(3)
+  var dbPool = {}
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.updateTeam([1, 'test', 'description', []], utils.testError(t, 'Bad Request'))
+})
+
+test('updateTeam should return an error if db transaction fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('BEGIN', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.updateTeam([1, 'test', 'description', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateTeam should return an error if updating name and description fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('UPDATE teams', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.updateTeam([1, 'test', 'description', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateTeam should return an error if updating name and description returns rowCount 0', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount(undefined, {testRollback: true, t: t}, {rowCount: 0})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.updateTeam([1, 'test', 'description', [], []], utils.testError(t, 'Not Found'))
+})
+
+test('updateTeam should return an error if deleting team members fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE FROM team_members', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.updateTeam([1, 'test', 'description', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateTeam should return an error if inserting team members fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('INSERT INTO team_members', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.updateTeam([1, 'test', 'description', [{}], [{}]], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateTeam should return an error if deleting team policies fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE FROM team_policies', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.updateTeam([1, 'test', 'description', [{}], [{}]], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateTeam should return an error if inserting team policies fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('INSERT INTO team_policies', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.updateTeam([1, 'test', 'description', [{}], [{}]], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateTeam should return an error if commit fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('COMMIT', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.updateTeam([1, 'test', 'description', [{}], [{}]], utils.testError(t, 'Error: query error test'))
+})
+
+test('deleteTeamById should return an error if the transaction fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('BEGIN', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.deleteTeamById([1], utils.testError(t, 'Error: query error test'))
+})
+
+test('deleteTeamById should return an error if deliting team members fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE from team_members', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.deleteTeamById([1], utils.testError(t, 'Error: query error test'))
+})
+
+test('deleteTeamById should return an error if deliting team policies fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE from team_policies', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.deleteTeamById([1], utils.testError(t, 'Error: query error test'))
+})
+
+test('deleteTeamById should return an error if deliting team fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE from teams', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.deleteTeamById([1], utils.testError(t, 'Error: query error test'))
+})
+
+test('deleteTeamById should return an error if deliting team return rowCount 0', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount(undefined, {testRollback: true, t: t}, {rowCount: 0})
+  var teamOps = TeamOps(dbPool, mu, () => {})
+
+  teamOps.deleteTeamById([1], utils.testError(t, 'Not Found'))
+})
+
+test('deleteTeamById should return an error if commit fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('COMMIT', {testRollback: true, t: t})
+  var teamOps = TeamOps(dbPool, mu, {debug: () => {}})
+
+  teamOps.deleteTeamById([1], utils.testError(t, 'Error: query error test'))
+})
+
+test('readTeamById should return an error if selecting the team data return rowcount 0', (t) => {
+  t.plan(3)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount(undefined, undefined, {rowCount: 0})
+  var teamOps = TeamOps(dbPool, mu, {debug: () => {}})
+
+  teamOps.readTeamById([testTeamId], utils.testError(t, 'Not Found'))
+})
+
+test('readTeamById should return an error if selecting the team members data fails', (t) => {
+  t.plan(3)
+  var dbPool = {connect: function (cb) {
+    var client = {query: (sql, params, cb) => {
+      cb = cb || params
+      if (sql.startsWith('SELECT id, name')) {
+        return cb(undefined, {rowCount: 1, rows: [{id: 1, name: 'filo', description: 'description'}]})
+      }
+      if (sql.startsWith('SELECT users.id')) {
+        return cb(new Error('query error test'))
+      }
+      cb(undefined, {rowCount: 1, rows: []})
+    }}
+    cb(undefined, client, () => {})
+  }}
+  var teamOps = TeamOps(dbPool, mu, {debug: () => {}})
+
+  teamOps.readTeamById([testTeamId], utils.testError(t, 'Error: query error test'))
+})
+
+test('readTeamById should return an error if selecting the policies data fails', (t) => {
+  t.plan(3)
+  var dbPool = {connect: function (cb) {
+    var client = {query: (sql, params, cb) => {
+      cb = cb || params
+      if (sql.startsWith('SELECT id, name')) {
+        return cb(undefined, {rowCount: 1, rows: [{id: 1, name: 'filo', description: 'description'}]})
+      }
+      if (sql.startsWith('SELECT pol.id, pol.name')) {
+        return cb(new Error('query error test'))
+      }
+      cb(undefined, {rowCount: 1, rows: []})
+    }}
+    cb(undefined, client, () => {})
+  }}
+  var teamOps = TeamOps(dbPool, mu, {debug: () => {}})
+
+  teamOps.readTeamById([testTeamId], utils.testError(t, 'Error: query error test'))
 })

--- a/service/test/lib/userOpsTest.js
+++ b/service/test/lib/userOpsTest.js
@@ -3,13 +3,13 @@
 const mu = require('mu')()
 const test = require('tap').test
 const service = require('../../lib/service')
+const UserOps = require('../../lib/userOps')
+const utils = require('../utils')
 
 var opts = {
   logLevel: 'warn',
   mu
 }
-
-// TODO: add checks for rowcounts, in e.g. createUser
 
 test('list of all users', (t) => {
   t.plan(3)
@@ -18,7 +18,7 @@ test('list of all users', (t) => {
       t.error(err, 'should be no error')
       t.ok(result, 'result should be supplied')
       // console.log(result)
-// TODO:      t.deepEqual(result, expectedUserList, 'data should be as expected')
+      // TODO:      t.deepEqual(result, expectedUserList, 'data should be as expected')
       svc.destroy({}, (err, result) => {
         t.error(err)
       })
@@ -32,7 +32,7 @@ test('list of org users', (t) => {
     svc.listOrgUsers([1], (err, result) => {
       t.error(err, 'should be no error')
       t.ok(result, 'result should be supplied')
-// TODO:      t.deepEqual(result, expectedUserList, 'data should be as expected')
+      // TODO:      t.deepEqual(result, expectedUserList, 'data should be as expected')
       svc.destroy({}, (err, result) => {
         t.error(err)
       })
@@ -95,7 +95,7 @@ test('update a user', (t) => {
 test('read a specific user', (t) => {
   t.plan(3)
   service(opts, (svc) => {
-    svc.readUserById([1], (err, result) => {
+    svc.readUserById([3], (err, result) => {
       t.error(err, 'should be no error')
       t.ok(result, 'result should be supplied')
       // t.deepEqual(result, [{ id: 99, name: 'Augustus Gloop' }], 'data should be as expected')
@@ -132,4 +132,184 @@ test('read a specific user by token', (t) => {
       })
     })
   })
+})
+
+test('should return an error if the db connection fails', (t) => {
+  t.plan(24)
+  var userOps = UserOps(utils.getDbPollConnectionError(), mu, {debug: () => {}})
+  var functionsUnderTest = ['listAllUsers', 'listOrgUsers', 'createUser', 'createUserById', 'readUserById', 'updateUser', 'deleteUserById', 'getUserByToken']
+
+  functionsUnderTest.forEach((f) => {
+    userOps[f]([1, 'test', [], []], utils.testError(t, 'Error: connection error test'))
+  })
+})
+
+test('should return an error if the first db query fails', (t) => {
+  t.plan(18)
+  var userOps = UserOps(utils.getDbPollFirstQueryError(), mu, {debug: () => {}})
+  var functionsUnderTest = ['listAllUsers', 'listOrgUsers', 'createUser', 'createUserById', 'readUserById', 'getUserByToken']
+
+  functionsUnderTest.forEach((f) => {
+    userOps[f]([], utils.testError(t, 'Error: query error test'))
+  })
+})
+
+test('createUser should return an error if reading the user fails', (t) => {
+  t.plan(3)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('SELECT id, name from users', undefined, {rowCount: 1, rows: [{id: 1234}]})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.createUser([], utils.testError(t, 'Error: query error test'))
+})
+
+test('createUserById should return an error if reading the user fails', (t) => {
+  t.plan(3)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('SELECT id, name from users', undefined, {rowCount: 1, rows: [{id: 1234}]})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.createUserById([], utils.testError(t, 'Error: query error test'))
+})
+
+test('readUserById should return an error if the team cannot be retrieved', (t) => {
+  t.plan(3)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('SELECT teams.id', undefined, {rowCount: 1, rows: [{id: 1234, name: 'test'}]})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.readUserById([], utils.testError(t, 'Error: query error test'))
+})
+
+test('readUserById should return an error if the policies cannot be retrieved', (t) => {
+  t.plan(3)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('SELECT pol.id', undefined, {rowCount: 1, rows: [{id: 1234, name: 'test'}]})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.readUserById([], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateUser should return an error if teams is not an array', (t) => {
+  t.plan(3)
+  var dbPool = {}
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.updateUser([1, 'test'], utils.testError(t, 'Bad Request'))
+})
+
+test('updateUser should return an error if policies is not an array', (t) => {
+  t.plan(3)
+  var dbPool = {}
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.updateUser([1, 'test', []], utils.testError(t, 'Bad Request'))
+})
+
+test('updateUser should return an error if the transaction cannot be started', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('BEGIN', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.updateUser([1, 'test', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateUser should return an error if the update query fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('UPDATE users', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.updateUser([1, 'test', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateUser should return an error if the delete query on team_members fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE FROM team_members', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.updateUser([1, 'test', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateUser should return an error if the insert query on team_members fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('INSERT INTO team_members', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.updateUser([1, 'test', [1], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateUser should return an error if the delete query on user_policies fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE FROM user_policies', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.updateUser([1, 'test', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateUser should return an error if the insert query on team_members fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('INSERT INTO user_policies', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.updateUser([1, 'test', [], [1]], utils.testError(t, 'Error: query error test'))
+})
+
+test('updateUser should return an error if commit fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('COMMIT', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.updateUser([1, 'test', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('deleteUserById should return an error if the transaction cannot be started', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('BEGIN', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.deleteUserById([1], utils.testError(t, 'Error: query error test'))
+})
+
+test('deleteUserById should return an error if deleting from user policies fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE from user_policies', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.deleteUserById([1, 'test', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('deleteUserById should return an error if deleting from team memebers fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE from team_members', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.deleteUserById([1, 'test', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('deleteUserById should return an error if deleting from users fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE from users', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.deleteUserById([1, 'test', [], []], utils.testError(t, 'Error: query error test'))
+})
+
+test('deleteUserById should return an error if deleting from users returns a rowCount 0', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount(undefined, {testRollback: true, t: t}, {rowCount: 0})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.deleteUserById([1, 'test', [], []], utils.testError(t, 'Not Found'))
+})
+
+test('deleteUserById should return an error if commit fails', (t) => {
+  t.plan(4)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount('COMMIT', {testRollback: true, t: t})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.deleteUserById([1], utils.testError(t, 'Error: query error test'))
+})
+
+test('getUserByToken should return an error if selecting from users returns a rowCount 0', (t) => {
+  t.plan(3)
+  var dbPool = utils.getDbPoolErrorForQueryOrRowCount(undefined, undefined, {rowCount: 0})
+  var userOps = UserOps(dbPool, mu, {debug: () => {}})
+
+  userOps.deleteUserById([1, 'test', [], []], utils.testError(t, 'Not Found'))
 })

--- a/service/test/mocks/iamMock.js
+++ b/service/test/mocks/iamMock.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const originalIam = require('iam-js')
+
+module.exports = (policies, cb1) => {
+  if (policies.policyMock) {
+    return cb1({process: (resource, action, cb2) => {
+      cb2(new Error('policyMock test error'))
+    }})
+  }
+  return originalIam(policies, cb1)
+}

--- a/service/test/utils.js
+++ b/service/test/utils.js
@@ -1,0 +1,73 @@
+'use strict'
+
+/**
+ * Calls the callback with an error when the `connect` function is executed
+ */
+function getDbPollConnectionError () {
+  return {connect: function (cb) {
+    cb(new Error('connection error test'))
+  }}
+}
+
+/**
+ * Calls the callback with an error when the `query` function is executed
+ */
+function getDbPollFirstQueryError () {
+  return {connect: function (cb) {
+    var client = {query: (sql, params, cb) => {
+      cb = cb || params
+      cb(new Error('query error test'))
+    }}
+    cb(undefined, client, () => {})
+  }}
+}
+
+/**
+ * Calls the callback with an error when the query starting with `startsWith` should be executed.
+ *
+ * If `startsWith` is `undefined` the `query` will always return the `result` object.
+ *
+ * Note: the `result` object is returned for all the `query` invocations in which `startsWith` is not matched.
+ *
+ * To test the `ROLLBACK` call, you will need to increase `t.plan` by one and pass the `options.testRollback` as true
+ * along with the test object `t`.
+ *
+ * @param  {String} startsWith
+ * @param  {Object} result
+ */
+function getDbPoolErrorForQueryOrRowCount (startsWith, options = {testRollback: false, t: undefined}, result = {rowCount: 1, rows: []}) {
+  return {connect: function (cb) {
+    var client = {query: (sql, params, cb) => {
+      cb = cb || params
+      if (sql.startsWith(startsWith)) {
+        return cb(new Error('query error test'))
+      }
+      if (options.testRollback && sql.startsWith('ROLLBACK')) {
+        options.t.equal('ROLLBACK', sql)
+      }
+      cb(undefined, result)
+    }}
+    cb(undefined, client, () => {})
+  }}
+}
+
+/**
+ * Helper method fot testing that the callback is called with an `err` object with a specific message
+ *
+ * @param  {Object} t
+ * @param  {String} errorString
+ */
+function testError (t, errorString) {
+  return (err, result) => {
+    t.ok(err, 'should be error')
+    t.equal(err.message, errorString, 'correct error message')
+    t.notOk(result, 'result should not be supplied')
+  }
+}
+
+module.exports = {
+  getDbPollConnectionError: getDbPollConnectionError,
+  getDbPollFirstQueryError: getDbPollFirstQueryError,
+  getDbPoolErrorForQueryOrRowCount: getDbPoolErrorForQueryOrRowCount,
+  testError: testError
+}


### PR DESCRIPTION
Issue #108 

Add tests for failure cases in:

* teamOps
* policyOps
* authorizeOps
* userOps

Refactor a bit the tests to use the service modules directly instead of testig them only indirectly using [`service`](https://github.com/nearform/labs-authorization/blob/master/service/lib/service.js).