### PR TITLE
[006] Add more detailed swagger descriptions to routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,13 +114,26 @@ JSON structure:
 }
 ```
 
+### Service API documentation
+
+The Swagger API documentation gives explanations on the exposed API.
+
+To run Swagger:
+
+```
+npm run start:service
+```
+
+and then go to `http://localhost:8080/documentation`
+
+The Swagger documentation also gives the ability to execute calls to the API and see their results.
+
+
 ## API
 
 An example API route for fetching all the users is: http://localhost:8000/authorization/users
 
 Curl examples for all the routes can be found in api/route.js
-
-Swagger documentation can be found once the API is running by visiting: http://localhost:8000/documentation
 
 To expose the routes start both the service and the API with the following:
 

--- a/service/routes/private/policies.js
+++ b/service/routes/private/policies.js
@@ -5,6 +5,7 @@ const Boom = require('boom')
 const serviceKey = require('./../../security/serviceKey')
 const Action = require('./../../lib/config/config.auth').Action
 const policyOps = require('./../../lib/ops/policyOps')
+const swagger = require('./../../swagger')
 
 exports.register = function (server, options, next) {
 
@@ -37,7 +38,13 @@ exports.register = function (server, options, next) {
           version: Joi.string().required().description('policy version'),
           name: Joi.string().required().description('policy name'),
           statements: Joi.string().required().description('policy statements')
-        }
+        },
+        query: {
+          sig: Joi.string().required()
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Create a policy for the current user organization',
       notes: 'The POST /authorization/policies endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
@@ -46,7 +53,8 @@ exports.register = function (server, options, next) {
         auth: {
           action: Action.CreatePolicy
         }
-      }
+      },
+      response: {schema: swagger.Policy}
     }
   })
 
@@ -79,7 +87,13 @@ exports.register = function (server, options, next) {
           version: Joi.string().required().description('policy version'),
           name: Joi.string().required().description('policy name'),
           statements: Joi.string().required().description('policy statements')
-        }
+        },
+        query: {
+          sig: Joi.string().required()
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Update a policy of the current user organization',
       notes: 'The PUT /authorization/policies/{id} endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
@@ -89,7 +103,8 @@ exports.register = function (server, options, next) {
           action: Action.UpdatePolicy,
           getParams: (request) => ({ policyId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.Policy}
     }
   })
 
@@ -114,7 +129,13 @@ exports.register = function (server, options, next) {
       validate: {
         params: {
           id: Joi.number().required().description('policy id')
-        }
+        },
+        query: {
+          sig: Joi.string().required()
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Delete a policy',
       notes: 'The DELETE /authorization/policies/{id} endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',

--- a/service/routes/public/authorization.js
+++ b/service/routes/public/authorization.js
@@ -35,11 +35,17 @@ exports.register = function (server, options, next) {
           userId: Joi.number().required().description('The user that wants to perform the action on a given resource'),
           action: Joi.string().required().description('The action to check'),
           resource: Joi.string().required().description('The resource that the user wants to perform the action on')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Authorize user action against a resource',
       notes: 'The GET /authorization/check/{userId}/{action}/{resource} endpoint returns if a user can perform and action\non a resource\n',
-      tags: ['api', 'service', 'authorization']
+      tags: ['api', 'service', 'authorization'],
+      response: {schema: Joi.object({
+        access: Joi.boolean()
+      })}
     }
   })
 
@@ -68,11 +74,17 @@ exports.register = function (server, options, next) {
         params: {
           userId: Joi.number().required().description('The user that wants to perform the action on a given resource'),
           resource: Joi.string().required().description('The resource that the user wants to perform the action on')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'List all the actions a user can perform on a resource',
       notes: 'The GET /authorization/list/{userId}/{resource} endpoint returns a list of all the actions a user\ncan perform on a given resource\n',
-      tags: ['api', 'service', 'authorization']
+      tags: ['api', 'service', 'authorization'],
+      response: {schema: Joi.object({
+        actions: Joi.array().items(Joi.string())
+      })}
     }
   })
 

--- a/service/routes/public/organizations.js
+++ b/service/routes/public/organizations.js
@@ -3,6 +3,7 @@
 const Joi = require('joi')
 const organizationOps = require('./../../lib/ops/organizationOps')
 const Action = require('./../../lib/config/config.auth').Action
+const swagger = require('./../../swagger')
 
 exports.register = function (server, options, next) {
 
@@ -19,7 +20,13 @@ exports.register = function (server, options, next) {
         auth: {
           action: Action.ListOrganizations
         }
-      }
+      },
+      validate: {
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
+      },
+      response: {schema: swagger.OrganizationList}
     }
   })
 
@@ -37,7 +44,16 @@ exports.register = function (server, options, next) {
           action: Action.ReadOrganization,
           getParams: (request) => ({ organizationId: request.params.id })
         }
-      }
+      },
+      validate: {
+        params: {
+          id: Joi.string().required().description('organization id')
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
+      },
+      response: {schema: swagger.Organization}
     }
   })
 
@@ -69,7 +85,10 @@ exports.register = function (server, options, next) {
           user: Joi.object().keys({
             name: Joi.string().required()
           })
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Create an organization',
       notes: 'The POST /authorization/organizations endpoint will create a new organization, the default organization admin policy and (if provided) its admin.',
@@ -78,7 +97,8 @@ exports.register = function (server, options, next) {
         auth: {
           action: Action.CreateOrganization
         }
-      }
+      },
+      response: {schema: swagger.OrganizationAndUser}
     }
   })
 
@@ -107,6 +127,14 @@ exports.register = function (server, options, next) {
           action: Action.DeleteOrganization,
           getParams: (request) => ({ organizationId: request.params.id })
         }
+      },
+      validate: {
+        params: {
+          id: Joi.string().required().description('organization id')
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       }
     }
   })
@@ -125,10 +153,16 @@ exports.register = function (server, options, next) {
     },
     config: {
       validate: {
+        params: {
+          id: Joi.string().required().description('organization id')
+        },
         payload: {
           name: Joi.string().required().description('organization name'),
           description: Joi.string().required().description('organization description')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Update an organization',
       notes: 'The PUT /authorization/organizations/{id} endpoint will update an organization name and description',
@@ -138,7 +172,8 @@ exports.register = function (server, options, next) {
           action: Action.UpdateOrganization,
           getParams: (request) => ({ organizationId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.Organization}
     }
   })
 

--- a/service/routes/public/policies.js
+++ b/service/routes/public/policies.js
@@ -3,6 +3,7 @@
 const Joi = require('joi')
 const policyOps = require('./../../lib/ops/policyOps')
 const Action = require('./../../lib/config/config.auth').Action
+const swagger = require('./../../swagger')
 
 exports.register = function (server, options, next) {
   server.route({
@@ -21,7 +22,13 @@ exports.register = function (server, options, next) {
         auth: {
           action: Action.ListPolicies
         }
-      }
+      },
+      validate: {
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
+      },
+      response: {schema: swagger.PolicyList}
     }
   })
 
@@ -38,7 +45,10 @@ exports.register = function (server, options, next) {
       validate: {
         params: {
           id: Joi.number().required().description('policy id')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Fetch all the defined policies',
       notes: 'The GET /authorization/policies/{id} endpoint returns a single policy based on it\'s id.\n',
@@ -48,7 +58,8 @@ exports.register = function (server, options, next) {
           action: Action.ReadPolicy,
           getParams: (request) => ({ policyId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.Policy}
     }
   })
 

--- a/service/routes/public/teams.js
+++ b/service/routes/public/teams.js
@@ -3,6 +3,7 @@
 const Joi = require('joi')
 const teamOps = require('./../../lib/ops/teamOps')
 const Action = require('./../../lib/config/config.auth').Action
+const swagger = require('./../../swagger')
 
 exports.register = function (server, options, next) {
 
@@ -21,7 +22,13 @@ exports.register = function (server, options, next) {
         auth: {
           action: Action.ListTeams
         }
-      }
+      },
+      validate: {
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
+      },
+      response: {schema: swagger.TeamList}
     }
   })
 
@@ -56,7 +63,10 @@ exports.register = function (server, options, next) {
           user: Joi.object().optional().description('Default admin user to be added to the team').keys({
             name: Joi.string().required('Name for the user')
           })
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Create a teams',
       notes: 'The POST /authorization/teams endpoint creates a new team given its data\n',
@@ -65,7 +75,8 @@ exports.register = function (server, options, next) {
         auth: {
           action: Action.CreateTeam
         }
-      }
+      },
+      response: {schema: swagger.Team}
     }
   })
 
@@ -82,7 +93,10 @@ exports.register = function (server, options, next) {
       validate: {
         params: {
           id: Joi.number().required().description('The team ID')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Fetch a team given its identifier',
       notes: 'The GET /authorization/teams/{id} endpoint returns a single team data\n',
@@ -92,7 +106,8 @@ exports.register = function (server, options, next) {
           action: Action.ReadTeam,
           getParams: (request) => ({ teamId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.Team}
     }
   })
 
@@ -123,7 +138,10 @@ exports.register = function (server, options, next) {
           name: Joi.string().description('Updated team name'),
           description: Joi.string().description('Updated team description'),
           users: Joi.array().description('User ids')
-        }).or('name', 'description', 'users')
+        }).or('name', 'description', 'users'),
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Update a team',
       notes: 'The PUT /authorization/teams endpoint updates a team data\n',
@@ -133,7 +151,8 @@ exports.register = function (server, options, next) {
           action: Action.UpdateTeam,
           getParams: (request) => ({ teamId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.Team}
     }
   })
 
@@ -156,7 +175,10 @@ exports.register = function (server, options, next) {
       validate: {
         params: {
           id: Joi.number().required().description('The team ID')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Delete a team',
       notes: 'The DELETE /authorization/teams endpoint deletes a team\n',
@@ -197,7 +219,10 @@ exports.register = function (server, options, next) {
         },
         payload: {
           parentId: Joi.number().required().description('The new parent ID')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Nest a team',
       notes: 'The PUT /authorization/teams/{id}/nest endpoint nests a team\n',
@@ -207,7 +232,8 @@ exports.register = function (server, options, next) {
           action: Action.ManageTeams,
           getParams: (request) => ({ teamId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.Team}
     }
   })
 
@@ -235,7 +261,10 @@ exports.register = function (server, options, next) {
       validate: {
         params: {
           id: Joi.number().required().description('The team ID')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Unnest a team',
       notes: 'The PUT /authorization/teams/{id}/unnest endpoint unnests a team\n',
@@ -245,7 +274,8 @@ exports.register = function (server, options, next) {
           action: Action.ManageTeams,
           getParams: (request) => ({ teamId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.Team}
     }
   })
 
@@ -271,11 +301,15 @@ exports.register = function (server, options, next) {
         },
         payload: {
           policies: Joi.array().items(Joi.number()).required().description('Policy ids')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Add one or more policies to a team',
       notes: 'The PUT /authorization/teams/{id}/policies endpoint add one or more new policies to a team\n',
-      tags: ['api', 'service', 'put', 'teams', 'policies']
+      tags: ['api', 'service', 'put', 'teams', 'policies'],
+      response: {schema: swagger.Team}
     }
   })
 
@@ -302,11 +336,15 @@ exports.register = function (server, options, next) {
         },
         payload: {
           policies: Joi.array().items(Joi.number()).required().description('Policy ids')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Clear and replace policies for a team',
       notes: 'The POST /authorization/teams/{id}/policies endpoint removes all the team policies and replace them\n',
-      tags: ['api', 'service', 'post', 'teams', 'policies']
+      tags: ['api', 'service', 'post', 'teams', 'policies'],
+      response: {schema: swagger.Team}
     }
   })
 
@@ -329,11 +367,15 @@ exports.register = function (server, options, next) {
       validate: {
         params: {
           id: Joi.number().required().description('Team id')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Clear all team policies',
       notes: 'The DELETE /authorization/teams/{id}/policies endpoint removes all the team policies\n',
-      tags: ['api', 'service', 'delete', 'teams', 'policies']
+      tags: ['api', 'service', 'delete', 'teams', 'policies'],
+      response: {schema: swagger.Team}
     }
   })
 
@@ -357,11 +399,15 @@ exports.register = function (server, options, next) {
         params: {
           teamId: Joi.number().required().description('Team id'),
           policyId: Joi.number().required().description('Policy id')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Remove a team policy',
       notes: 'The DELETE /authorization/teams/{teamId}/policies/{policyId} endpoint removes a specific team policy\n',
-      tags: ['api', 'service', 'delete', 'teams', 'policies']
+      tags: ['api', 'service', 'delete', 'teams', 'policies'],
+      response: {schema: swagger.Team}
     }
   })
 

--- a/service/routes/public/users.js
+++ b/service/routes/public/users.js
@@ -3,6 +3,7 @@
 const Joi = require('joi')
 const userOps = require('./../../lib/ops/userOps')
 const Action = require('./../../lib/config/config.auth').Action
+const swagger = require('./../../swagger')
 
 exports.register = function (server, options, next) {
 
@@ -21,7 +22,13 @@ exports.register = function (server, options, next) {
         auth: {
           action: Action.ListUsers
         }
-      }
+      },
+      validate: {
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
+      },
+      response: {schema: swagger.UserList}
     }
   })
 
@@ -38,7 +45,10 @@ exports.register = function (server, options, next) {
       validate: {
         params: {
           id: Joi.number().required().description('user id')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Fetch a user given its identifier',
       notes: 'The GET /authorization/users/{id} endpoint returns a single user data\n',
@@ -48,7 +58,8 @@ exports.register = function (server, options, next) {
           action: Action.ReadUser,
           getParams: (request) => ({ userId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.User}
     }
   })
 
@@ -74,7 +85,10 @@ exports.register = function (server, options, next) {
       validate: {
         payload: {
           name: Joi.string().required().description('User name')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Create a new user',
       notes: 'The POST /authorization/users endpoint creates a new user given its data\n',
@@ -83,7 +97,8 @@ exports.register = function (server, options, next) {
         auth: {
           action: Action.CreateUser
         }
-      }
+      },
+      response: {schema: swagger.User}
     }
   })
 
@@ -106,7 +121,10 @@ exports.register = function (server, options, next) {
       validate: {
         params: {
           id: Joi.number().required().description('user id')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Delete a user',
       notes: 'The DELETE /authorization/users endpoint delete a user\n',
@@ -146,7 +164,10 @@ exports.register = function (server, options, next) {
           teams: Joi.array().required().items(Joi.object().keys({
             id: Joi.number().required()
           }))
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Update a user',
       notes: 'The PUT /authorization/users endpoint updates a user data\n',
@@ -156,7 +177,8 @@ exports.register = function (server, options, next) {
           action: Action.UpdateUser,
           getParams: (request) => ({ userId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.User}
     }
   })
 
@@ -184,7 +206,10 @@ exports.register = function (server, options, next) {
           policies: Joi.array().required().items(Joi.object().keys({
             id: Joi.number().required()
           }))
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Add one or more policies to a user',
       notes: 'The PUT /authorization/users/{id}/policies endpoint add one or more new policies to a user\n',
@@ -194,7 +219,8 @@ exports.register = function (server, options, next) {
           action: Action.AddUserPolicy,
           getParams: (request) => ({ userId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.User}
     }
   })
 
@@ -223,7 +249,10 @@ exports.register = function (server, options, next) {
           policies: Joi.array().required().items(Joi.object().keys({
             id: Joi.number().required()
           }))
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Clear and replace policies for a user',
       notes: 'The POST /authorization/users/{id}/policies endpoint removes all the user policies and replace them\n',
@@ -233,7 +262,8 @@ exports.register = function (server, options, next) {
           action: Action.AddUserPolicy,
           getParams: (request) => ({ userId: request.params.id })
         }
-      }
+      },
+      response: {schema: swagger.User}
     }
   })
 
@@ -256,7 +286,10 @@ exports.register = function (server, options, next) {
       validate: {
         params: {
           id: Joi.number().required().description('user id')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Clear all user\'s policies',
       notes: 'The DELETE /authorization/users/{id}/policies endpoint removes all the user policies\n',
@@ -290,7 +323,10 @@ exports.register = function (server, options, next) {
         params: {
           userId: Joi.number().required().description('user id'),
           policyId: Joi.number().required().description('policy id')
-        }
+        },
+        headers: Joi.object({
+          'authorization': Joi.any().required()
+        }).unknown()
       },
       description: 'Remove a user\'s policy',
       notes: 'The DELETE /authorization/users/{userId}/policies/{policyId} endpoint removes a specific user\'s policy\n',

--- a/service/swagger.js
+++ b/service/swagger.js
@@ -1,0 +1,86 @@
+'use strict'
+
+const Joi = require('joi')
+
+const PolicyStatements = Joi.object({
+  Statement: Joi.array().items(Joi.object({
+    Effect: Joi.string(),
+    Action: Joi.array().items(Joi.string()),
+    Resource: Joi.array().items(Joi.string()),
+    Sid: Joi.string(),
+    Condition: Joi.object({})
+  }))
+})
+
+const Policy = Joi.object({
+  id: Joi.number(),
+  version: Joi.string(),
+  name: Joi.string(),
+  statements: PolicyStatements
+})
+
+const PolicyList = Joi.array().items(Policy)
+
+const PolicyRef = Joi.object({
+  id: Joi.number(),
+  version: Joi.string(),
+  name: Joi.string()
+})
+
+const UserRef = Joi.object({
+  id: Joi.number(),
+  name: Joi.string()
+})
+
+const Team = Joi.object({
+  id: Joi.number(),
+  name: Joi.string(),
+  description: Joi.string(),
+  path: Joi.string(),
+  users: Joi.array().items(UserRef),
+  policies: Joi.array().items(PolicyRef)
+})
+
+const TeamList = Joi.array().items(Team)
+
+const TeamRef = Joi.object({
+  id: Joi.number(),
+  name: Joi.string()
+})
+
+const User = Joi.object({
+  id: Joi.number(),
+  name: Joi.string(),
+  organizationId: Joi.string(),
+  teams: Joi.array().items(TeamRef),
+  policies: Joi.array().items(PolicyRef)
+})
+
+const UserList = Joi.array().items(User)
+
+const Organization = Joi.object({
+  id: Joi.string(),
+  name: Joi.string(),
+  description: Joi.string()
+})
+const OrganizationAndUser = Joi.object({
+  id: Joi.string(),
+  name: Joi.string(),
+  description: Joi.string(),
+  user: UserRef
+})
+
+const OrganizationList = Joi.array().items(Organization)
+
+module.exports = {
+  UserList: UserList,
+  User: User,
+  TeamList: TeamList,
+  Team: Team,
+  PolicyList: PolicyList,
+  Policy: Policy,
+  PolicyRef: PolicyRef,
+  Organization: Organization,
+  OrganizationList: OrganizationList,
+  OrganizationAndUser: OrganizationAndUser
+}

--- a/service/test/routes/private/policiesTest.js
+++ b/service/test/routes/private/policiesTest.js
@@ -51,7 +51,6 @@ lab.experiment('Policies', () => {
       id: 2,
       version: '2016-07-01',
       name: 'Documents Admin',
-      organizationId: 'WONKA',
       statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
     }
 
@@ -122,7 +121,6 @@ lab.experiment('Policies', () => {
       id: 2,
       version: '2016-07-01',
       name: 'Documents Admin - updated',
-      organizationId: 'WONKA',
       statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Update"],"Resource":["wonka:documents:/public/*"]}]}'
     }
 

--- a/service/test/routes/public/organizationsTest.js
+++ b/service/test/routes/public/organizationsTest.js
@@ -36,6 +36,8 @@ lab.experiment('Organizations', () => {
     server.inject(options, (response) => {
       const result = response.result
 
+      console.log(result)
+
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal(expected)
 

--- a/service/test/routes/public/policiesTest.js
+++ b/service/test/routes/public/policiesTest.js
@@ -71,7 +71,7 @@ lab.experiment('Policies', () => {
       id: 1,
       name: 'SysAdmin',
       version: '0.1',
-      statements: [{
+      statements: {
         'Statement': [
           {
             'Action': [
@@ -92,7 +92,7 @@ lab.experiment('Policies', () => {
             ]
           }
         ]
-      }]
+      }
     }
 
     policyOps.readPolicy = (params, cb) => {

--- a/service/test/routes/public/usersTest.js
+++ b/service/test/routes/public/usersTest.js
@@ -72,7 +72,7 @@ lab.experiment('Users', () => {
       id: 1,
       name: 'John',
       policies: [],
-      team: []
+      teams: []
     }
 
     userOps.readUser = function (params, cb) {
@@ -125,7 +125,7 @@ lab.experiment('Users', () => {
       id: 2,
       name: 'Salman',
       policies: [],
-      team: []
+      teams: []
     }
 
     userOps.createUser = function (params, cb) {
@@ -162,7 +162,7 @@ lab.experiment('Users', () => {
       id: 2,
       name: 'Salman',
       policies: [],
-      team: []
+      teams: []
     }
 
     userOps.createUser = function (params, cb) {
@@ -348,7 +348,7 @@ lab.experiment('Users', () => {
       id: 1,
       name: 'John',
       policies: [{ id: 1, name: 'new policy' }],
-      team: []
+      teams: []
     }
 
     userOps.addUserPolicies = function (params, cb) {
@@ -381,7 +381,7 @@ lab.experiment('Users', () => {
       id: 1,
       name: 'John',
       policies: [],
-      team: []
+      teams: []
     }
 
     userOps.replaceUserPolicies = function (params, cb) {

--- a/service/wiring-hapi.js
+++ b/service/wiring-hapi.js
@@ -18,6 +18,7 @@ server.connection({
 })
 
 const swaggerOptions = {
+  jsonEditor: true,
   info: {
     title: 'Authorization API Documentation',
     version: packageJson.version


### PR DESCRIPTION
This should let us perform project demos without postman.
The swagger documentation gives the ability to execute calls to the api and see their result.

![gif](http://g.recordit.co/IiJ8XPsSeK.gif)