### PR TITLE
Add generation of config.js based on env variables

### DIFF
--- a/component/.gitignore
+++ b/component/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/component/bin/config.template
+++ b/component/bin/config.template
@@ -1,0 +1,5 @@
+'use strict'
+
+const Reconfig = require('reconfig')
+
+module.exports = new Reconfig({{config}})

--- a/component/bin/generateConfig.js
+++ b/component/bin/generateConfig.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const Reconfig = require('reconfig')
+const fs = require('fs')
+const path = require('path')
+
+const config = new Reconfig({
+  api: {
+    basUrl: 'http://localhost:8000'
+  }
+}, { envPrefix: 'LABS_AUTH_COMPONENT' })
+
+try {
+  let content = fs.readFileSync(path.join(__dirname, 'config.template'), 'utf8')
+  content = content.replace('{{config}}', JSON.stringify(config._rawConfig))
+
+  fs.writeFileSync(path.join(__dirname, '../config.js'), content)
+} catch (err) {
+  console.log(err)
+  throw err
+}

--- a/component/package.json
+++ b/component/package.json
@@ -12,7 +12,7 @@
     "test": "./node_modules/.bin/lab ./test/",
     "coverage": "./node_modules/.bin/lab ./test/ -r html -o coverage.html",
     "dev": "./node_modules/.bin/webpack-dev-server",
-    "build": "npm run lint && ./node_modules/.bin/webpack"
+    "build": "npm run lint && node ./bin/generateConfig.js && ./node_modules/.bin/webpack"
   },
   "contributors": [
     "Salman Mitha <salmanmitha@gmail.com>"


### PR DESCRIPTION
In this PR we generate a config module based on the env variables of the machine that is building the fronted app.

The base configuration is present inside [`component/bin/generateConfig.js`] and will be copied into [`config.js`](https://github.com/nearform/labs-authorization/pull/127/files#diff-13e35fbac08070814d99693e2cd290acR17) with the overridden values from the env variables.

We could even go for a tool like this https://github.com/namshi/node-nmconfig if we want to use `.yml` files for configuration