### PR TITLE
Add poll.query for single query statements

### DIFF
--- a/service/lib/policyOps.js
+++ b/service/lib/policyOps.js
@@ -11,57 +11,50 @@ module.exports = function (dbPool) {
     * $1 = user_id
     */
     listAllUserPolicies: function listAllUserPolicies ({ userId }, cb) {
-      dbPool.connect(function (err, client, done) {
+      const params = [
+        userId
+      ]
+      /* Query1: For fetching policies attached directly to the user */
+      /* Query2: For fetching policies attached to the teams user belongs to */
+      const sql = `(
+
+          SELECT
+            version,
+            name,
+            statements
+          FROM
+            policies p JOIN user_policies up
+          ON
+            p.id = up.policy_id
+          WHERE
+            up.user_id = $1
+
+        ) UNION (
+
+          SELECT
+            version,
+            name,
+            statements
+          FROM
+            policies p JOIN team_policies tp
+          ON
+            p.id = tp.policy_id
+          WHERE
+            tp.team_id IN (
+              SELECT team_id FROM team_members tm WHERE tm.user_id = $1
+            )
+        )
+      `
+      dbPool.query(sql, params, function (err, result) {
         if (err) return cb(Boom.badImplementation(err))
 
-        /* Query1: For fetching policies attached directly to the user */
-        /* Query2: For fetching policies attached to the teams user belongs to */
-        const sql = `(
+        const userPolicies = result.rows.map(row => ({
+          Version: row.version,
+          Name: row.name,
+          Statement: row.statements.Statement
+        }))
 
-            SELECT
-              version,
-              name,
-              statements
-            FROM
-              policies p JOIN user_policies up
-            ON
-              p.id = up.policy_id
-            WHERE
-              up.user_id = $1
-
-          ) UNION (
-
-            SELECT
-              version,
-              name,
-              statements
-            FROM
-              policies p JOIN team_policies tp
-            ON
-              p.id = tp.policy_id
-            WHERE
-              tp.team_id IN (
-                SELECT team_id FROM team_members tm WHERE tm.user_id = $1
-              )
-          )
-        `
-
-        const params = [
-          userId
-        ]
-
-        client.query(sql, params, function (err, result) {
-          done() // release the client back to the pool
-          if (err) return cb(Boom.badImplementation(err))
-
-          const userPolicies = result.rows.map(row => ({
-            Version: row.version,
-            Name: row.name,
-            Statement: row.statements.Statement
-          }))
-
-          return cb(null, userPolicies)
-        })
+        return cb(null, userPolicies)
       })
     },
 
@@ -69,15 +62,10 @@ module.exports = function (dbPool) {
     * no query args (but may e.g. sort in future)
     */
     listAllPolicies: function listAllPolicies (args, cb) {
-      dbPool.connect(function (err, client, done) {
+      dbPool.query('SELECT  id, version, name from policies ORDER BY UPPER(name)', function (err, result) {
         if (err) return cb(Boom.badImplementation(err))
 
-        client.query('SELECT  id, version, name from policies ORDER BY UPPER(name)', function (err, result) {
-          done() // release the client back to the pool
-          if (err) return cb(Boom.badImplementation(err))
-
-          return cb(null, result.rows)
-        })
+        return cb(null, result.rows)
       })
     },
 
@@ -86,22 +74,10 @@ module.exports = function (dbPool) {
     * no query args (but may e.g. sort in future)
     */
     listAllPoliciesDetails: function listAllPoliciesDetails (args, cb) {
-      dbPool.connect(function (err, client, done) {
+      dbPool.query('SELECT  id, version, name, statements from policies ORDER BY UPPER(name)', function (err, result) {
         if (err) return cb(Boom.badImplementation(err))
 
-        client.query('SELECT  id, version, name, statements from policies ORDER BY UPPER(name)', function (err, result) {
-          done() // release the client back to the pool
-          if (err) return cb(Boom.badImplementation(err))
-
-          var results = result.rows.map((policy) => ({
-            id: policy.id,
-            name: policy.name,
-            version: policy.version,
-            statements: policy.statements.Statement
-          }))
-
-          return cb(null, results)
-        })
+        return cb(null, result.rows)
       })
     },
 
@@ -109,22 +85,16 @@ module.exports = function (dbPool) {
     * $1 = id
     */
     readPolicyById: function readPolicyById (args, cb) {
-      dbPool.connect(function (err, client, done) {
+      dbPool.query('SELECT id, version, name, statements from policies WHERE id = $1', args, function (err, result) {
         if (err) return cb(Boom.badImplementation(err))
+        if (result.rowCount === 0) return cb(Boom.notFound())
 
-        client.query('SELECT id, version, name, statements from policies WHERE id = $1', args, function (err, result) {
-          done() // release the client back to the pool
-
-          if (err) return cb(Boom.badImplementation(err))
-          if (result.rowCount === 0) return cb(Boom.notFound())
-
-          var policy = result.rows[0]
-          return cb(null, {
-            id: policy.id,
-            name: policy.name,
-            version: policy.version,
-            statements: policy.statements.Statement
-          })
+        var policy = result.rows[0]
+        return cb(null, {
+          id: policy.id,
+          name: policy.name,
+          version: policy.version,
+          statements: policy.statements.Statement
         })
       })
     },
@@ -136,20 +106,41 @@ module.exports = function (dbPool) {
     * $4 = statements
     */
     createPolicy: function createPolicy (args, cb) {
+      const tasks = []
+      var policy
+
       dbPool.connect(function (err, client, done) {
         if (err) return cb(Boom.badImplementation(err))
 
-        client.query('INSERT INTO policies (id, version, name, org_id, statements) VALUES (DEFAULT, $1, $2, $3, $4) RETURNING id', args, function (err, result) {
-          done() // release the client back to the pool
-          if (err) return cb(Boom.badImplementation(err))
+        tasks.push((next) => { client.query('BEGIN', next) })
+        tasks.push((next) => {
+          client.query('INSERT INTO policies (id, version, name, org_id, statements) VALUES (DEFAULT, $1, $2, $3, $4) RETURNING id', args, function (err, result) {
+            if (err) return next(err)
 
-          const policy = result.rows[0]
-
-          policyOps.readPolicyById([policy.id], function (err, result) {
-            if (err) return cb(Boom.badImplementation(err))
-
-            return cb(null, result)
+            policy = result.rows[0]
+            next()
           })
+        })
+        tasks.push((next) => { client.query('COMMIT', next) })
+
+        tasks.push((next) => {
+          policyOps.readPolicyById([policy.id], function (err, result) {
+            if (err) return next(err)
+
+            policy = result
+
+            next()
+          })
+        })
+
+        async.series(tasks, (err) => {
+          if (err) {
+            dbUtil.rollback(client, done)
+            return cb(err.isBoom ? err : Boom.badImplementation(err))
+          }
+
+          done()
+          return cb(null, policy)
         })
       })
     },
@@ -172,38 +163,24 @@ module.exports = function (dbPool) {
       const tasks = []
 
       dbPool.connect(function (err, client, done) {
-        if (err) {
-          return cb(Boom.badImplementation(err))
-        }
+        if (err) return cb(Boom.badImplementation(err))
 
-        tasks.push((next) => {
-          client.query('BEGIN', (err, res) => {
-            if (err) return next(Boom.badImplementation(err))
-            next()
-          })
-        })
-
+        tasks.push((next) => { client.query('BEGIN', next) })
         tasks.push((next) => {
           client.query('UPDATE policies SET version = $2, name = $3, org_id = $4, statements = $5 WHERE id = $1', [id, version, name, orgId, statements], (err, res) => {
-            if (err) return next(Boom.badImplementation(err))
+            if (err) return next(err)
             if (res.rowCount === 0) return next(Boom.notFound())
 
             next()
           })
         })
-
-        tasks.push((next) => {
-          client.query('COMMIT', (err) => {
-            if (err) return next(Boom.badImplementation(err))
-
-            next()
-          })
-        })
+        tasks.push((next) => { client.query('COMMIT', next) })
 
         async.series(tasks, (err) => {
           if (err) {
             dbUtil.rollback(client, done)
-            return cb(err)
+
+            return cb(err.isBoom ? err : Boom.badImplementation(err))
           }
 
           done()
@@ -220,54 +197,26 @@ module.exports = function (dbPool) {
       const tasks = []
 
       dbPool.connect(function (err, client, done) {
-        if (err) {
-          return cb(Boom.badImplementation(err))
-        }
+        if (err) return cb(Boom.badImplementation(err))
 
-        tasks.push((next) => {
-          client.query('BEGIN', (err, res) => {
-            if (err) return next(Boom.badImplementation(err))
-            next()
-          })
-        })
-
-        tasks.push((next) => {
-          client.query('DELETE from user_policies WHERE policy_id = $1', [id], (err, res) => {
-            if (err) return next(Boom.badImplementation(err))
-
-            next()
-          })
-        })
-
-        tasks.push((next) => {
-          client.query('DELETE from team_policies WHERE policy_id = $1', [id], (err, res) => {
-            if (err) return next(Boom.badImplementation(err))
-
-            next()
-          })
-        })
-
+        tasks.push((next) => { client.query('BEGIN', next) })
+        tasks.push((next) => { client.query('DELETE from user_policies WHERE policy_id = $1', [id], next) })
+        tasks.push((next) => { client.query('DELETE from team_policies WHERE policy_id = $1', [id], next) })
         tasks.push((next) => {
           client.query('DELETE from policies WHERE id = $1', [id], (err, res) => {
-            if (err) return next(Boom.badImplementation(err))
+            if (err) return next(err)
             if (res.rowCount === 0) return next(Boom.notFound())
 
             next()
           })
         })
 
-        tasks.push((next) => {
-          client.query('COMMIT', (err) => {
-            if (err) return next(Boom.badImplementation(err))
-
-            next()
-          })
-        })
+        tasks.push((next) => { client.query('COMMIT', next) })
 
         async.series(tasks, (err) => {
           if (err) {
             dbUtil.rollback(client, done)
-            return cb(err)
+            return cb(err.isBoom ? err : Boom.badImplementation(err))
           }
 
           done()

--- a/service/lib/userOps.js
+++ b/service/lib/userOps.js
@@ -19,17 +19,10 @@ module.exports = function (dbPool, log) {
     * no query args (but may e.g. sort in future)
     */
     listAllUsers: function listAllUsers (args, cb) {
-      dbPool.connect(function (err, client, done) {
+      dbPool.query('SELECT * from users ORDER BY UPPER(name)', function (err, result) {
         if (err) return cb(Boom.badImplementation(err))
 
-        client.query('SELECT * from users ORDER BY UPPER(name)', function (err, result) {
-          done() // release the client back to the pool
-          if (err) return cb(Boom.badImplementation(err))
-
-          log.debug('listAllUsers: count of: %d', result.rowCount)
-
-          return cb(null, result.rows)
-        })
+        return cb(null, result.rows)
       })
     },
 
@@ -37,15 +30,10 @@ module.exports = function (dbPool, log) {
     * $1 = org_id
     */
     listOrgUsers: function listOrgUsers (args, cb) {
-      dbPool.connect(function (err, client, done) {
+      dbPool.query('SELECT  * from users WHERE org_id = $1 ORDER BY UPPER(name)', args, function (err, result) {
         if (err) return cb(Boom.badImplementation(err))
 
-        client.query('SELECT  * from users WHERE org_id = $1 ORDER BY UPPER(name)', args, function (err, result) {
-          done() // release the client back to the pool
-          if (err) return cb(Boom.badImplementation(err))
-
-          return cb(null, result.rows)
-        })
+        return cb(null, result.rows)
       })
     },
 
@@ -53,19 +41,38 @@ module.exports = function (dbPool, log) {
     * $1 = name, $2 = org_id
     */
     createUser: function createUser (args, cb) {
+      const tasks = []
+      var user
+
       dbPool.connect(function (err, client, done) {
         if (err) return cb(Boom.badImplementation(err))
 
-        client.query('INSERT INTO users (id, name, org_id) VALUES (DEFAULT, $1, $2) RETURNING id', args, function (err, result) {
-          done() // release the client back to the pool
-          if (err) return cb(Boom.badImplementation(err))
+        tasks.push((next) => { client.query('BEGIN', next) })
+        tasks.push((next) => {
+          client.query('INSERT INTO users (id, name, org_id) VALUES (DEFAULT, $1, $2) RETURNING id', args, function (err, result) {
+            if (err) return next(err)
 
-          log.debug('create user result: %j', result)
-          userOps.readUserById([result.rows[0].id], function (err, result) {
-            if (err) return cb(err)
-
-            return cb(null, result)
+            user = {id: result.rows[0].id}
+            next()
           })
+        })
+        tasks.push((next) => { client.query('COMMIT', next) })
+        tasks.push((next) => {
+          userOps.readUserById([user.id], function (err, result) {
+            if (err) return next(err)
+
+            user = result
+            next()
+          })
+        })
+
+        async.series(tasks, (err) => {
+          if (err) {
+            return cb(err.isBoom ? err : Boom.badImplementation(err))
+          }
+
+          done()
+          return cb(null, user)
         })
       })
     },
@@ -75,19 +82,31 @@ module.exports = function (dbPool, log) {
     * (allows passing in of ID for test purposes)
     */
     createUserById: function createUserById (args, cb) {
+      const tasks = []
+      var user
+
       dbPool.connect(function (err, client, done) {
         if (err) return cb(Boom.badImplementation(err))
 
-        client.query('INSERT INTO users (id, name, org_id) VALUES ($1, $2, $3)', args, function (err, result) {
-          done() // release the client back to the pool
-          if (err) return cb(Boom.badImplementation(err))
-
-          log.debug('create user result: %j', result)
+        tasks.push((next) => { client.query('BEGIN', next) })
+        tasks.push((next) => { client.query('INSERT INTO users (id, name, org_id) VALUES ($1, $2, $3)', args, next) })
+        tasks.push((next) => { client.query('COMMIT', next) })
+        tasks.push((next) => {
           userOps.readUserById([args[0]], function (err, result) {
-            if (err) return cb(err)
+            if (err) return next(err)
 
-            return cb(null, result)
+            user = result
+            next()
           })
+        })
+
+        async.series(tasks, (err) => {
+          if (err) {
+            return cb(err.isBoom ? err : Boom.badImplementation(err))
+          }
+
+          done()
+          return cb(null, user)
         })
       })
     },
@@ -96,51 +115,56 @@ module.exports = function (dbPool, log) {
     * $1 = id
     */
     readUserById: function readUserById (args, cb) {
-      var user = {
+      const user = {
         'id': null,
         'name': null,
         teams: [],
         policies: []
       }
+      const tasks = []
 
       dbPool.connect(function (err, client, done) {
         if (err) return cb(Boom.badImplementation(err))
 
-        client.query('SELECT id, name from users WHERE id = $1', args, function (err, result) {
-          if (err) {
-            done() // release the client back to the pool
-            return cb(Boom.badImplementation(err))
-          }
+        tasks.push((next) => {
+          client.query('SELECT id, name from users WHERE id = $1', args, function (err, result) {
+            if (err) return next(err)
+            if (result.rowCount === 0) return next(Boom.notFound())
 
-          if (result.rowCount === 0) {
-            done()
-            return cb(Boom.notFound())
-          }
+            user.id = result.rows[0].id
+            user.name = result.rows[0].name
 
-          user.id = result.rows[0].id
-          user.name = result.rows[0].name
+            next()
+          })
+        })
 
+        tasks.push((next) => {
           client.query('SELECT teams.id, teams.name from team_members mem, teams WHERE mem.user_id = $1 and mem.team_id = teams.id ORDER BY UPPER(teams.name)', args, function (err, result) {
-            if (err) {
-              done() // release the client back to the pool
-              return cb(Boom.badImplementation(err))
-            }
-
+            if (err) return next(err)
             result.rows.forEach(function (row) {
               user.teams.push(row)
             })
-
-            client.query('SELECT pol.id, pol.version, pol.name from user_policies upol, policies pol WHERE upol.user_id = $1 and upol.policy_id = pol.id ORDER BY UPPER(pol.name)', args, function (err, result) {
-              done() // release the client back to the pool
-              if (err) return cb(Boom.badImplementation(err))
-
-              result.rows.forEach(function (row) {
-                user.policies.push(row)
-              })
-
-              return cb(null, user)
-            })
+            next()
           })
+        })
+
+        tasks.push((next) => {
+          client.query('SELECT pol.id, pol.version, pol.name from user_policies upol, policies pol WHERE upol.user_id = $1 and upol.policy_id = pol.id ORDER BY UPPER(pol.name)', args, function (err, result) {
+            if (err) return next(err)
+            result.rows.forEach(function (row) {
+              user.policies.push(row)
+            })
+            next()
+          })
+        })
+
+        async.series(tasks, (err) => {
+          if (err) {
+            return cb(err.isBoom ? err : Boom.badImplementation(err))
+          }
+
+          done()
+          return cb(null, user)
         })
       })
     },
@@ -159,72 +183,35 @@ module.exports = function (dbPool, log) {
       dbPool.connect(function (err, client, done) {
         if (err) return cb(Boom.badImplementation(err))
 
-        tasks.push((next) => {
-          client.query('BEGIN', (err, res) => {
-            if (err) return next(Boom.badImplementation(err))
-            next()
-          })
-        })
-
+        tasks.push((next) => { client.query('BEGIN', next) })
         tasks.push((next) => {
           client.query('UPDATE users SET name = $2 WHERE id = $1', [id, name], (err, res) => {
-            if (err) return next(Boom.badImplementation(err))
+            if (err) return next(err)
             if (res.rowCount === 0) return next(Boom.notFound())
 
             next(null, res)
           })
         })
-
-        tasks.push((next) => {
-          client.query('DELETE FROM team_members WHERE user_id = $1', [id], (err) => {
-            if (err) return next(Boom.badImplementation(err))
-
-            next()
-          })
-        })
+        tasks.push((next) => { client.query('DELETE FROM team_members WHERE user_id = $1', [id], next) })
 
         if (teams.length > 0) {
-          tasks.push((next) => {
-            let stmt = dbUtil.buildInsertStmt('INSERT INTO team_members (team_id, user_id) VALUES ', teams.map(p => [p.id, id]))
-            client.query(stmt.statement, stmt.params, (err) => {
-              if (err) return next(Boom.badImplementation(err))
-
-              next()
-            })
-          })
+          let stmt = dbUtil.buildInsertStmt('INSERT INTO team_members (team_id, user_id) VALUES ', teams.map(p => [p.id, id]))
+          tasks.push((next) => { client.query(stmt.statement, stmt.params, next) })
         }
 
-        tasks.push((next) => {
-          client.query('DELETE FROM user_policies WHERE user_id = $1', [id], (err) => {
-            if (err) return next(Boom.badImplementation(err))
-
-            next()
-          })
-        })
+        tasks.push((next) => { client.query('DELETE FROM user_policies WHERE user_id = $1', [id], next) })
 
         if (policies.length > 0) {
-          tasks.push((next) => {
-            let stmt = dbUtil.buildInsertStmt('INSERT INTO user_policies (policy_id, user_id) VALUES ', policies.map(p => [p.id, id]))
-            client.query(stmt.statement, stmt.params, (err) => {
-              if (err) return next(Boom.badImplementation(err))
-
-              next()
-            })
-          })
+          let stmt = dbUtil.buildInsertStmt('INSERT INTO user_policies (policy_id, user_id) VALUES ', policies.map(p => [p.id, id]))
+          tasks.push((next) => { client.query(stmt.statement, stmt.params, next) })
         }
 
-        tasks.push((next) => {
-          client.query('COMMIT', (err) => {
-            if (err) return next(Boom.badImplementation(err))
-
-            next()
-          })
-        })
+        tasks.push((next) => { client.query('COMMIT', next) })
 
         async.series(tasks, (err) => {
           if (err) {
             dbUtil.rollback(client, done)
-            return cb(err)
+            return cb(err.isBoom ? err : Boom.badImplementation(err))
           }
 
           done()
@@ -241,47 +228,23 @@ module.exports = function (dbPool, log) {
       dbPool.connect(function (err, client, done) {
         if (err) return cb(Boom.badImplementation(err))
 
-        tasks.push((next) => {
-          client.query('BEGIN', (err, res) => {
-            if (err) return next(Boom.badImplementation(err))
-            next()
-          })
-        })
-
-        tasks.push((next) => {
-          client.query('DELETE from user_policies WHERE user_id = $1', args, function (err, result) {
-            if (err) return next(Boom.badImplementation(err))
-            next()
-          })
-        })
-
-        tasks.push((next) => {
-          client.query('DELETE from team_members WHERE user_id = $1', args, function (err, result) {
-            if (err) return next(Boom.badImplementation(err))
-            next()
-          })
-        })
-
+        tasks.push((next) => { client.query('BEGIN', next) })
+        tasks.push((next) => { client.query('DELETE from user_policies WHERE user_id = $1', args, next) })
+        tasks.push((next) => { client.query('DELETE from team_members WHERE user_id = $1', args, next) })
         tasks.push((next) => {
           client.query('DELETE from users WHERE id = $1', args, function (err, result) {
-            if (err) return next(Boom.badImplementation(err))
+            if (err) return next(err)
             if (result.rowCount === 0) return next(Boom.notFound())
 
             next()
           })
         })
-
-        tasks.push((next) => {
-          client.query('COMMIT', function (err, result) {
-            if (err) return next(Boom.badImplementation(err))
-            next()
-          })
-        })
+        tasks.push((next) => { client.query('COMMIT', next) })
 
         async.series(tasks, (err) => {
           if (err) {
             dbUtil.rollback(client, done)
-            return cb(err)
+            return cb(err.isBoom ? err : Boom.badImplementation(err))
           }
 
           done()
@@ -294,19 +257,12 @@ module.exports = function (dbPool, log) {
     * $1 = id
     */
     getUserByToken: function getUserByToken (userId, cb) {
-      dbPool.connect((err, client, done) => {
+      dbPool.query('SELECT id, name FROM users WHERE id = $1', [ userId ], function (err, result) {
         if (err) return cb(Boom.badImplementation(err))
+        if (result.rowCount === 0) return cb(Boom.notFound())
 
-        client.query('SELECT id, name FROM users WHERE id = $1', [ userId ], (err, result) => {
-          done()
-
-          if (err) return cb(Boom.badImplementation(err))
-          if (result.rowCount === 0) return cb(Boom.notFound())
-
-          const user = result.rows[0]
-
-          return cb(null, user)
-        })
+        const user = result.rows[0]
+        return cb(null, user)
       })
     }
   }

--- a/service/test/lib/unit/userOpsTest.js
+++ b/service/test/lib/unit/userOpsTest.js
@@ -8,7 +8,7 @@ const async = require('async')
 const UserOps = require('../../../lib/userOps')
 const utils = require('../../utils')
 
-lab.experiment('teamOps', () => {
+lab.experiment('userOps', () => {
   lab.test('should return an error if the db connection fails', (done) => {
     var userOps = UserOps(utils.getDbPollConnectionError(), {debug: () => {}})
     var functionsUnderTest = ['listAllUsers', 'listOrgUsers', 'createUser', 'createUserById', 'readUserById', 'updateUser', 'deleteUserById', 'getUserByToken']

--- a/service/test/utils.js
+++ b/service/test/utils.js
@@ -4,22 +4,34 @@
  * Calls the callback with an error when the `connect` function is executed
  */
 function getDbPollConnectionError () {
-  return {connect: function (cb) {
-    cb(new Error('connection error test'))
-  }}
+  return {
+    connect: function (cb) {
+      cb(new Error('connection error test'))
+    },
+    query: function (sql, params, cb) {
+      cb = cb || params
+      cb(new Error('connection error test'))
+    }
+  }
 }
 
 /**
  * Calls the callback with an error when the `query` function is executed
  */
 function getDbPollFirstQueryError () {
-  return {connect: function (cb) {
-    var client = {query: (sql, params, cb) => {
+  return {
+    connect: function (cb) {
+      var client = {query: (sql, params, cb) => {
+        cb = cb || params
+        cb(new Error('query error test'))
+      }}
+      cb(undefined, client, () => {})
+    },
+    query: function (sql, params, cb) {
       cb = cb || params
       cb(new Error('query error test'))
-    }}
-    cb(undefined, client, () => {})
-  }}
+    }
+  }
 }
 
 /**
@@ -36,8 +48,21 @@ function getDbPollFirstQueryError () {
  * @param  {Object} result
  */
 function getDbPoolErrorForQueryOrRowCount (startsWith, options = {testRollback: false, expect: undefined}, result = {rowCount: 1, rows: []}) {
-  return {connect: function (cb) {
-    var client = {query: (sql, params, cb) => {
+  return {
+    connect: function (cb) {
+      var client = {query: (sql, params, cb) => {
+        cb = cb || params
+        if (sql.startsWith(startsWith)) {
+          return cb(new Error('query error test'))
+        }
+        if (options.testRollback && sql.startsWith('ROLLBACK')) {
+          options.expect(sql).to.equal('ROLLBACK')
+        }
+        cb(undefined, result)
+      }}
+      cb(undefined, client, () => {})
+    },
+    query: function (sql, params, cb) {
       cb = cb || params
       if (sql.startsWith(startsWith)) {
         return cb(new Error('query error test'))
@@ -46,9 +71,8 @@ function getDbPoolErrorForQueryOrRowCount (startsWith, options = {testRollback: 
         options.expect(sql).to.equal('ROLLBACK')
       }
       cb(undefined, result)
-    }}
-    cb(undefined, client, () => {})
-  }}
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Issue #144 

What is changed:

* `poll.query` for single query statements
* `BEGIN`/`COMMIT` for writing statements (insert, update)
* refactor the code handling the queries so that is less verbose and uses `async.series` for queries with multiple statement
