### PR TITLE
Add private API endpoints for policies create/update/delete

### DIFF
--- a/service/lib/config.js
+++ b/service/lib/config.js
@@ -18,5 +18,12 @@ module.exports = new Reconfig({
     pino: {
       level: 'info'
     }
+  },
+  security: {
+    api_service_keys: {
+      private: [
+        '123456789'
+      ]
+    }
   }
 }, { envPrefix: 'LABS_AUTH_SERVICE' })

--- a/service/lib/policyOps.js
+++ b/service/lib/policyOps.js
@@ -1,16 +1,18 @@
 'use strict'
 
 const Boom = require('boom')
+const async = require('async')
+const dbUtil = require('./dbUtil')
 
 module.exports = function (dbPool) {
-  return {
+  var policyOps = {
 
     /*
     * $1 = user_id
     */
     listAllUserPolicies: function listAllUserPolicies ({ userId }, cb) {
       dbPool.connect(function (err, client, done) {
-        if (err) return cb(Boom.wrap(err))
+        if (err) return cb(Boom.badImplementation(err))
 
         /* Query1: For fetching policies attached directly to the user */
         /* Query2: For fetching policies attached to the teams user belongs to */
@@ -50,7 +52,7 @@ module.exports = function (dbPool) {
 
         client.query(sql, params, function (err, result) {
           done() // release the client back to the pool
-          if (err) return cb(Boom.wrap(err))
+          if (err) return cb(Boom.badImplementation(err))
 
           const userPolicies = result.rows.map(row => ({
             Version: row.version,
@@ -68,11 +70,11 @@ module.exports = function (dbPool) {
     */
     listAllPolicies: function listAllPolicies (args, cb) {
       dbPool.connect(function (err, client, done) {
-        if (err) return cb(Boom.wrap(err))
+        if (err) return cb(Boom.badImplementation(err))
 
         client.query('SELECT  id, version, name from policies ORDER BY UPPER(name)', function (err, result) {
           done() // release the client back to the pool
-          if (err) return cb(Boom.wrap(err))
+          if (err) return cb(Boom.badImplementation(err))
 
           return cb(null, result.rows)
         })
@@ -85,11 +87,11 @@ module.exports = function (dbPool) {
     */
     listAllPoliciesDetails: function listAllPoliciesDetails (args, cb) {
       dbPool.connect(function (err, client, done) {
-        if (err) return cb(Boom.wrap(err))
+        if (err) return cb(Boom.badImplementation(err))
 
         client.query('SELECT  id, version, name, statements from policies ORDER BY UPPER(name)', function (err, result) {
           done() // release the client back to the pool
-          if (err) return cb(Boom.wrap(err))
+          if (err) return cb(Boom.badImplementation(err))
 
           var results = result.rows.map((policy) => ({
             id: policy.id,
@@ -108,12 +110,12 @@ module.exports = function (dbPool) {
     */
     readPolicyById: function readPolicyById (args, cb) {
       dbPool.connect(function (err, client, done) {
-        if (err) return cb(Boom.wrap(err))
+        if (err) return cb(Boom.badImplementation(err))
 
         client.query('SELECT id, version, name, statements from policies WHERE id = $1', args, function (err, result) {
           done() // release the client back to the pool
 
-          if (err) return cb(Boom.wrap(err))
+          if (err) return cb(Boom.badImplementation(err))
           if (result.rowCount === 0) return cb(Boom.notFound())
 
           var policy = result.rows[0]
@@ -125,6 +127,155 @@ module.exports = function (dbPool) {
           })
         })
       })
+    },
+
+    /*
+    * $1 = version
+    * $2 = name
+    * $3 = org_id
+    * $4 = statements
+    */
+    createPolicy: function createPolicy (args, cb) {
+      dbPool.connect(function (err, client, done) {
+        if (err) return cb(Boom.badImplementation(err))
+
+        client.query('INSERT INTO policies (id, version, name, org_id, statements) VALUES (DEFAULT, $1, $2, $3, $4) RETURNING id', args, function (err, result) {
+          done() // release the client back to the pool
+          if (err) return cb(Boom.badImplementation(err))
+
+          const policy = result.rows[0]
+
+          policyOps.readPolicyById([policy.id], function (err, result) {
+            if (err) return cb(Boom.badImplementation(err))
+
+            return cb(null, result)
+          })
+        })
+      })
+    },
+
+    // TODO: Allow updating specific fields only ??
+    //
+    // Should we handle the updated version as a new version => update teams and users associated with the previous version?
+    // Like in http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-using.html#edit-managed-policy-console
+    //
+    /*
+    * $1 = id
+    * $2 = version
+    * $3 = name
+    * $4 = org_id
+    * $5 = statements
+    */
+    updatePolicy: function updatePolicy (args, cb) {
+
+      const [ id, version, name, orgId, statements ] = args
+      const tasks = []
+
+      dbPool.connect(function (err, client, done) {
+        if (err) {
+          return cb(Boom.badImplementation(err))
+        }
+
+        tasks.push((next) => {
+          client.query('BEGIN', (err, res) => {
+            if (err) return next(Boom.badImplementation(err))
+            next()
+          })
+        })
+
+        tasks.push((next) => {
+          client.query('UPDATE policies SET version = $2, name = $3, org_id = $4, statements = $5 WHERE id = $1', [id, version, name, orgId, statements], (err, res) => {
+            if (err) return next(Boom.badImplementation(err))
+            if (res.rowCount === 0) return next(Boom.notFound())
+
+            next()
+          })
+        })
+
+        tasks.push((next) => {
+          client.query('COMMIT', (err) => {
+            if (err) return next(Boom.badImplementation(err))
+
+            next()
+          })
+        })
+
+        async.series(tasks, (err) => {
+          if (err) {
+            dbUtil.rollback(client, done)
+            return cb(err)
+          }
+
+          done()
+          return cb(null, {id, version, name, statements: JSON.parse(statements).Statement})
+        })
+      })
+    },
+
+    /*
+    * $1 = id
+    */
+    deletePolicyById: function deletePolicyById (args, cb) {
+      const [ id ] = args
+      const tasks = []
+
+      dbPool.connect(function (err, client, done) {
+        if (err) {
+          return cb(Boom.badImplementation(err))
+        }
+
+        tasks.push((next) => {
+          client.query('BEGIN', (err, res) => {
+            if (err) return next(Boom.badImplementation(err))
+            next()
+          })
+        })
+
+        tasks.push((next) => {
+          client.query('DELETE from user_policies WHERE policy_id = $1', [id], (err, res) => {
+            if (err) return next(Boom.badImplementation(err))
+
+            next()
+          })
+        })
+
+        tasks.push((next) => {
+          client.query('DELETE from team_policies WHERE policy_id = $1', [id], (err, res) => {
+            if (err) return next(Boom.badImplementation(err))
+
+            next()
+          })
+        })
+
+        tasks.push((next) => {
+          client.query('DELETE from policies WHERE id = $1', [id], (err, res) => {
+            if (err) return next(Boom.badImplementation(err))
+            if (res.rowCount === 0) return next(Boom.notFound())
+
+            next()
+          })
+        })
+
+        tasks.push((next) => {
+          client.query('COMMIT', (err) => {
+            if (err) return next(Boom.badImplementation(err))
+
+            next()
+          })
+        })
+
+        async.series(tasks, (err) => {
+          if (err) {
+            dbUtil.rollback(client, done)
+            return cb(err)
+          }
+
+          done()
+          return cb(null)
+        })
+      })
     }
   }
+
+  return policyOps
 }

--- a/service/routes/private/policies.js
+++ b/service/routes/private/policies.js
@@ -1,0 +1,73 @@
+'use strict'
+
+const PolicyOps = require('./../../lib/policyOps')
+const security = require('./../security')
+const Boom = require('boom')
+
+function isValidCreateRequest (request) {
+  return request.payload.version &&
+    request.payload.name &&
+    request.payload.orgId &&
+    request.payload.statements
+}
+
+exports.register = function (server, options, next) {
+  const policyOps = PolicyOps(options.dbPool)
+
+  server.route({
+    method: 'POST',
+    path: '/authorization/policies',
+    handler: function (request, reply) {
+      if (!security.hasValidServiceKey(request)) return reply(Boom.forbidden())
+      if (!isValidCreateRequest(request)) return reply(Boom.badRequest())
+
+      const { version, name, orgId, statements } = request.payload
+      const params = [version, name, orgId, statements]
+
+      policyOps.createPolicy(params, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply(res).code(201)
+      })
+    }
+  })
+
+  server.route({
+    method: 'PUT',
+    path: '/authorization/policies/{id}',
+    handler: function (request, reply) {
+      if (!security.hasValidServiceKey(request)) return reply(Boom.forbidden())
+      if (!isValidCreateRequest(request)) return reply(Boom.badRequest())
+
+      const { version, name, orgId, statements } = request.payload
+      const params = [request.params.id, version, name, orgId, statements]
+
+      policyOps.updatePolicy(params, reply)
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/policies/{id}',
+    handler: function (request, reply) {
+      if (!security.hasValidServiceKey(request)) return reply(Boom.forbidden())
+
+      policyOps.deletePolicyById([request.params.id], function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply(res).code(204)
+      })
+    }
+  })
+
+  next()
+}
+
+exports.register.attributes = {
+  name: 'provate-policies',
+  version: '0.0.1'
+}

--- a/service/routes/security.js
+++ b/service/routes/security.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const config = require('./../lib/config')
+
+// We may want to do it registering a plugin and have a mapping for the url that need service keys?
+function hasValidServiceKey (request) {
+  let validKeys = config.get('security.api_service_keys.private')
+
+  return (validKeys.indexOf(!!request.query && request.query.sig) !== -1)
+}
+
+module.exports = {
+  hasValidServiceKey
+}

--- a/service/test/lib/integration/policyOpsTest.js
+++ b/service/test/lib/integration/policyOpsTest.js
@@ -50,4 +50,35 @@ lab.experiment('PolicyOps', () => {
       done()
     })
   })
+
+  lab.test('create, update and delete a policy', (done) => {
+    var params = ['2016-07-01', 'Documents Admin', 'WONKA', '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}']
+    var policyId
+
+    policyOps.createPolicy(params, (err, policy) => {
+      expect(err).to.not.exist()
+      expect(policy).to.exist()
+
+      policyId = policy.id
+
+      expect(policy.name).to.equal('Documents Admin')
+      expect(policy.version).to.equal('2016-07-01')
+      expect(policy.statements).to.equal([{Effect: 'Allow', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*']}])
+
+      params[0] = '2016-07-02'
+      params[1] = 'Documents Admin v2'
+      params[3] = '{"Statement":[{"Effect":"Deny","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+
+      policyOps.updatePolicy([policyId, ...params], (err, policy) => {
+        expect(err).to.not.exist()
+        expect(policy).to.exist()
+
+        expect(policy.name).to.equal('Documents Admin v2')
+        expect(policy.version).to.equal('2016-07-02')
+        expect(policy.statements).to.equal([{Effect: 'Deny', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*']}])
+
+        policyOps.deletePolicyById([policyId], done)
+      })
+    })
+  })
 })

--- a/service/test/lib/unit/policyOpsTest.js
+++ b/service/test/lib/unit/policyOpsTest.js
@@ -14,12 +14,12 @@ lab.experiment('policyOps', () => {
       cb(new Error('connection error test'))
     }}
     var policyOps = PolicyOps(dbPool)
-    var functionsUnderTest = ['listAllUserPolicies', 'listAllPolicies', 'listAllPoliciesDetails', 'readPolicyById']
+    var functionsUnderTest = ['listAllUserPolicies', 'listAllPolicies', 'listAllPoliciesDetails', 'readPolicyById', 'createPolicy', 'updatePolicy', 'deletePolicyById']
     var tasks = []
 
     functionsUnderTest.forEach((f) => {
       tasks.push((cb) => {
-        policyOps[f]({userId: 1234}, utils.testError(expect, 'connection error test', cb))
+        policyOps[f]([], utils.testError(expect, 'Error: connection error test', cb))
       })
     })
 
@@ -35,12 +35,12 @@ lab.experiment('policyOps', () => {
       cb(undefined, client, () => {})
     }}
     var policyOps = PolicyOps(dbPool)
-    var functionsUnderTest = ['listAllUserPolicies', 'listAllPolicies', 'listAllPoliciesDetails', 'readPolicyById']
+    var functionsUnderTest = ['listAllUserPolicies', 'listAllPolicies', 'listAllPoliciesDetails', 'readPolicyById', 'createPolicy', 'updatePolicy', 'deletePolicyById']
     var tasks = []
 
     functionsUnderTest.forEach((f) => {
       tasks.push((cb) => {
-        policyOps[f]({userId: 1234}, utils.testError(expect, 'query error test', cb))
+        policyOps[f]([], utils.testError(expect, 'Error: query error test', cb))
       })
     })
 
@@ -57,5 +57,61 @@ lab.experiment('policyOps', () => {
     var policyOps = PolicyOps(dbPool)
 
     policyOps.readPolicyById([1], utils.testError(expect, 'Not Found', done))
+  })
+
+  lab.test('updatePolicy should return an error if the update fails', (done) => {
+    var dbPool = utils.getDbPoolErrorForQueryOrRowCount('UPDATE policies', {testRollback: true, expect: expect})
+    var policyOps = PolicyOps(dbPool, () => {})
+
+    policyOps.updatePolicy([1, '2016-07-03', 'name', 'org_id', ''], utils.testError(expect, 'Error: query error test', done))
+  })
+
+  lab.test('updatePolicy should return an error if updating returns rowCount 0', (done) => {
+    var dbPool = utils.getDbPoolErrorForQueryOrRowCount(undefined, {testRollback: true, expect: expect}, {rowCount: 0})
+    var policyOps = PolicyOps(dbPool, () => {})
+
+    policyOps.updatePolicy([1, '2016-07-03', 'name', 'org_id', ''], utils.testError(expect, 'Not Found', done))
+  })
+
+  lab.test('updatePolicy should return an error if the update commit fails', (done) => {
+    var dbPool = utils.getDbPoolErrorForQueryOrRowCount('COMMIT', {testRollback: true, expect: expect})
+    var policyOps = PolicyOps(dbPool, () => {})
+
+    policyOps.updatePolicy([1, '2016-07-03', 'name', 'org_id', ''], utils.testError(expect, 'Error: query error test', done))
+  })
+
+  lab.test('deletePolicyById should return an error if deliting from user_policies fails', (done) => {
+    var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE from user_policies', {testRollback: true, expect: expect})
+    var policyOps = PolicyOps(dbPool, () => {})
+
+    policyOps.deletePolicyById([1, '2016-07-03', 'name', 'org_id', ''], utils.testError(expect, 'Error: query error test', done))
+  })
+
+  lab.test('deletePolicyById should return an error if deliting from team_policies fails', (done) => {
+    var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE from team_policies', {testRollback: true, expect: expect})
+    var policyOps = PolicyOps(dbPool, () => {})
+
+    policyOps.deletePolicyById([1, '2016-07-03', 'name', 'org_id', ''], utils.testError(expect, 'Error: query error test', done))
+  })
+
+  lab.test('deletePolicyById should return an error if deliting from policies fails', (done) => {
+    var dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE from policies', {testRollback: true, expect: expect})
+    var policyOps = PolicyOps(dbPool, () => {})
+
+    policyOps.deletePolicyById([1, '2016-07-03', 'name', 'org_id', ''], utils.testError(expect, 'Error: query error test', done))
+  })
+
+  lab.test('deletePolicyById should return an error if deleting from policies returns rowCount 0', (done) => {
+    var dbPool = utils.getDbPoolErrorForQueryOrRowCount(undefined, {testRollback: true, expect: expect}, {rowCount: 0})
+    var policyOps = PolicyOps(dbPool, () => {})
+
+    policyOps.deletePolicyById([1, '2016-07-03', 'name', 'org_id', ''], utils.testError(expect, 'Not Found', done))
+  })
+
+  lab.test('deletePolicyById should return an error if the delete commit fails', (done) => {
+    var dbPool = utils.getDbPoolErrorForQueryOrRowCount('COMMIT', {testRollback: true, expect: expect})
+    var policyOps = PolicyOps(dbPool, () => {})
+
+    policyOps.deletePolicyById([1, '2016-07-03', 'name', 'org_id', ''], utils.testError(expect, 'Error: query error test', done))
   })
 })

--- a/service/test/routes/private/policiesTest.js
+++ b/service/test/routes/private/policiesTest.js
@@ -1,0 +1,178 @@
+'use strict'
+
+const expect = require('code').expect
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+var proxyquire = require('proxyquire')
+
+var policyOps = {}
+var policiesRoutes = proxyquire('./../../../routes/private/policies', { './../../lib/policyOps': () => policyOps })
+var server = proxyquire('./../../../wiring-hapi', { './routes/private/policies': policiesRoutes })
+
+lab.experiment('Policies', () => {
+  lab.test('create new policy without a service key should return 403 Forbidden', (done) => {
+    const options = {
+      method: 'POST',
+      url: '/authorization/policies?sig=1234'
+    }
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(403)
+
+      done()
+    })
+  })
+
+  lab.test('create new policy without valid data should return 400 Bad Request', (done) => {
+    const options = {
+      method: 'POST',
+      url: '/authorization/policies?sig=123456789',
+      payload: {
+        version: '2016-07-01',
+        name: 'Documents Admin',
+        orgId: 'WONKA'
+      }
+    }
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+
+      done()
+    })
+  })
+
+  lab.test('create new policy should return 201 and the created policy data', (done) => {
+    const policyStub = {
+      id: 2,
+      version: '2016-07-01',
+      name: 'Documents Admin',
+      orgId: 'WONKA',
+      statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+    }
+
+    const options = {
+      method: 'POST',
+      url: '/authorization/policies?sig=123456789',
+      payload: {
+        version: policyStub.version,
+        name: policyStub.name,
+        orgId: policyStub.orgId,
+        statements: policyStub.statements
+      }
+    }
+
+    policyOps.createPolicy = (params, cb) => {
+      process.nextTick(() => {
+        cb(null, policyStub)
+      })
+    }
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(201)
+      expect(result).to.equal(policyStub)
+
+      done()
+    })
+  })
+
+  lab.test('update new policy without a service key should return 403 Forbidden', (done) => {
+    const options = {
+      method: 'PUT',
+      url: '/authorization/policies/1?sig=1234'
+    }
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(403)
+
+      done()
+    })
+  })
+
+  lab.test('update policy without valid data should return 400 Bad Request', (done) => {
+    const options = {
+      method: 'PUT',
+      url: '/authorization/policies/1?sig=123456789',
+      payload: {
+        version: '2016-07-01',
+        name: 'Documents Admin',
+        orgId: 'WONKA'
+      }
+    }
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+
+      done()
+    })
+  })
+
+  lab.test('update new policy should return the updated policy data', (done) => {
+    const policyStub = {
+      id: 2,
+      version: '2016-07-01',
+      name: 'Documents Admin - updated',
+      orgId: 'WONKA',
+      statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Update"],"Resource":["wonka:documents:/public/*"]}]}'
+    }
+
+    const options = {
+      method: 'PUT',
+      url: '/authorization/policies/2?sig=123456789',
+      payload: {
+        version: policyStub.version,
+        name: policyStub.name,
+        orgId: policyStub.orgId,
+        statements: policyStub.statements
+      }
+    }
+
+    policyOps.updatePolicy = (params, cb) => {
+      process.nextTick(() => {
+        cb(null, policyStub)
+      })
+    }
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal(policyStub)
+
+      done()
+    })
+  })
+
+  lab.test('delete policy without a service key should return 403 Forbidden', (done) => {
+    const options = {
+      method: 'DELETE',
+      url: '/authorization/policies/1?sig=1234'
+    }
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(403)
+
+      done()
+    })
+  })
+
+  lab.test('delete policy should return 204', (done) => {
+    const options = {
+      method: 'DELETE',
+      url: '/authorization/policies/1?sig=123456789'
+    }
+
+    policyOps.deletePolicyById = (params, cb) => {
+      process.nextTick(() => {
+        cb(null)
+      })
+    }
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(204)
+
+      done()
+    })
+  })
+})

--- a/service/wiring-hapi.js
+++ b/service/wiring-hapi.js
@@ -46,11 +46,11 @@ server.register(
     {
       register: require('./routes/public/authorization'),
       options
+    },
+    {
+      register: require('./routes/private/policies'),
+      options
     }
-    // {
-    //   register: require('./routes/private/policies'),
-    //   options
-    // },
   ],
   function (err) {
     if (err) { throw err }


### PR DESCRIPTION
Issue #139 

Add endpoints to create/update/delete a policy:

- `POST /authorization/policies`
- `PUT /authorization/policies/{id}`
- `DELETE /authorization/policies/{id}`

All these endpoints are accessible only if a service key is provided (ie: `/authorization/policies/{id}?sig=123456789`)

The service key can be configured in `config.js` and overridden by one or more env variables when running the app in production.