### PR TITLE
Issue 194 update team single fields

### DIFF
--- a/service/lib/dbUtil.js
+++ b/service/lib/dbUtil.js
@@ -61,8 +61,38 @@ class SqlStatement {
     this.values = values
   }
 
+  glue (pieces, separator) {
+    const result = pieces
+      .map((piece) => {
+        piece.strings = piece.strings.filter(s => !!s.trim())
+
+        return piece
+      })
+      .reduce((res, current) => {
+        res.strings = res.strings.concat(current.strings)
+        res.values = res.values.concat(current.values)
+
+        return res
+      }, { strings: [], values: [] })
+
+    result.strings = result.strings.map((value, index) => {
+      if (index === 0 || value.trim() === '') {
+        return value
+      }
+
+      return separator + value
+    }).concat([' '])
+
+    return new SqlStatement(
+      result.strings,
+      result.values
+    )
+  }
+
   get text () {
-    return this.strings.reduce((prev, curr, i) => prev + '$' + i + curr).replace(/^\s+/, '')
+    return this.strings.reduce((prev, curr, i) => {
+      return prev + '$' + i + curr
+    }).replace(/^\s+/, '')
   }
 
   append (statement) {

--- a/service/routes/public/teams.js
+++ b/service/routes/public/teams.js
@@ -101,7 +101,7 @@ exports.register = function (server, options, next) {
     method: 'PUT',
     path: '/authorization/teams/{id}',
     handler: function (request, reply) {
-      const id = request.params.id
+      const { id } = request.params
       const { organizationId } = request.udaru
       const { name, description, users } = request.payload
 
@@ -120,11 +120,11 @@ exports.register = function (server, options, next) {
         params: {
           id: Joi.number().required().description('The team ID')
         },
-        payload: {
+        payload: Joi.object().keys({
           name: Joi.string().description('Updated team name'),
           description: Joi.string().description('Updated team description'),
-          users: Joi.array().items(Joi.number()).required().description('User ids')
-        }
+          users: Joi.array().description('User ids')
+        }).or('name', 'description', 'users')
       },
       description: 'Update a team',
       notes: 'The PUT /authorization/teams endpoint updates a team data\n',

--- a/service/test/lib/integration/teamOpsTest.js
+++ b/service/test/lib/integration/teamOpsTest.js
@@ -86,6 +86,76 @@ lab.experiment('TeamOps', () => {
     })
   })
 
+  lab.test('create, update only the name and delete a team', (done) => {
+    teamOps.createTeam(teamData, function (err, result) {
+      testTeamId = result.id
+
+      expect(err).to.not.exist()
+
+      const updateData = {
+        id: testTeamId,
+        name: 'Team 5',
+        organizationId: 'WONKA'
+      }
+
+      teamOps.updateTeam(updateData, (err, result) => {
+        expect(err).to.not.exist()
+        expect(result).to.exist()
+        expect(result.name).to.equal('Team 5')
+        expect(result.description).to.equal(teamData.description)
+
+        teamOps.deleteTeam({ id: testTeamId, organizationId: 'WONKA' }, done)
+      })
+    })
+  })
+
+  lab.test('create, update only the description and delete a team', (done) => {
+    teamOps.createTeam(teamData, function (err, result) {
+      testTeamId = result.id
+
+      expect(err).to.not.exist()
+
+      const updateData = {
+        id: testTeamId,
+        description: 'new desc',
+        organizationId: 'WONKA'
+      }
+
+      teamOps.updateTeam(updateData, (err, result) => {
+        expect(err).to.not.exist()
+        expect(result).to.exist()
+        expect(result.description).to.equal('new desc')
+        expect(result.name).to.equal(teamData.name)
+
+        teamOps.deleteTeam({ id: testTeamId, organizationId: 'WONKA' }, done)
+      })
+    })
+  })
+
+  lab.test('create, update only the users and delete a team', (done) => {
+    teamOps.createTeam(teamData, function (err, result) {
+      testTeamId = result.id
+
+      expect(err).to.not.exist()
+
+      const updateData = {
+        id: testTeamId,
+        users: [1, 2, 3],
+        organizationId: 'WONKA'
+      }
+
+      teamOps.updateTeam(updateData, (err, result) => {
+        expect(err).to.not.exist()
+        expect(result).to.exist()
+        expect(result.description).to.equal(teamData.description)
+        expect(result.name).to.equal(teamData.name)
+        expect(result.users).to.equal([{ id: 2, name: 'Charlie Bucket' }, { id: 3, name: 'Mike Teavee' }, { id: 1, name: 'Super User' }])
+
+        teamOps.deleteTeam({ id: testTeamId, organizationId: 'WONKA' }, done)
+      })
+    })
+  })
+
   lab.test('read a specific team', (done) => {
     teamOps.readTeam({ id: 1, organizationId: 'WONKA' }, (err, result) => {
 

--- a/service/test/lib/unit/dbUtilsTest.js
+++ b/service/test/lib/unit/dbUtilsTest.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const expect = require('code').expect
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+
+const dbUtil = require('../../../lib/dbUtil')
+const SQL = dbUtil.SQL
+
+lab.experiment('dbUtil', () => {
+
+  lab.test('SQL helper - build complex query with append', (done) => {
+    const name = 'Team 5'
+    const description = 'description'
+    const teamId = 7
+    const organizationId = 'WONKA'
+
+    const sql = SQL`UPDATE teams SET name = ${name}, description = ${description} `
+    sql.append(SQL`WHERE id = ${teamId} AND org_id = ${organizationId}`)
+
+    expect(sql.text).to.equal('UPDATE teams SET name = $1, description = $2 WHERE id = $3 AND org_id = $4')
+    expect(sql.values).to.equal([name, description, teamId, organizationId])
+    done()
+  })
+
+  lab.test('SQL helper - build complex query with glue', (done) => {
+    const name = 'Team 5'
+    const description = 'description'
+    const teamId = 7
+    const organizationId = 'WONKA'
+
+    const sql = SQL` UPDATE teams SET `
+
+    const updates = []
+    updates.push(SQL`name = ${name}`)
+    updates.push(SQL`description = ${description}`)
+
+    sql.append(sql.glue(updates, ' , '))
+    sql.append(SQL`WHERE id = ${teamId} AND org_id = ${organizationId}`)
+
+    expect(sql.text).to.equal('UPDATE teams SET name = $1 , description = $2 WHERE id = $3 AND org_id = $4')
+    expect(sql.values).to.equal([name, description, teamId, organizationId])
+    done()
+  })
+
+  lab.test('SQL helper - build complex query with append and glue', (done) => {
+    const updates = []
+    const v1 = 'v1'
+    const v2 = 'v2'
+    const v3 = 'v3'
+    const v4 = 'v4'
+    const v5 = 'v5'
+    const v6 = 'v6'
+    const v7 = 'v7'
+
+    const sql = SQL`TEST QUERY glue pieces FROM `
+    updates.push(SQL`v1 = ${v1}`)
+    updates.push(SQL`v2 = ${v2}`)
+    updates.push(SQL`v3 = ${v3}`)
+    updates.push(SQL`v4 = ${v4}`)
+    updates.push(SQL`v5 = ${v5}`)
+
+    sql.append(sql.glue(updates, ' , '))
+    sql.append(SQL`WHERE v6 = ${v6} `)
+    sql.append(SQL`AND v7 = ${v7}`)
+
+    expect(sql.text).to.equal('TEST QUERY glue pieces FROM v1 = $1 , v2 = $2 , v3 = $3 , v4 = $4 , v5 = $5 WHERE v6 = $6 AND v7 = $7')
+    expect(sql.values).to.equal([v1, v2, v3, v4, v5, v6, v7])
+    done()
+  })
+
+  lab.test('SQL helper - build complex query with append', (done) => {
+    const v1 = 'v1'
+    const v2 = 'v2'
+    const v3 = 'v3'
+    const v4 = 'v4'
+    const v5 = 'v5'
+    const v6 = 'v6'
+    const v7 = 'v7'
+
+    const sql = SQL`TEST QUERY glue pieces FROM `
+    sql.append(SQL`v1 = ${v1}, `)
+    sql.append(SQL`v2 = ${v2}, `)
+    sql.append(SQL`v3 = ${v3}, `)
+    sql.append(SQL`v4 = ${v4}, `)
+    sql.append(SQL`v5 = ${v5} `)
+    sql.append(SQL`WHERE v6 = ${v6} `)
+    sql.append(SQL`AND v7 = ${v7}`)
+
+    expect(sql.text).to.equal('TEST QUERY glue pieces FROM v1 = $1, v2 = $2, v3 = $3, v4 = $4, v5 = $5 WHERE v6 = $6 AND v7 = $7')
+    expect(sql.values).to.equal([v1, v2, v3, v4, v5, v6, v7])
+    done()
+  })
+})
+

--- a/service/test/routes/public/teamsTest.js
+++ b/service/test/routes/public/teamsTest.js
@@ -171,6 +171,138 @@ lab.experiment('Teams', () => {
     })
   })
 
+  lab.test('update team validation nothing in payload', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/teams/2',
+      payload: {
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+
+      done()
+    })
+  })
+
+  lab.test('update only team users', (done) => {
+    const teamStub = {
+      id: 2,
+      name: 'Team C',
+      description: 'Team B is now Team C',
+      users: [],
+      policies: []
+    }
+
+    teamOps.updateTeam = (params, cb) => {
+      expect(params).to.equal({ id: 2,
+        name: undefined,
+        description: undefined,
+        users: [],
+        organizationId: 'WONKA'
+      })
+      process.nextTick(() => {
+        cb(null, teamStub)
+      })
+    }
+
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/teams/2',
+      payload: {
+        users: []
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal(teamStub)
+
+      done()
+    })
+  })
+
+  lab.test('update only team name', (done) => {
+    const teamStub = {
+      id: 2,
+      name: 'Team C',
+      description: 'Team B is now Team C',
+      users: [],
+      policies: []
+    }
+
+    teamOps.updateTeam = (params, cb) => {
+      expect(params).to.equal({ id: 2,
+        name: 'Team C',
+        description: undefined,
+        users: undefined,
+        organizationId: 'WONKA'
+      })
+      process.nextTick(() => {
+        cb(null, teamStub)
+      })
+    }
+
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/teams/2',
+      payload: {
+        name: 'Team C'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal(teamStub)
+
+      done()
+    })
+  })
+
+  lab.test('update only team description', (done) => {
+    const teamStub = {
+      id: 2,
+      name: 'Team C',
+      description: 'Team B is now Team C',
+      users: [],
+      policies: []
+    }
+
+    teamOps.updateTeam = (params, cb) => {
+      expect(params).to.equal({ id: 2,
+        name: undefined,
+        description: 'Team B is now Team C',
+        users: undefined,
+        organizationId: 'WONKA'
+      })
+      process.nextTick(() => {
+        cb(null, teamStub)
+      })
+    }
+
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/teams/2',
+      payload: {
+        description: 'Team B is now Team C'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal(teamStub)
+
+      done()
+    })
+  })
+
   lab.test('update team', (done) => {
     const teamStub = {
       id: 2,


### PR DESCRIPTION
This PR adds the ability to update single fields for a team (`name`, `description` and `users`)

Ref. issue #194 