### PR TITLE
Add db link between organizations and policies

### DIFF
--- a/scripts/init/database/migrations/001.do.sql
+++ b/scripts/init/database/migrations/001.do.sql
@@ -7,7 +7,7 @@ CREATE EXTENSION ltree;
  */
 CREATE TABLE organizations (
  id          VARCHAR(20) UNIQUE,
- name        VARCHAR(30) NOT NULL,
+ name        VARCHAR(64) NOT NULL,
  description VARCHAR(30)
 );
 
@@ -54,5 +54,10 @@ CREATE TABLE user_policies (
 
 CREATE TABLE team_policies (
   team_id   INT REFERENCES teams(id) NOT NULL,
+  policy_id INT REFERENCES policies(id) NOT NULL
+);
+
+CREATE TABLE organization_policies (
+  org_id   VARCHAR(20) REFERENCES organizations(id) NOT NULL,
   policy_id INT REFERENCES policies(id) NOT NULL
 );

--- a/service/lib/authorizeOps.js
+++ b/service/lib/authorizeOps.js
@@ -8,11 +8,11 @@ module.exports = function (policyOps) {
     /**
      * Return if a user can perform an action on a certain resource
      *
-     * @param  {Object}   options { resource, action, userId }
+     * @param  {Object}   options { resource, action, userId,  }
      * @param  {Function} cb
      */
-    isUserAuthorized: function isUserAuthorized ({ resource, action, userId }, cb) {
-      policyOps.listAllUserPolicies({ userId }, (err, policies) => {
+    isUserAuthorized: function isUserAuthorized ({ resource, action, userId, organizationId }, cb) {
+      policyOps.listAllUserPolicies({ userId, organizationId }, (err, policies) => {
         if (err) {
           return cb(err)
         }
@@ -39,14 +39,14 @@ module.exports = function (policyOps) {
      * @param  {Object}   options { userId, resource }
      * @param  {Function} cb
      */
-    listAuthorizations: function listAuthorizations ({ userId, resource }, cb) {
+    listAuthorizations: function listAuthorizations ({ userId, resource, organizationId }, cb) {
       const data = []
       var actions = []
       var errors = []
       // build the set of actions in the user's policy set
       // can't check per resource as requires wildcard processing
 
-      policyOps.listAllUserPolicies({ userId }, (err, policies) => {
+      policyOps.listAllUserPolicies({ userId, organizationId }, (err, policies) => {
         if (err) return cb(Boom.wrap(err))
 
         policies.forEach(p => {

--- a/service/routes/public/authorization.js
+++ b/service/routes/public/authorization.js
@@ -11,11 +11,13 @@ exports.register = function (server, options, next) {
     method: 'GET',
     path: '/authorization/check/{userId}/{action}/{resource*}',
     handler: function (request, reply) {
+      const { id: organizationId } = request.authorization.organization
       const { resource, action, userId } = request.params
       const params = {
         userId,
         action,
-        resource
+        resource,
+        organizationId
       }
 
       authorize.isUserAuthorized(params, reply)
@@ -38,10 +40,12 @@ exports.register = function (server, options, next) {
     method: 'GET',
     path: '/authorization/list/{userId}/{resource*}',
     handler: function (request, reply) {
+      const { id: organizationId } = request.authorization.organization
       const { resource, userId } = request.params
       const params = {
         userId,
-        resource
+        resource,
+        organizationId
       }
 
       authorize.listAuthorizations(params, reply)

--- a/service/test/lib/unit/authorizeOpsTest.js
+++ b/service/test/lib/unit/authorizeOpsTest.js
@@ -12,7 +12,7 @@ const Authorize = proxyquire('../../../lib/authorizeOps', {'iam-js': iamMock})
 lab.experiment('authorize', () => {
 
   lab.test('isUserAuthorized - should return an error if fetching the user policies returns and error', (done) => {
-    var policyOps = {listAllUserPolicies: function (userId, cb) {
+    var policyOps = {listAllUserPolicies: function (params, cb) {
       return cb(new Error('test error'))
     }}
 
@@ -20,7 +20,8 @@ lab.experiment('authorize', () => {
     authorizeOps.isUserAuthorized({
       userId: 1,
       resource: 'database:pg01:balancesheet',
-      action: 'finance:ReadBalanceSheet'
+      action: 'finance:ReadBalanceSheet',
+      organizationId: 'WONKA'
     }, (err, result) => {
       expect(err).to.exist()
       expect(result).to.not.exist()
@@ -31,7 +32,7 @@ lab.experiment('authorize', () => {
   })
 
   lab.test('isUserAuthorized - should return an error if iam-js returns an error', (done) => {
-    var policyOps = {listAllUserPolicies: function (userId, cb) {
+    var policyOps = {listAllUserPolicies: function (params, cb) {
       return cb(null, {policyMock: true})
     }}
 
@@ -39,7 +40,8 @@ lab.experiment('authorize', () => {
     authorizeOps.isUserAuthorized({
       userId: 1,
       resource: 'database:pg01:balancesheet',
-      action: 'finance:ReadBalanceSheet'
+      action: 'finance:ReadBalanceSheet',
+      organizationId: 'WONKA'
     }, (err, result) => {
       expect(err).to.exist()
       expect(result).to.not.exist()
@@ -50,7 +52,7 @@ lab.experiment('authorize', () => {
   })
 
   lab.test('listAuthorizations - should return an error if fetching the user policies returns and error', (done) => {
-    var policyOps = {listAllUserPolicies: function (userId, cb) {
+    var policyOps = {listAllUserPolicies: function (params, cb) {
       return cb(new Error('test error'))
     }}
 
@@ -58,7 +60,7 @@ lab.experiment('authorize', () => {
     authorizeOps.listAuthorizations({
       userId: 1,
       resource: 'database:pg01:balancesheet',
-      action: 'finance:ReadBalanceSheet'
+      organizationId: 'WONKA'
     }, (err, result) => {
       expect(err).to.exist()
       expect(result).to.not.exist()
@@ -69,7 +71,7 @@ lab.experiment('authorize', () => {
   })
 
   lab.test('isUserAuthorized - should return an error if iam-js returns an error', (done) => {
-    var policyOps = {listAllUserPolicies: function (userId, cb) {
+    var policyOps = {listAllUserPolicies: function (params, cb) {
       let policies = [{Statement: [{Action: ['finance:ReadBalanceSheet'], Resource: ['database:pg01:balancesheet'], Effect: 'Allow'}]}]
       policies.policyMock = true
       return cb(null, policies)
@@ -79,7 +81,7 @@ lab.experiment('authorize', () => {
     authorizeOps.listAuthorizations({
       userId: 1,
       resource: 'database:pg01:balancesheet',
-      action: 'finance:ReadBalanceSheet'
+      organizationId: 'WONKA'
     }, (err, result) => {
       expect(err).to.exist()
       expect(result).to.not.exist()


### PR DESCRIPTION
This PR adds the `organization_policies` table so that we can assign policies to an organization (as we do with teams)

This PR also rewrote the query we run for fetching all user policies.

Ref. issue #181 