### PR TITLE
Add webpack config alias for dev and prod

### DIFF
--- a/component/config.dev.js
+++ b/component/config.dev.js
@@ -1,0 +1,7 @@
+const Reconfig = require('reconfig')
+
+module.exports = new Reconfig({
+  api: {
+    basUrl: 'http://localhost:8000'
+  }
+})

--- a/component/config.prod.js
+++ b/component/config.prod.js
@@ -1,0 +1,7 @@
+const Reconfig = require('reconfig')
+
+module.exports = new Reconfig({
+  api: {
+    basUrl: 'http://localhost:9004'
+  }
+})

--- a/component/package.json
+++ b/component/package.json
@@ -39,6 +39,7 @@
     "react-router": "^2.8.1",
     "react-router-redux": "^4.0.6",
     "react-tap-event-plugin": "^2.0.1",
+    "reconfig": "^3.2.0",
     "redux": "^3.6.0",
     "redux-form": "^6.1.0",
     "redux-thunk": "^2.1.0"

--- a/component/src/middleware/api.js
+++ b/component/src/middleware/api.js
@@ -1,13 +1,13 @@
 import request from 'axios'
+import config from 'appConfig'
 
-const API_BASE = 'http://localhost:8000'
 const URL_REGEX = /^(https?:\/\/)/
 
 export const callApi = (options) => {
   const { method = 'get', data, params } = options
   const endpoint = typeof options === 'string' ? options : options.endpoint
 
-  const fullUrl = URL_REGEX.test(endpoint) ? endpoint : API_BASE + endpoint
+  const fullUrl = URL_REGEX.test(endpoint) ? endpoint : config.get('api.basUrl') + endpoint
 
   options = {
     method: method || (data ? 'post' : 'get'),

--- a/component/webpack.config.dev.js
+++ b/component/webpack.config.dev.js
@@ -48,7 +48,11 @@ module.exports = {
   ],
 
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['', '.js', '.jsx'],
+    root: path.resolve(__dirname),
+    alias: {
+      appConfig: 'config.dev.js'
+    }
   },
 
   devtool: 'source-map',

--- a/component/webpack.config.prod.js
+++ b/component/webpack.config.prod.js
@@ -41,7 +41,11 @@ module.exports = {
   ],
 
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['', '.js', '.jsx'],
+    root: path.resolve(__dirname),
+    alias: {
+      appConfig: 'config.prod.js'
+    }
   },
 
   output: {


### PR DESCRIPTION
Add `component/config.dev.js` and `component/config.prod.js` to the webpack config files for those environments.

This will let us define different configuration for each env through webpack [aliases](https://github.com/nearform/labs-authorization/pull/128/files#diff-c27111a4b4db73b7af398b83b15bcca2R2).