### PR TITLE
[003] Minor changes to expose functions accepting a db.client

### DIFF
--- a/service/lib/ops/userOps.js
+++ b/service/lib/ops/userOps.js
@@ -127,17 +127,7 @@ const removeUserPolicy = (job, next) => {
 const insertUserPolicies = (job, next) => {
   const { id: userId, policies } = job
 
-  const sqlQuery = SQL`
-    INSERT INTO user_policies (
-      policy_id, user_id
-    ) VALUES
-  `
-  sqlQuery.append(SQL`(${policies[0]}, ${userId})`)
-  policies.slice(1).forEach((policyId) => {
-    sqlQuery.append(SQL`, (${policyId}, ${userId})`)
-  })
-
-  job.client.query(sqlQuery, next)
+  userOps.insertPolicies(job.client, userId, policies, next)
 }
 
 const userOps = {
@@ -172,6 +162,20 @@ const userOps = {
       )
       RETURNING id
     `
+
+    client.query(sqlQuery, cb)
+  },
+
+  insertPolicies: function insertUser (client, id, policies, cb) {
+    const sqlQuery = SQL`
+      INSERT INTO user_policies (
+        policy_id, user_id
+      ) VALUES
+    `
+    sqlQuery.append(SQL`(${policies[0]}, ${id})`)
+    policies.slice(1).forEach((policyId) => {
+      sqlQuery.append(SQL`, (${policyId}, ${id})`)
+    })
 
     client.query(sqlQuery, cb)
   },


### PR DESCRIPTION
As done in many other parts of the code, this PR adds a couple public functions to `userOps` that accept a db `client` to run query on the same connection when needed.