### PR TITLE
Make policy input and output consistent

### DIFF
--- a/service/lib/policyOps.js
+++ b/service/lib/policyOps.js
@@ -15,7 +15,8 @@ module.exports = function (dbPool) {
         userId
       ]
       /* Query1: For fetching policies attached directly to the user */
-      /* Query2: For fetching policies attached to the teams user belongs to */
+      /* Query2: For fetching policies attached to the teams the user belongs to */
+      /* TO-DO Query3: For fetching policies attached to the organization the user belongs to */
       const sql = `(
 
           SELECT
@@ -89,13 +90,7 @@ module.exports = function (dbPool) {
         if (err) return cb(Boom.badImplementation(err))
         if (result.rowCount === 0) return cb(Boom.notFound())
 
-        var policy = result.rows[0]
-        return cb(null, {
-          id: policy.id,
-          name: policy.name,
-          version: policy.version,
-          statements: policy.statements.Statement
-        })
+        return cb(null, result.rows[0])
       })
     },
 
@@ -149,7 +144,7 @@ module.exports = function (dbPool) {
           }
 
           done()
-          return cb(null, {id, version, name, statements: JSON.parse(statements).Statement})
+          return cb(null, {id, version, name, statements: JSON.parse(statements)})
         })
       })
     },

--- a/service/test/lib/integration/policyOpsTest.js
+++ b/service/test/lib/integration/policyOpsTest.js
@@ -63,7 +63,7 @@ lab.experiment('PolicyOps', () => {
 
       expect(policy.name).to.equal('Documents Admin')
       expect(policy.version).to.equal('2016-07-01')
-      expect(policy.statements).to.equal([{Effect: 'Allow', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*']}])
+      expect(policy.statements).to.equal({Statement: [{Effect: 'Allow', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*']}]})
 
       params[0] = '2016-07-02'
       params[1] = 'Documents Admin v2'
@@ -75,7 +75,7 @@ lab.experiment('PolicyOps', () => {
 
         expect(policy.name).to.equal('Documents Admin v2')
         expect(policy.version).to.equal('2016-07-02')
-        expect(policy.statements).to.equal([{Effect: 'Deny', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*']}])
+        expect(policy.statements).to.equal({Statement: [{Effect: 'Deny', Action: ['documents:Read'], Resource: ['wonka:documents:/public/*']}]})
 
         policyOps.deletePolicyById([policyId], done)
       })


### PR DESCRIPTION
As discussed yesterday, we wanted the policy data given in input to be consistent with the policy data returned by GET `/policies` or GET `/policies/1234`

Ref: https://github.com/nearform/labs-authorization/issues/147