### PR TITLE
Issue 167: Add endpoints to add/delete/replace user's policies

### DIFF
--- a/service/routes/public/users.js
+++ b/service/routes/public/users.js
@@ -104,14 +104,13 @@ exports.register = function (server, options, next) {
     handler: function (request, reply) {
       const { id: organizationId } = request.authorization.organization
       const id = request.params.id
-      const { name, teams, policies } = request.payload
+      const { name, teams } = request.payload
 
       const params = {
         id,
         organizationId,
         name,
-        teams,
-        policies
+        teams
       }
       userOps.updateUser(params, reply)
     },
@@ -124,15 +123,132 @@ exports.register = function (server, options, next) {
           name: Joi.string().required().description('user name'),
           teams: Joi.array().required().items(Joi.object().keys({
             id: Joi.number().required()
-          })),
-          policies: Joi.array().required().items(Joi.object().keys({
-            id: Joi.number().required()
           }))
         }
       },
       description: 'Update a user',
       notes: 'The PUT /authorization/users endpoint updates a user data\n',
       tags: ['api', 'service', 'put', 'users']
+    }
+  })
+
+  server.route({
+    method: 'PUT',
+    path: '/authorization/users/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { id: organizationId } = request.authorization.organization
+      const { policies } = request.payload
+
+      const params = {
+        id,
+        organizationId,
+        policies
+      }
+      userOps.addUserPolicies(params, reply)
+    },
+    config: {
+      validate: {
+        params: {
+          id: Joi.number().required().description('user id')
+        },
+        payload: {
+          policies: Joi.array().required().items(Joi.object().keys({
+            id: Joi.number().required()
+          }))
+        }
+      },
+      description: 'Add one or more policies to a user',
+      notes: 'The PUT /authorization/users/{id}/policies endpoint add one or more new policies to a user\n',
+      tags: ['api', 'service', 'put', 'users', 'policies']
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/authorization/users/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { id: organizationId } = request.authorization.organization
+      const { policies } = request.payload
+
+      const params = {
+        id,
+        organizationId,
+        policies
+      }
+
+      userOps.replaceUserPolicies(params, reply)
+    },
+    config: {
+      validate: {
+        params: {
+          id: Joi.number().required().description('user id')
+        },
+        payload: {
+          policies: Joi.array().required().items(Joi.object().keys({
+            id: Joi.number().required()
+          }))
+        }
+      },
+      description: 'Clear and replace policies for a user',
+      notes: 'The POST /authorization/users/{id}/policies endpoint removes all the user policies and replace them\n',
+      tags: ['api', 'service', 'post', 'users', 'policies']
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/users/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { id: organizationId } = request.authorization.organization
+
+      userOps.deleteUserPolicies({ id, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: {
+          id: Joi.number().required().description('user id')
+        }
+      },
+      description: 'Clear all user\'s policies',
+      notes: 'The DELETE /authorization/users/{id}/policies endpoint removes all the user policies\n',
+      tags: ['api', 'service', 'delete', 'users', 'policies']
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/users/{userId}/policies/{policyId}',
+    handler: function (request, reply) {
+      const { userId, policyId } = request.params
+      const { id: organizationId } = request.authorization.organization
+
+      userOps.deleteUserPolicy({ userId, policyId, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: {
+          userId: Joi.number().required().description('user id'),
+          policyId: Joi.number().required().description('policy id')
+        }
+      },
+      description: 'Remove a user\'s policy',
+      notes: 'The DELETE /authorization/users/{userId}/policies/{policyId} endpoint removes a specific user\'s policy\n',
+      tags: ['api', 'service', 'delete', 'users', 'policies']
     }
   })
 

--- a/service/test/lib/integration/authorizeOpsTest.js
+++ b/service/test/lib/integration/authorizeOpsTest.js
@@ -18,362 +18,167 @@ const policyOps = PolicyOps(db.pool)
 const authorize = Authorize(policyOps)
 const teamOps = TeamOps(db.pool, logger)
 
-
+let testUserId
+let testTeamId
+const organizationId = 'WONKA'
 const testUserData = {
   name: 'Salman',
-  organizationId: 'WONKA'
+  organizationId
+}
+const updateUserData = {
+  organizationId,
+  name: 'Salman',
+  teams: [{ id: 4 }]
 }
 
-const updateUserData = {
-  organizationId: testUserData.organizationId,
-  name: testUserData.name,
-  teams: [{ id: 4 }],
-  policies: [{ id: 1 }]
-}
 
 lab.experiment('AuthorizeOps', () => {
-  lab.test('check authorization should return access true for allowed', (done) => {
-    const tasks = []
-    let testUserId
+  lab.before((done) => {
+    userOps.createUser(testUserData, (err, result) => {
+      if (err) return done(err)
+      testUserId = result.id
 
-    tasks.push((next) => {
-      userOps.createUser(testUserData, (err, result) => {
-        if (err) return next(err)
-        testUserId = result.id
-
-        next(err)
-      })
-    })
-
-    tasks.push((next) => {
       updateUserData.id = testUserId
       userOps.updateUser(updateUserData, (err, result) => {
-        if (err) return next(err)
+        if (err) return done(err)
 
-        next(err)
+        userOps.replaceUserPolicies({ id: testUserId, policies: [{ id: 1 }], organizationId }, done)
       })
     })
+  })
 
-    tasks.push((next) => {
-      authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'finance:ReadBalanceSheet' }, (err, result) => {
-        if (err) return next(err)
+  lab.after((done) => {
+    userOps.deleteUser({ id: testUserId, organizationId: 'WONKA' }, (err, res) => {
+      if (err) return done(err)
 
-        expect(err).to.not.exist()
-        expect(result).to.exist()
-        expect(result.access).to.be.true()
-
-        next(err)
-      })
+      teamOps.deleteTeam({ id: testTeamId, organizationId }, done)
     })
+  })
 
-    tasks.push((next) => {
-      userOps.deleteUser({ id: testUserId, organizationId: 'WONKA' }, (err, result) => {
-        expect(err).to.not.exist()
+  lab.test('check authorization should return access true for allowed', (done) => {
+    authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'finance:ReadBalanceSheet' }, (err, result) => {
+      if (err) return done(err)
 
-        next(err)
-      })
+      expect(err).to.not.exist()
+      expect(result).to.exist()
+      expect(result.access).to.be.true()
+
+      done()
     })
-
-    async.series(tasks, done)
   })
 
   lab.test('authorize isUserAuthorized - check on a resource and action with wildcards both in action and resource', (done) => {
-    const tasks = []
-    let testUserId
 
-    tasks.push((next) => {
-      userOps.createUser(testUserData, (err, result) => {
-        if (err) return next(err)
-        testUserId = result.id
+    userOps.replaceUserPolicies({ id: testUserId, policies: [{ id: 5 }], organizationId }, (err, result) => {
+      if (err) return done(err)
 
-        next()
-      })
-    })
-
-    tasks.push((next) => {
-      updateUserData.id = testUserId
-      updateUserData.policies = [{ id: 5 }]
-
-      userOps.updateUser(updateUserData, (err, result) => {
-        if (err) return next(err)
-        next()
-      })
-    })
-
-    tasks.push((next) => {
       authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:dropTable' }, (err, result) => {
-        if (err) return next(err)
+        if (err) return done(err)
 
         expect(err).to.not.exist()
         expect(result).to.exist()
         expect(result.access).to.be.true()
 
-        next()
+        done()
       })
     })
-
-    tasks.push((next) => {
-      userOps.deleteUser({ id: testUserId, organizationId: 'WONKA' }, (err, result) => {
-        expect(err).to.not.exist()
-        next()
-      })
-    })
-
-    async.series(tasks, done)
   })
 
   lab.test('authorize isUserAuthorized - check on a resource and action with wildcards only for resource', (done) => {
-    const tasks = []
-    let testUserId
 
-    tasks.push((next) => {
-      userOps.createUser(testUserData, (err, result) => {
-        if (err) next(err)
-        testUserId = result.id
+    userOps.replaceUserPolicies({ id: testUserId, policies: [{ id: 6 }], organizationId }, (err, result) => {
+      if (err) return done(err)
 
-        next()
-      })
-    })
-
-    tasks.push((next) => {
-      updateUserData.id = testUserId
-      updateUserData.policies = [{ id: 6 }]
-
-      userOps.updateUser(updateUserData, (err, result) => {
-        if (err) next(err)
-        next()
-      })
-    })
-
-    tasks.push((next) => {
       authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:Read' }, (err, result) => {
-        if (err) next(err)
+        if (err) return done(err)
 
         expect(err).to.not.exist()
         expect(result).to.exist()
         expect(result.access).to.be.true()
 
-        next()
+        done()
       })
     })
-
-    tasks.push((next) => {
-      userOps.deleteUser({ id: testUserId, organizationId: 'WONKA' }, (err, result) => {
-        expect(err).to.not.exist()
-        next()
-      })
-    })
-
-    async.series(tasks, done)
   })
 
   lab.test('authorize isUserAuthorized - check on a resource and action with wildcards only for action', (done) => {
-    const tasks = []
-    let testUserId
+    userOps.replaceUserPolicies({ id: testUserId, policies: [{ id: 7 }], organizationId }, (err, result) => {
+      if (err) return done(err)
 
-    tasks.push((next) => {
-      userOps.createUser(testUserData, (err, result) => {
-        if (err) next(err)
-        testUserId = result.id
-
-        next()
-      })
-    })
-
-    tasks.push((next) => {
-      updateUserData.id = testUserId
-      updateUserData.policies = [{ id: 7 }]
-
-      userOps.updateUser(updateUserData, (err, result) => {
-        if (err) next(err)
-        next()
-      })
-    })
-
-    tasks.push((next) => {
       authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:Delete' }, (err, result) => {
-        if (err) next(err)
+        if (err) return done(err)
 
         expect(err).to.not.exist()
         expect(result).to.exist()
         expect(result.access).to.be.true()
 
-        next()
+        done()
       })
     })
-
-    tasks.push((next) => {
-      userOps.deleteUser({ id: testUserId, organizationId: 'WONKA' }, (err, result) => {
-        expect(err).to.not.exist()
-        next()
-      })
-    })
-
-    async.series(tasks, done)
   })
 
   lab.test('authorize isUserAuthorized - check on a resource and action with wildcards for URL resource', (done) => {
-    const tasks = []
-    let testUserId
+    userOps.replaceUserPolicies({ id: testUserId, policies: [{ id: 8 }], organizationId }, (err, result) => {
+      if (err) return done(err)
 
-    tasks.push((next) => {
-      userOps.createUser(testUserData, (err, result) => {
-        if (err) next(err)
-        testUserId = result.id
-
-        next()
-      })
-    })
-
-    tasks.push((next) => {
-      updateUserData.id = testUserId
-      updateUserData.policies = [{ id: 8 }]
-
-      userOps.updateUser(updateUserData, (err, result) => {
-        if (err) next(err)
-        next()
-      })
-    })
-
-    tasks.push((next) => {
       authorize.isUserAuthorized({ userId: testUserId, resource: '/my/site/i/should/read/this', action: 'Read' }, (err, result) => {
-        if (err) next(err)
+        if (err) return done(err)
 
         expect(err).to.not.exist()
         expect(result).to.exist()
         expect(result.access).to.be.true()
 
-        next()
+        done()
       })
     })
-
-    tasks.push((next) => {
-      userOps.deleteUser({ id: testUserId, organizationId: 'WONKA' }, (err, result) => {
-        expect(err).to.not.exist()
-        next()
-      })
-    })
-
-    async.series(tasks, done)
   })
 
   lab.test('authorize isUserAuthorized - should return false if the policies has a wildcard on the resource but we are asking for the wrong action', (done) => {
-    const tasks = []
-    let testUserId
+    userOps.replaceUserPolicies({ id: testUserId, policies: [{ id: 6 }], organizationId }, (err, result) => {
+      if (err) return done(err)
 
-    tasks.push((next) => {
-      userOps.createUser(testUserData, (err, result) => {
-        if (err) next(err)
-        testUserId = result.id
-
-        next()
-      })
-    })
-
-    tasks.push((next) => {
-      updateUserData.id = testUserId
-      updateUserData.policies = [{ id: 6 }]
-
-      userOps.updateUser(updateUserData, (err, result) => {
-        if (err) next(err)
-        next()
-      })
-    })
-
-    tasks.push((next) => {
       authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:balancesheet', action: 'database:Write' }, (err, result) => {
-        if (err) next(err)
+        if (err) return done(err)
 
         expect(err).to.not.exist()
         expect(result).to.exist()
         expect(result.access).to.be.false()
 
-        next()
+        done()
       })
     })
-
-    tasks.push((next) => {
-      userOps.deleteUser({ id: testUserId, organizationId: 'WONKA' }, (err, result) => {
-        expect(err).to.not.exist()
-        next()
-      })
-    })
-
-    async.series(tasks, done)
   })
 
   lab.test('authorize isUserAuthorized - should return false if the policies has a wildcard on the action but we are asking for the wrong resource', (done) => {
-    const tasks = []
-    let testUserId
+    userOps.replaceUserPolicies({ id: testUserId, policies: [{ id: 6 }], organizationId }, (err, result) => {
+      if (err) return done(err)
 
-    tasks.push((next) => {
-      userOps.createUser(testUserData, (err, result) => {
-        if (err) next(err)
-        testUserId = result.id
-
-        next()
-      })
-    })
-
-    tasks.push((next) => {
-      updateUserData.id = testUserId
-      updateUserData.policies = [{ id: 6 }]
-
-      userOps.updateUser(updateUserData, (err, result) => {
-        if (err) next(err)
-        next()
-      })
-    })
-
-    tasks.push((next) => {
       authorize.isUserAuthorized({ userId: testUserId, resource: 'database:pg01:notMyTable', action: 'database:Write' }, (err, result) => {
-        if (err) next(err)
+        if (err) return done(err)
 
         expect(err).to.not.exist()
         expect(result).to.exist()
         expect(result.access).to.be.false()
 
-        next()
+        done()
       })
     })
-
-    tasks.push((next) => {
-      userOps.deleteUser({ id: testUserId, organizationId: 'WONKA' }, (err, result) => {
-        expect(err).to.not.exist()
-        next()
-      })
-    })
-
-    async.series(tasks, done)
   })
 
   lab.test('authorize listAuthorizations - get all user actions on a resource', (done) => {
-    let testUserId
-    let testTeamId
-    const testUserName = 'Orson Cart'
     const testTeamName = 'Actors'
     const testTeamParent = null
     const testTeamDesc = 'Famous Actors'
-    const organizationId = 'WONKA'
     const tasks = []
 
     // set-up
     tasks.push((cb) => {
-      userOps.listOrgUsers({ organizationId }, (err, result) => {
-        expect(result.length).to.equal(6)
-        cb(err, result)
-      })
+      updateUserData.id = testUserId
+      updateUserData.teams = []
+      userOps.updateUser(updateUserData, cb)
     })
-
-    tasks.push((res, cb) => {
-      const userData = {
-        name: testUserName,
-        organizationId
-      }
-      userOps.createUser(userData, (err, result) => {
-        testUserId = result.id
-        cb(err, result)
-      })
+    tasks.push((result, cb) => {
+      userOps.replaceUserPolicies({ id: testUserId, policies: [], organizationId }, cb)
     })
 
     tasks.push((result, cb) => {
@@ -393,13 +198,6 @@ lab.experiment('AuthorizeOps', () => {
       teamOps.createTeam(teamData, (err, result) => {
         expect(err).to.not.exist()
         testTeamId = result.id
-        cb(err, result)
-      })
-    })
-
-    tasks.push((result, cb) => {
-      userOps.listOrgUsers({ organizationId }, (err, result) => {
-        expect(result.length).to.equal(7)
         cb(err, result)
       })
     })
@@ -446,12 +244,11 @@ lab.experiment('AuthorizeOps', () => {
 
     // test for user permissions on the resource
     tasks.push((result, cb) => {
-      updateUserData.id = testUserId
-      updateUserData.name = testUserName
       updateUserData.teams = []
-      updateUserData.policies = [{ id: 3 }]
-
       userOps.updateUser(updateUserData, cb)
+    })
+    tasks.push((result, cb) => {
+      userOps.replaceUserPolicies({ id: testUserId, policies: [{ id: 3 }], organizationId }, cb)
     })
 
     tasks.push((result, cb) => {
@@ -469,12 +266,11 @@ lab.experiment('AuthorizeOps', () => {
 
     // test for team and user permissions on the resource
     tasks.push((result, cb) => {
-      updateUserData.id = testUserId
-      updateUserData.name = testUserName
       updateUserData.teams = [{ id: 1 }]
-      updateUserData.policies = [{ id: 4 }]
-
       userOps.updateUser(updateUserData, cb)
+    })
+    tasks.push((result, cb) => {
+      userOps.replaceUserPolicies({ id: testUserId, policies: [{ id: 4 }], organizationId }, cb)
     })
 
     tasks.push((result, cb) => {
@@ -488,34 +284,6 @@ lab.experiment('AuthorizeOps', () => {
 
         cb(err, result)
       })
-    })
-
-    // clean-up
-    tasks.push((result, cb) => {
-      policyOps.listByOrganization({ organizationId }, (err, policies) => {
-        expect(err).to.not.exist()
-
-        const defaultPolicy = policies.find((p) => {
-          return p.name === 'Default Team Admin for ' + testTeamId
-        })
-        expect(defaultPolicy).to.exist()
-
-        policyOps.deletePolicy({ id: defaultPolicy.id, organizationId }, (err, result) => {
-          expect(err).to.not.exist()
-          cb(err, result)
-        })
-      })
-    })
-
-    tasks.push((result, cb) => {
-      userOps.deleteUser({ id: testUserId, organizationId }, (err, result) => {
-        expect(err).to.not.exist()
-        cb(err, result)
-      })
-    })
-
-    tasks.push((result, cb) => {
-      teamOps.deleteTeam({ id: testTeamId, organizationId }, cb)
     })
 
     async.waterfall(tasks, done)

--- a/service/test/lib/integration/teamOpsTest.js
+++ b/service/test/lib/integration/teamOpsTest.js
@@ -17,6 +17,12 @@ const policyOps = PolicyOps(db.pool, logger)
 const userOps = UserOps(db.pool, logger)
 
 let testTeamId
+const teamData = {
+  name: 'Team 4',
+  description: 'This is a test team',
+  parentId: null,
+  organizationId: 'WONKA'
+}
 
 lab.experiment('TeamOps', () => {
 
@@ -32,12 +38,6 @@ lab.experiment('TeamOps', () => {
   })
 
   lab.test('create, update and delete a team', (done) => {
-    const teamData = {
-      name: 'Team 4',
-      description: 'This is a test team',
-      parentId: null,
-      organizationId: 'WONKA'
-    }
     teamOps.createTeam(teamData, function (err, result) {
       testTeamId = result.id
 
@@ -45,7 +45,7 @@ lab.experiment('TeamOps', () => {
       expect(result).to.exist()
       expect(result.name).to.equal('Team 4')
 
-      const teamData = {
+      const updateData = {
         id: testTeamId,
         name: 'Team 5',
         description: 'description',
@@ -54,7 +54,7 @@ lab.experiment('TeamOps', () => {
         organizationId: 'WONKA'
       }
 
-      teamOps.updateTeam(teamData, (err, result) => {
+      teamOps.updateTeam(updateData, (err, result) => {
         expect(err).to.not.exist()
         expect(result).to.exist()
         expect(result.name).to.equal('Team 5')
@@ -95,12 +95,6 @@ lab.experiment('TeamOps', () => {
   })
 
   lab.test('creating a team should create a default admin policy', (done) => {
-    const teamData = {
-      name: 'Team 5',
-      description: 'This is a test team for policies',
-      parentId: null,
-      organizationId: 'WONKA'
-    }
     teamOps.createTeam(teamData, function (err, result) {
       expect(err).to.not.exist()
       expect(result).to.exist()
@@ -121,12 +115,6 @@ lab.experiment('TeamOps', () => {
   })
 
   lab.test('creating a team with createOnly option should not create a default admin policy', (done) => {
-    const teamData = {
-      name: 'Team 6',
-      description: 'This is a test team for createOnly options',
-      parentId: null,
-      organizationId: 'WONKA'
-    }
     teamOps.createTeam(teamData, { createOnly: true }, function (err, result) {
       expect(err).to.not.exist()
       expect(result).to.exist()
@@ -145,13 +133,7 @@ lab.experiment('TeamOps', () => {
   })
 
   lab.test('create team support creation of default team admin user', (done) => {
-    const teamData = {
-      name: 'Team 6',
-      description: 'This is a test team for admin user',
-      parentId: null,
-      organizationId: 'WONKA',
-      user: { name: 'Team 6 Admin' }
-    }
+    teamData.user = { name: 'Team 6 Admin' }
 
     teamOps.createTeam(teamData, function (err, team) {
       expect(err).to.not.exist()

--- a/service/test/lib/integration/userOpsTest.js
+++ b/service/test/lib/integration/userOpsTest.js
@@ -53,25 +53,26 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('update a user', (done) => {
-    const expected = {id: 6, name: 'Augustus Gloop', teams: [{id: 4, name: 'Dream Team'}], policies: [{id: 1, name: 'DROP ALL TABLES!'}, {id: 2, name: 'THROW DESK'}]}
+    const expected = { id: 6, name: 'Augustus Gloop', organizationId: 'WONKA', teams: [{ id: 4, name: 'Managers' }], policies: [] }
     const data = {
       id: 6,
       organizationId: 'WONKA',
       name: 'Augustus Gloop',
-      teams: [{ id: 4, name: 'Dream Team' }],
-      policies: [{ id: 1, name: 'DROP ALL TABLES!' }, { id: 2, name: 'THROW DESK' }]
+      teams: [{ id: 4 }]
     }
+
     userOps.updateUser(data, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
       expect(result).to.equal(expected)
 
-      done()
+      data.teams = [{ id: 4 }, { id: 5 }]
+      userOps.updateUser(data, done)
     })
   })
 
   lab.test('read a specific user', (done) => {
-    const expected = {id: 4, name: 'Veruca Salt', organizationId: 'WONKA', teams: [{id: 3, name: 'Authors'}, {id: 2, name: 'Readers'}], policies: [{id: 2, version: '0.1', name: 'Accountant'}]}
+    const expected = { id: 4, name: 'Veruca Salt', organizationId: 'WONKA', teams: [{ id: 3, name: 'Authors' }, { id: 2, name: 'Readers' }], policies: [{ id: 2, version: '0.1', name: 'Accountant' }] }
     userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
@@ -99,6 +100,82 @@ lab.experiment('UserOps', () => {
       expect(result).to.not.exist()
 
       done()
+    })
+  })
+
+  lab.test('replace user\'s policies', (done) => {
+    userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+      expect(err).to.not.exist()
+      expect(user).to.exist()
+      expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }])
+
+      userOps.replaceUserPolicies({ id: 4, policies: [{ id: 1 }, { id: 3 }], organizationId: 'WONKA' }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([{ id: 1, name: 'Director', version: '0.1' }, { id: 3, name: 'Sys admin', version: '0.1' }])
+
+        userOps.replaceUserPolicies({ id: 4, policies: [{ id: 2 }], organizationId: 'WONKA' }, (err, user) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+    })
+  })
+
+  lab.test('add policies to user', (done) => {
+    userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+      expect(err).to.not.exist()
+      expect(user).to.exist()
+      expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }])
+
+      userOps.addUserPolicies({ id: 4, policies: [{ id: 1 }, { id: 3 }], organizationId: 'WONKA' }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }, { id: 1, name: 'Director', version: '0.1' }, { id: 3, name: 'Sys admin', version: '0.1' }])
+
+        userOps.replaceUserPolicies({ id: 4, policies: [{ id: 2 }], organizationId: 'WONKA' }, (err, user) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+    })
+  })
+
+  lab.test('delete user\'s policies', (done) => {
+    userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+      expect(err).to.not.exist()
+      expect(user).to.exist()
+      expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }])
+
+      userOps.deleteUserPolicies({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([])
+
+        userOps.replaceUserPolicies({ id: 4, policies: [{ id: 2 }], organizationId: 'WONKA' }, (err, user) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+    })
+  })
+
+  lab.test('delete specific user\'s policy', (done) => {
+    userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+      expect(err).to.not.exist()
+      expect(user).to.exist()
+      expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }])
+
+      userOps.deleteUserPolicy({ userId: 4, policyId: 2, organizationId: 'WONKA' }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([])
+
+        userOps.replaceUserPolicies({ id: 4, policies: [{ id: 2 }], organizationId: 'WONKA' }, (err, user) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
     })
   })
 })

--- a/service/test/lib/unit/userOpsTest.js
+++ b/service/test/lib/unit/userOpsTest.js
@@ -98,19 +98,39 @@ lab.experiment('userOps', () => {
     userOps.updateUser(updateUserData, utils.testError(expect, 'Error: query error test', done))
   })
 
-  lab.test('updateUser should return an error if the delete query on user_policies fails', (done) => {
+  lab.test('replaceUserPolicies should return an error if the delete query on user_policies fails', (done) => {
     const dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE FROM user_policies', {testRollback: true, expect: expect})
     const userOps = UserOps(dbPool, {debug: () => {}})
 
-    userOps.updateUser(updateUserData, utils.testError(expect, 'Error: query error test', done))
+    userOps.replaceUserPolicies({ id: 1, policies: [], organizationId: 'WONKA' }, utils.testError(expect, 'Error: query error test', done))
   })
 
-  lab.test('updateUser should return an error if the insert query on team_members fails', (done) => {
+  lab.test('replaceUserPolicies should return an error if the insert query on user_policies fails', (done) => {
     const dbPool = utils.getDbPoolErrorForQueryOrRowCount('INSERT INTO user_policies', {testRollback: true, expect: expect})
     const userOps = UserOps(dbPool, {debug: () => {}})
 
-    updateUserData.policies = [{ id: 1 }]
-    userOps.updateUser(updateUserData, utils.testError(expect, 'Error: query error test', done))
+    userOps.replaceUserPolicies({ id: 1, policies: [{ id: 1 }], organizationId: 'WONKA' }, utils.testError(expect, 'Error: query error test', done))
+  })
+
+  lab.test('addUserPolicies should return an error if the insert query on user_policies fails', (done) => {
+    const dbPool = utils.getDbPoolErrorForQueryOrRowCount('INSERT INTO user_policies', {testRollback: true, expect: expect})
+    const userOps = UserOps(dbPool, {debug: () => {}})
+
+    userOps.addUserPolicies({ id: 1, policies: [{ id: 1 }], organizationId: 'WONKA' }, utils.testError(expect, 'Error: query error test', done))
+  })
+
+  lab.test('deleteUserPolicies should return an error if the delete query on user_policies fails', (done) => {
+    const dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE FROM user_policies', {testRollback: true, expect: expect})
+    const userOps = UserOps(dbPool, {debug: () => {}})
+
+    userOps.deleteUserPolicies({ id: 1, organizationId: 'WONKA' }, utils.testError(expect, 'Error: query error test', done))
+  })
+
+  lab.test('deleteUserPolicy should return an error if the delete query on user_policies fails', (done) => {
+    const dbPool = utils.getDbPoolErrorForQueryOrRowCount('DELETE FROM user_policies', {testRollback: true, expect: expect})
+    const userOps = UserOps(dbPool, {debug: () => {}})
+
+    userOps.deleteUserPolicy({ userId: 1, policyId: 1, organizationId: 'WONKA' }, utils.testError(expect, 'Error: query error test', done))
   })
 
   lab.test('updateUser should return an error if commit fails', (done) => {

--- a/service/test/routes/public/usersTest.js
+++ b/service/test/routes/public/usersTest.js
@@ -298,8 +298,7 @@ lab.experiment('Users', () => {
       url: '/authorization/users/3',
       payload: {
         name: 'Joe',
-        teams: [],
-        policies: []
+        teams: []
       }
     })
 
@@ -330,8 +329,7 @@ lab.experiment('Users', () => {
       url: '/authorization/users/1',
       payload: {
         name: 'Joe',
-        teams: [],
-        policies: []
+        teams: []
       }
     })
 
@@ -340,6 +338,112 @@ lab.experiment('Users', () => {
 
       expect(response.statusCode).to.equal(500)
       expect(result).to.be.undefined
+
+      done()
+    })
+  })
+
+  lab.test('add policies to a user', (done) => {
+    let expected = {
+      id: 1,
+      name: 'John',
+      policies: [{ id: 1, name: 'new policy' }],
+      team: []
+    }
+
+    userOps.addUserPolicies = function (params, cb) {
+      expect(params).to.equal({ id: 1, organizationId: 'WONKA', policies: [ { id: 1 } ] })
+      process.nextTick(() => {
+        cb(null, expected)
+      })
+    }
+
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/users/1/policies',
+      payload: {
+        policies: [{ id: 1 }]
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal(expected)
+
+      done()
+    })
+  })
+
+  lab.test('clear and replace policies for a user', (done) => {
+    let expected = {
+      id: 1,
+      name: 'John',
+      policies: [],
+      team: []
+    }
+
+    userOps.replaceUserPolicies = function (params, cb) {
+      expect(params).to.equal({ id: 1, organizationId: 'WONKA', policies: [ { id: 1 } ] })
+      process.nextTick(() => {
+        cb(null, expected)
+      })
+    }
+
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users/1/policies',
+      payload: {
+        policies: [{ id: 1 }]
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal(expected)
+
+      done()
+    })
+  })
+
+  lab.test('remove all user\'s policies', (done) => {
+    userOps.deleteUserPolicies = function (params, cb) {
+      expect(params).to.equal({ id: 1, organizationId: 'WONKA' })
+      process.nextTick(() => {
+        cb(null)
+      })
+    }
+
+    const options = utils.requestOptions({
+      method: 'DELETE',
+      url: '/authorization/users/1/policies'
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(204)
+
+      done()
+    })
+  })
+
+  lab.test('remove one user\'s policies', (done) => {
+    userOps.deleteUserPolicy = function (params, cb) {
+      expect(params).to.equal({ userId: 33, policyId: 99, organizationId: 'WONKA' })
+      process.nextTick(() => {
+        cb(null)
+      })
+    }
+
+    const options = utils.requestOptions({
+      method: 'DELETE',
+      url: '/authorization/users/33/policies/99'
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(204)
 
       done()
     })


### PR DESCRIPTION
This PR adds new endpoints to deal with addding, removing and replacing of user policies.

What has been done:

- Remove `policies` form users update endpoint payload
- Implement the userOps functions for adding, replacing and deleting user policies
- Add api endpoints to add one or more user policies
- Add api endpoints to replace all the user policies
- Add api endpoint to remove all user policies
- Add api endpoint to remove a single user policy

Ref. issue #167 