### PR TITLE
Make user id a creation api parameter and if not present assign a uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,26 +63,34 @@ To access the database using the pgAdmin you have to fill in also the container 
 
 ## Service
 
-The service will respond to commands such as a list users request:
+The service will respond http calls such as
 
-    {role: 'authorization', cmd: 'list', type: 'users'}
+```
+GET /authorization/users
+```
 
 with data in the form:
 
-    [ { id: 1, name: 'Charlie Bucket' },
-      { id: 2, name: 'Grandpa Joe' },
-      { id: 3, name: 'Veruca Salt' },
-      { id: 4, name: 'Willy Wonka' } ]
+```
+[
+  { id: 'CharlieId', name: 'Charlie Bucket' },
+  { id: 'GrandpaId', name: 'Grandpa Joe' },
+  { id: 'VerucaId', name: 'Veruca Salt' },
+  { id: 'WillyId', name: 'Willy Wonka' }
+]
+```
 
-It also has a shutdown operation, which should be called when finished with the
-service:
-
-    {role: 'authorization', cmd: 'done'}
-
+To get more information see [Service Api documentation](#service-api-documentation)
 
 ### Setup SuperUser
 
 The init script needs to be run in order to setup the SuperUser: `node service/scripts/init`
+
+If you want to specify a better SuperUser id (default is `SuperUserId`) you can prefix the script as follow:
+
+```
+LABS_AUTH_SERVICE_authorization_superUser_id=myComplexId12345 node service/scripts/init
+```
 
 **Note:** if you have already ran some tests or loaded the test data, you will need to run `npm pg:init` again to reset the db.
 

--- a/scripts/init/database/db_load.sh
+++ b/scripts/init/database/db_load.sh
@@ -8,7 +8,7 @@ SELECT 'Database installed, schemaversion = ' || MAX(version) from schemaversion
 \cd '/testdata'
 \! pwd
 \COPY organizations(id, name, description) FROM 'organizations.csv' (FORMAT csv)
-\COPY users(name, org_id) FROM 'users.csv' (FORMAT csv)
+\COPY users(id, name, org_id) FROM 'users.csv' (FORMAT csv)
 \COPY teams(name, description, team_parent_id, org_id) FROM 'teams.csv' (FORMAT csv)
 \COPY team_members(user_id, team_id) FROM 'team_members.csv' (FORMAT csv)
 EOF"

--- a/scripts/init/database/migrations/001.do.sql
+++ b/scripts/init/database/migrations/001.do.sql
@@ -26,7 +26,7 @@ CREATE TABLE ref_actions (
 
 /* TODO: users should have additional 'username' column */
 CREATE TABLE users (
-  id        SERIAL UNIQUE,
+  id        VARCHAR(128) UNIQUE,
   name      VARCHAR(50) NOT NULL,
   org_id    VARCHAR REFERENCES organizations(id) NOT NULL
 );
@@ -44,12 +44,12 @@ CREATE INDEX teams_path_gist_idx ON teams USING GIST (path);
 
 CREATE TABLE team_members (
   team_id  INT REFERENCES teams(id) NOT NULL,
-  user_id  INT REFERENCES users(id) NOT NULL,
+  user_id  VARCHAR(128) REFERENCES users(id) NOT NULL,
   CONSTRAINT team_member_link PRIMARY KEY(team_id, user_id)
 );
 
 CREATE TABLE user_policies (
-  user_id   INT REFERENCES users(id) NOT NULL,
+  user_id   VARCHAR(128) REFERENCES users(id) NOT NULL,
   policy_id INT REFERENCES policies(id) NOT NULL,
   CONSTRAINT user_policy_link PRIMARY KEY(policy_id, user_id)
 );

--- a/scripts/init/database/testdata/team_members.csv
+++ b/scripts/init/database/testdata/team_members.csv
@@ -1,6 +1,6 @@
-2,2
-4,2
-4,3
-5,1
-6,4
-6,5
+CharlieId,2
+VerucaId,2
+VerucaId,3
+AugustusId,1
+WillyId,4
+WillyId,5

--- a/scripts/init/database/testdata/user_policies.csv
+++ b/scripts/init/database/testdata/user_policies.csv
@@ -1,7 +1,7 @@
-1,9
-4,2
-8,10
-8,11
-8,12
-8,13
-8,14
+ROOTid,9
+VerucaId,2
+ManyPoliciesId,10
+ManyPoliciesId,11
+ManyPoliciesId,12
+ManyPoliciesId,13
+ManyPoliciesId,14

--- a/scripts/init/database/testdata/users.csv
+++ b/scripts/init/database/testdata/users.csv
@@ -1,8 +1,8 @@
-Super User,ROOT
-Charlie Bucket,WONKA
-Mike Teavee,WONKA
-Veruca Salt,WONKA
-Augustus Gloop,WONKA
-Willy Wonka,WONKA
-Modify Me,WONKA
-Many Polices,WONKA
+ROOTid,Super User,ROOT
+CharlieId,Charlie Bucket,WONKA
+MikeId,Mike Teavee,WONKA
+VerucaId,Veruca Salt,WONKA
+AugustusId,Augustus Gloop,WONKA
+WillyId,Willy Wonka,WONKA
+ModifyId,Modify Me,WONKA
+ManyPoliciesId,Many Polices,WONKA

--- a/service/lib/config/index.js
+++ b/service/lib/config/index.js
@@ -39,6 +39,7 @@ module.exports = new Reconfig({
         name: 'SuperOrganization',
         description: 'SuperUser Organization'
       },
+      id: 'SuperUserId',
       name: 'SuperUser',
       defaultPolicy: {
         version: '1',

--- a/service/lib/ops/organizationOps.js
+++ b/service/lib/ops/organizationOps.js
@@ -104,10 +104,10 @@ function createDefaultPolicies (job, next) {
  */
 function insertOrgAdminUser (job, next) {
   if (job.user) {
-    const { name } = job.user
+    const { id, name } = job.user
     const { id: organizationId } = job.organization
 
-    userOps.insertUser(job.client, name, organizationId, (err, res) => {
+    userOps.insertUser(job.client, { id, name, organizationId }, (err, res) => {
       if (err) return next(err)
       job.user.id = res.rows[0].id
 

--- a/service/lib/ops/teamOps.js
+++ b/service/lib/ops/teamOps.js
@@ -64,8 +64,10 @@ function createDefaultPolicies (job, next) {
 
 function createDefaultUser (job, next) {
   if (!job.params.user) return next()
+  const { id, name } = job.params.user
+  const { organizationId } = job.params
 
-  userOps.insertUser(job.client, job.params.user.name, job.params.organizationId, (err, user) => {
+  userOps.insertUser(job.client, { id, name, organizationId }, (err, user) => {
     if (err) return next(err)
 
     job.user = user.rows[0]
@@ -307,7 +309,10 @@ var teamOps = {
 
     tasks.push((next) => {
       const sql = SQL`
-        SELECT id, name, description, path FROM teams WHERE id = ${id} AND org_id = ${organizationId}
+        SELECT id, name, description, path
+        FROM teams
+        WHERE id = ${id}
+        AND org_id = ${organizationId}
       `
 
       db.query(sql, (err, result) => {
@@ -323,8 +328,11 @@ var teamOps = {
 
     tasks.push((next) => {
       const sql = SQL`
-        SELECT users.id, users.name FROM team_members mem, users
-        WHERE mem.team_id = ${id} and mem.user_id = users.id ORDER BY UPPER(users.name)
+        SELECT users.id, users.name
+        FROM team_members mem, users
+        WHERE mem.team_id = ${id}
+        AND mem.user_id = users.id
+        ORDER BY UPPER(users.name)
       `
       db.query(sql, function (err, result) {
         if (err) return next(err)
@@ -336,8 +344,11 @@ var teamOps = {
 
     tasks.push((next) => {
       const sql = SQL`
-        SELECT pol.id, pol.name, pol.version FROM team_policies tpol, policies pol
-        WHERE tpol.team_id = ${id} and tpol.policy_id = pol.id ORDER BY UPPER(pol.name)
+        SELECT pol.id, pol.name, pol.version
+        FROM team_policies tpol, policies pol
+        WHERE tpol.team_id = ${id}
+        AND tpol.policy_id = pol.id
+        ORDER BY UPPER(pol.name)
       `
       db.query(sql, function (err, result) {
         if (err) return next(err)

--- a/service/package.json
+++ b/service/package.json
@@ -35,6 +35,7 @@
     "minimist": "1.2.0",
     "pg": "6.1.1",
     "reconfig": "3.2.0",
+    "uuid": "^3.0.1",
     "vision": "4.1.1"
   },
   "devDependencies": {

--- a/service/routes/public/authorization.js
+++ b/service/routes/public/authorization.js
@@ -32,7 +32,7 @@ exports.register = function (server, options, next) {
       },
       validate: {
         params: {
-          userId: Joi.number().required().description('The user that wants to perform the action on a given resource'),
+          userId: Joi.string().required().description('The user that wants to perform the action on a given resource'),
           action: Joi.string().required().description('The action to check'),
           resource: Joi.string().required().description('The resource that the user wants to perform the action on')
         },
@@ -72,7 +72,7 @@ exports.register = function (server, options, next) {
       },
       validate: {
         params: {
-          userId: Joi.number().required().description('The user that wants to perform the action on a given resource'),
+          userId: Joi.string().required().description('The user that wants to perform the action on a given resource'),
           resource: Joi.string().required().description('The resource that the user wants to perform the action on')
         },
         headers: Joi.object({

--- a/service/routes/public/organizations.js
+++ b/service/routes/public/organizations.js
@@ -83,6 +83,7 @@ exports.register = function (server, options, next) {
           name: Joi.string().required().description('organization name'),
           description: Joi.string().required().description('organization description'),
           user: Joi.object().keys({
+            id: Joi.string(),
             name: Joi.string().required()
           })
         },

--- a/service/routes/public/teams.js
+++ b/service/routes/public/teams.js
@@ -61,6 +61,7 @@ exports.register = function (server, options, next) {
           name: Joi.string().required().description('Name of the new team'),
           description: Joi.string().required().description('Description of new team'),
           user: Joi.object().optional().description('Default admin user to be added to the team').keys({
+            id: Joi.string().description('user id'),
             name: Joi.string().required('Name for the user')
           })
         },
@@ -137,7 +138,7 @@ exports.register = function (server, options, next) {
         payload: Joi.object().keys({
           name: Joi.string().description('Updated team name'),
           description: Joi.string().description('Updated team description'),
-          users: Joi.array().description('User ids')
+          users: Joi.array().items(Joi.string()).description('User ids')
         }).or('name', 'description', 'users'),
         headers: Joi.object({
           'authorization': Joi.any().required()

--- a/service/routes/public/users.js
+++ b/service/routes/public/users.js
@@ -44,7 +44,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('user id')
+          id: Joi.string().required().description('user id')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -68,12 +68,9 @@ exports.register = function (server, options, next) {
     path: '/authorization/users',
     handler: function (request, reply) {
       const { organizationId } = request.udaru
-      const params = {
-        name: request.payload.name,
-        organizationId
-      }
+      const { id, name } = request.payload
 
-      userOps.createUser(params, function (err, res) {
+      userOps.createUser({ id, name, organizationId }, function (err, res) {
         if (err) {
           return reply(err)
         }
@@ -84,6 +81,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         payload: {
+          id: Joi.string().description('user id'),
           name: Joi.string().required().description('User name')
         },
         headers: Joi.object({
@@ -120,7 +118,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('user id')
+          id: Joi.string().required().description('user id')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -157,7 +155,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('user id')
+          id: Joi.string().required().description('user id')
         },
         payload: {
           name: Joi.string().required().description('user name'),
@@ -200,12 +198,10 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('user id')
+          id: Joi.string().required().description('user id')
         },
         payload: {
-          policies: Joi.array().required().items(Joi.object().keys({
-            id: Joi.number().required()
-          }))
+          policies: Joi.array().required().items(Joi.number().required())
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -243,12 +239,10 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('user id')
+          id: Joi.string().required().description('user id')
         },
         payload: {
-          policies: Joi.array().required().items(Joi.object().keys({
-            id: Joi.number().required()
-          }))
+          policies: Joi.array().required().items(Joi.number().required())
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -285,7 +279,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          id: Joi.number().required().description('user id')
+          id: Joi.string().required().description('user id')
         },
         headers: Joi.object({
           'authorization': Joi.any().required()
@@ -321,7 +315,7 @@ exports.register = function (server, options, next) {
     config: {
       validate: {
         params: {
-          userId: Joi.number().required().description('user id'),
+          userId: Joi.string().required().description('user id'),
           policyId: Joi.number().required().description('policy id')
         },
         headers: Joi.object({

--- a/service/scripts/init.js
+++ b/service/scripts/init.js
@@ -20,6 +20,7 @@ function createUser (job, next) {
   const { organization } = job
 
   const superUserData = {
+    id: config.get('authorization.superUser.id'),
     name: config.get('authorization.superUser.name'),
     organizationId: organization.id
   }

--- a/service/security/hapi-auth-service.js
+++ b/service/security/hapi-auth-service.js
@@ -34,7 +34,7 @@ internals.implementation = function (server, options) {
         return reply(Boom.unauthorized('Missing authorization', 'udaru'))
       }
 
-      const userId = parseInt(authorization, 10)
+      const userId = String(authorization)
 
       settings.validateFunc(server, request, userId, (error, isValid, user) => {
         if (error) {

--- a/service/swagger.js
+++ b/service/swagger.js
@@ -28,7 +28,7 @@ const PolicyRef = Joi.object({
 })
 
 const UserRef = Joi.object({
-  id: Joi.number(),
+  id: Joi.string(),
   name: Joi.string()
 })
 
@@ -49,7 +49,7 @@ const TeamRef = Joi.object({
 })
 
 const User = Joi.object({
-  id: Joi.number(),
+  id: Joi.string(),
   name: Joi.string(),
   organizationId: Joi.string(),
   teams: Joi.array().items(TeamRef),

--- a/service/test/endToEnd/authorizationTest.js
+++ b/service/test/endToEnd/authorizationTest.js
@@ -1,0 +1,81 @@
+'use strict'
+
+const expect = require('code').expect
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+const utils = require('./../utils')
+const server = require('./../../wiring-hapi')
+
+lab.experiment('Authorization', () => {
+  lab.test('check authorization should return access true for allowed', (done) => {
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/access/ROOTid/action_a/resource_a'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal({ access: true })
+
+      done()
+    })
+  })
+
+  lab.test('check authorization should return access false for denied', (done) => {
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/access/Modifyid/action_a/resource_a'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal({ access: false })
+
+      done()
+    })
+  })
+
+  lab.test('list authorizations should return actions allowed for the user', (done) => {
+    const actionList = {
+      actions: []
+    }
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/list/ModifyId/not/my/resource'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal(actionList)
+
+      done()
+    })
+  })
+
+  lab.test('list authorizations should return actions allowed for the user', (done) => {
+    const actionList = {
+      actions: ['Read']
+    }
+    const options = utils.requestOptions({
+      method: 'GET',
+      // TO BE DISCUSSED: We need double slashes "//" if we use a "/" at the beginning of a resource in the policies
+      // @see https://github.com/nearform/labs-authorization/issues/198
+      url: '/authorization/list/ManyPoliciesId//myapp/users/filippo'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal(actionList)
+
+      done()
+    })
+  })
+})

--- a/service/test/endToEnd/usersTest.js
+++ b/service/test/endToEnd/usersTest.js
@@ -3,21 +3,218 @@
 const expect = require('code').expect
 const Lab = require('lab')
 const lab = exports.lab = Lab.script()
-var utils = require('./../utils')
-
-var server = require('./../../wiring-hapi')
+const utils = require('./../utils')
+const userOps = require('../../lib/ops/userOps')
+const server = require('./../../wiring-hapi')
 
 lab.experiment('Users', () => {
+
+  lab.test('get user list', (done) => {
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/users'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.length).to.equal(7)
+      expect(result[0]).to.equal({
+        id: 'AugustusId',
+        name: 'Augustus Gloop',
+        organizationId: 'WONKA'
+      })
+
+      done()
+    })
+  })
+
+  lab.test('get single user', (done) => {
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/users/AugustusId'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal({
+        id: 'AugustusId',
+        name: 'Augustus Gloop',
+        organizationId: 'WONKA',
+        policies: [],
+        teams: [
+          {
+            id: 1,
+            name: 'Admins'
+          }
+        ]
+      })
+
+      done()
+    })
+  })
+
+  lab.test('delete user should return 204 if success', (done) => {
+    userOps.createUser({name: 'test', id: 'testId', organizationId: 'ROOT'}, (err, user) => {
+      expect(err).to.not.exist()
+
+      const options = utils.requestOptions({
+        method: 'DELETE',
+        url: '/authorization/users/testId',
+        headers: {
+          authorization: 'ROOTid'
+        }
+      })
+
+      server.inject(options, (response) => {
+        const result = response.result
+
+        expect(response.statusCode).to.equal(204)
+        expect(result).to.be.undefined
+
+        done()
+      })
+    })
+  })
+
+  lab.test('update user should return 200 for success', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/users/ModifyId',
+      payload: {
+        name: 'Modify you',
+        teams: []
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal({
+        id: 'ModifyId',
+        name: 'Modify you',
+        organizationId: 'WONKA',
+        teams: [],
+        policies: []
+      })
+
+      userOps.updateUser({ name: 'Modify Me', id: 'ModifyId', organizationId: 'WONKA', teams: [] }, done)
+    })
+  })
+
+  lab.test('add policies to a user', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/users/ModifyId/policies',
+      payload: {
+        policies: [1]
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.policies).to.equal([{
+        id: 1,
+        name: 'Director',
+        version: '0.1'
+      }])
+
+      userOps.deleteUserPolicies({ id: 'ModifyId', organizationId: 'WONKA' }, done)
+    })
+  })
+
+  lab.test('clear and replace policies for a user', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users/ModifyId/policies',
+      payload: {
+        policies: [1]
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.policies).to.equal([{
+        id: 1,
+        name: 'Director',
+        version: '0.1'
+      }])
+
+      options.payload.policies = [2, 3]
+      server.inject(options, (response) => {
+        const result = response.result
+
+        expect(response.statusCode).to.equal(200)
+        expect(result.policies).to.equal([
+          {
+            id: 2,
+            name: 'Accountant',
+            version: '0.1'
+          },
+          {
+            id: 3,
+            name: 'Sys admin',
+            version: '0.1'
+          }
+        ])
+
+        userOps.deleteUserPolicies({ id: 'ModifyId', organizationId: 'WONKA' }, done)
+      })
+    })
+  })
+
+  lab.test('remove all user\'s policies', (done) => {
+    const options = utils.requestOptions({
+      method: 'DELETE',
+      url: '/authorization/users/ManyPoliciesId/policies'
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(204)
+      userOps.readUser({ id: 'ManyPoliciesId', organizationId: 'WONKA' }, (err, user) => {
+        expect(err).not.to.exist()
+        expect(user.policies).to.equal([])
+
+        userOps.replaceUserPolicies({ id: 'ManyPoliciesId', organizationId: 'WONKA', policies: [10, 11, 12, 13, 14] }, done)
+      })
+    })
+  })
+
+  lab.test('remove one user\'s policies', (done) => {
+    const options = utils.requestOptions({
+      method: 'DELETE',
+      url: '/authorization/users/ManyPoliciesId/policies/10'
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(204)
+      userOps.readUser({ id: 'ManyPoliciesId', organizationId: 'WONKA' }, (err, user) => {
+        expect(err).not.to.exist()
+        expect(user.policies.map(p => p.id)).to.equal([14, 13, 12, 11])
+
+        userOps.replaceUserPolicies({ id: 'ManyPoliciesId', organizationId: 'WONKA', policies: [10, 11, 12, 13, 14] }, done)
+      })
+    })
+  })
 
   lab.test('create user for a non existent organization', (done) => {
     const options = utils.requestOptions({
       method: 'POST',
       url: '/authorization/users',
       payload: {
-        name: 'Salman'
+        name: 'Salman',
+        id: 'testId'
       },
       headers: {
-        authorization: 1,
+        authorization: 'ROOTid',
         org: 'DOES_NOT_EXISTS'
       }
     })
@@ -30,6 +227,103 @@ lab.experiment('Users', () => {
         error: 'Bad Request',
         message: `Organization 'DOES_NOT_EXISTS' does not exists`,
         statusCode: 400
+      })
+
+      done()
+    })
+  })
+
+  lab.test('create user for a specific organization being a SuperUser', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users',
+      payload: {
+        name: 'Salman',
+        id: 'testId'
+      },
+      headers: {
+        authorization: 'ROOTid',
+        org: 'OILCOUSA'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(201)
+      expect(result.id).to.equal('testId')
+      expect(result.name).to.equal('Salman')
+      expect(result.organizationId).to.equal('OILCOUSA')
+
+      userOps.deleteUser({ id: 'testId', organizationId: 'OILCOUSA' }, done)
+    })
+  })
+
+
+  lab.test('create user for a specific organization being a SuperUser but without specifying the user id', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users',
+      payload: {
+        name: 'Salman'
+      },
+      headers: {
+        authorization: 'ROOTid',
+        org: 'OILCOUSA'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(201)
+      expect(result.id).to.not.be.null()
+      expect(result.name).to.equal('Salman')
+      expect(result.organizationId).to.equal('OILCOUSA')
+
+      userOps.deleteUser({ id: result.id, organizationId: 'OILCOUSA' }, done)
+    })
+  })
+
+  lab.test('create user for the admin organization', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users',
+      payload: {
+        name: 'Salman',
+        id: 'U2FsbWFu'
+      },
+      headers: {
+        authorization: 'ROOTid'
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(201)
+      expect(result.id).to.equal('U2FsbWFu')
+      expect(result.name).to.equal('Salman')
+      expect(result.organizationId).to.equal('ROOT')
+
+      userOps.deleteUser({ id: result.id, organizationId: 'ROOT' }, done)
+    })
+  })
+
+  lab.test('create user should return 400 bad request if input validation fails', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users',
+      payload: {}
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(400)
+      expect(result).to.include({
+        statusCode: 400,
+        error: 'Bad Request'
       })
 
       done()

--- a/service/test/lib/integration/organizationOpsTest.js
+++ b/service/test/lib/integration/organizationOpsTest.js
@@ -110,6 +110,49 @@ lab.experiment('OrganizationOps', () => {
     })
   })
 
+  lab.test('create an organization specifying a user and its id, should create the user and assign the OrgAdmin policy to it', (done) => {
+    organizationOps.create({
+      id: 'nearForm',
+      name: 'nearForm',
+      description: 'nearform description',
+      user: {
+        id: 'myspecialid',
+        name: 'example example'
+      }
+    }, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.exist()
+      expect(result.organization).to.exist()
+      expect(result.organization.name).to.equal('nearForm')
+      expect(result.user).to.exist()
+      expect(result.user.name).to.equal('example example')
+      expect(result.user.id).to.equal('myspecialid')
+
+      userOps.listOrgUsers({ organizationId: 'nearForm' }, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.length).to.equal(1)
+        expect(res[0].name).to.equal('example example')
+
+        userOps.readUser({ id: res[0].id, organizationId: 'nearForm' }, (err, user) => {
+          expect(err).to.not.exist()
+          expect(user).to.exist()
+          expect(user.teams.length).to.equal(0)
+
+          organizationOps.deleteById(result.organization.id, (err, res) => {
+            expect(err).to.not.exist()
+
+            userOps.listOrgUsers({ organizationId: 'nearForm' }, (err, res) => {
+              expect(err).to.not.exist()
+              expect(res.length).to.equal(0)
+              done()
+            })
+          })
+        })
+      })
+    })
+  })
+
   lab.test('update an organization', (done) => {
     const createData = { id: 'nearForm1', name: 'nearForm', description: 'nearform description' }
     const updateData = { id: 'nearForm1', name: 'nearFormUp', description: 'nearFormUp desc up' }

--- a/service/test/lib/integration/userOpsTest.js
+++ b/service/test/lib/integration/userOpsTest.js
@@ -20,26 +20,44 @@ lab.experiment('UserOps', () => {
 
   lab.test('create and delete a user by ID', (done) => {
     const userData = {
-      id: 99,
+      id: 'testId',
       name: 'Mike Teavee',
       organizationId: 'WONKA'
     }
-    userOps.createUserById(userData, (err, result) => {
+    userOps.createUser(userData, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
-      expect(result).to.equal({ id: 99, name: 'Mike Teavee', organizationId: 'WONKA', teams: [], policies: [] })
+      expect(result).to.equal({ id: 'testId', name: 'Mike Teavee', organizationId: 'WONKA', teams: [], policies: [] })
 
-      userOps.deleteUser({ id: 99, organizationId: 'WONKA' }, done)
+      userOps.deleteUser({ id: 'testId', organizationId: 'WONKA' }, done)
+    })
+  })
+
+  lab.test('create and delete a user without specifying an id', (done) => {
+    const userData = {
+      name: 'Mike Teavee',
+      organizationId: 'WONKA'
+    }
+    userOps.createUser(userData, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.exist()
+      expect(result.id).to.not.be.null()
+      expect(result.name).to.equal('Mike Teavee')
+      expect(result.organizationId).to.equal('WONKA')
+      expect(result.teams).to.equal([])
+      expect(result.policies).to.equal([])
+
+      userOps.deleteUser({ id: result.id, organizationId: 'WONKA' }, done)
     })
   })
 
   lab.test('create user in not existing organization', (done) => {
     const userData = {
-      id: 99,
+      id: 'testId',
       name: 'Mike Teavee',
       organizationId: 'DO_NOT_EXIST_ORG'
     }
-    userOps.createUserById(userData, (err, result) => {
+    userOps.createUser(userData, (err, result) => {
       expect(err).to.exist()
       expect(result).to.not.exist()
 
@@ -47,24 +65,10 @@ lab.experiment('UserOps', () => {
     })
   })
 
-  lab.test('create a user (and delete it)', (done) => {
-    const userData = {
-      name: 'Grandma Josephine',
-      organizationId: 'WONKA'
-    }
-    userOps.createUser(userData, function (err, result) {
-      expect(err).to.not.exist()
-      expect(result).to.exist()
-      expect(result.name).to.equal('Grandma Josephine')
-
-      userOps.deleteUser({ id: result.id, organizationId: 'WONKA' }, done)
-    })
-  })
-
   lab.test('update a user', (done) => {
-    const expected = { id: 6, name: 'Augustus Gloop', organizationId: 'WONKA', teams: [{ id: 4, name: 'Managers' }], policies: [] }
+    const expected = { id: 'AugustusId', name: 'Augustus Gloop', organizationId: 'WONKA', teams: [{ id: 4, name: 'Managers' }], policies: [] }
     const data = {
-      id: 6,
+      id: 'AugustusId',
       organizationId: 'WONKA',
       name: 'Augustus Gloop',
       teams: [4]
@@ -81,8 +85,8 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('read a specific user', (done) => {
-    const expected = { id: 4, name: 'Veruca Salt', organizationId: 'WONKA', teams: [{ id: 3, name: 'Authors' }, { id: 2, name: 'Readers' }], policies: [{ id: 2, version: '0.1', name: 'Accountant' }] }
-    userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, result) => {
+    const expected = { id: 'VerucaId', name: 'Veruca Salt', organizationId: 'WONKA', teams: [{ id: 3, name: 'Authors' }, { id: 2, name: 'Readers' }], policies: [{ id: 2, version: '0.1', name: 'Accountant' }] }
+    userOps.readUser({ id: 'VerucaId', organizationId: 'WONKA' }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
       expect(result).to.equal(expected)
@@ -93,7 +97,7 @@ lab.experiment('UserOps', () => {
 
   lab.test('getUserOrganizationId', (done) => {
     const expected = 'WONKA'
-    userOps.getUserOrganizationId(4, (err, result) => {
+    userOps.getUserOrganizationId('VerucaId', (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
       expect(result).to.equal(expected)
@@ -103,7 +107,7 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('read a specific user that does not exist', (done) => {
-    userOps.readUser({ id: 987654321, organizationId: 'WONKA' }, (err, result) => {
+    userOps.readUser({ id: '987654321', organizationId: 'WONKA' }, (err, result) => {
       expect(err).to.exist()
       expect(err.output.statusCode).to.equal(404)
       expect(result).to.not.exist()
@@ -113,17 +117,17 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('replace user\'s policies', (done) => {
-    userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+    userOps.readUser({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
       expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }])
 
-      userOps.replaceUserPolicies({ id: 4, policies: [1, 3], organizationId: 'WONKA' }, (err, user) => {
+      userOps.replaceUserPolicies({ id: 'VerucaId', policies: [1, 3], organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.not.exist()
         expect(user).to.exist()
         expect(user.policies).to.equal([{ id: 1, name: 'Director', version: '0.1' }, { id: 3, name: 'Sys admin', version: '0.1' }])
 
-        userOps.replaceUserPolicies({ id: 4, policies: [2], organizationId: 'WONKA' }, (err, user) => {
+        userOps.replaceUserPolicies({ id: 'VerucaId', policies: [2], organizationId: 'WONKA' }, (err, user) => {
           expect(err).to.not.exist()
           done()
         })
@@ -132,17 +136,17 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('add policies to user', (done) => {
-    userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+    userOps.readUser({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
       expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }])
 
-      userOps.addUserPolicies({ id: 4, policies: [1, 3], organizationId: 'WONKA' }, (err, user) => {
+      userOps.addUserPolicies({ id: 'VerucaId', policies: [1, 3], organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.not.exist()
         expect(user).to.exist()
         expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }, { id: 1, name: 'Director', version: '0.1' }, { id: 3, name: 'Sys admin', version: '0.1' }])
 
-        userOps.replaceUserPolicies({ id: 4, policies: [2], organizationId: 'WONKA' }, (err, user) => {
+        userOps.replaceUserPolicies({ id: 'VerucaId', policies: [2], organizationId: 'WONKA' }, (err, user) => {
           expect(err).to.not.exist()
           done()
         })
@@ -151,17 +155,17 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('add twice the same policy to a user', (done) => {
-    userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+    userOps.readUser({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
       expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }])
 
-      userOps.addUserPolicies({ id: 4, policies: [1, 2, 3], organizationId: 'WONKA' }, (err, user) => {
+      userOps.addUserPolicies({ id: 'VerucaId', policies: [1, 2, 3], organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.not.exist()
         expect(user).to.exist()
         expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }, { id: 1, name: 'Director', version: '0.1' }, { id: 3, name: 'Sys admin', version: '0.1' }])
 
-        userOps.replaceUserPolicies({ id: 4, policies: [2], organizationId: 'WONKA' }, (err, user) => {
+        userOps.replaceUserPolicies({ id: 'VerucaId', policies: [2], organizationId: 'WONKA' }, (err, user) => {
           expect(err).to.not.exist()
           done()
         })
@@ -170,17 +174,17 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('delete user\'s policies', (done) => {
-    userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+    userOps.readUser({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
       expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }])
 
-      userOps.deleteUserPolicies({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+      userOps.deleteUserPolicies({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.not.exist()
         expect(user).to.exist()
         expect(user.policies).to.equal([])
 
-        userOps.replaceUserPolicies({ id: 4, policies: [2], organizationId: 'WONKA' }, (err, user) => {
+        userOps.replaceUserPolicies({ id: 'VerucaId', policies: [2], organizationId: 'WONKA' }, (err, user) => {
           expect(err).to.not.exist()
           done()
         })
@@ -189,17 +193,17 @@ lab.experiment('UserOps', () => {
   })
 
   lab.test('delete specific user\'s policy', (done) => {
-    userOps.readUser({ id: 4, organizationId: 'WONKA' }, (err, user) => {
+    userOps.readUser({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
       expect(user.policies).to.equal([{ id: 2, name: 'Accountant', version: '0.1' }])
 
-      userOps.deleteUserPolicy({ userId: 4, policyId: 2, organizationId: 'WONKA' }, (err, user) => {
+      userOps.deleteUserPolicy({ userId: 'VerucaId', policyId: 2, organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.not.exist()
         expect(user).to.exist()
         expect(user.policies).to.equal([])
 
-        userOps.replaceUserPolicies({ id: 4, policies: [2], organizationId: 'WONKA' }, (err, user) => {
+        userOps.replaceUserPolicies({ id: 'VerucaId', policies: [2], organizationId: 'WONKA' }, (err, user) => {
           expect(err).to.not.exist()
           done()
         })

--- a/service/test/routes/public/authorizationTest.js
+++ b/service/test/routes/public/authorizationTest.js
@@ -12,49 +12,6 @@ var authRoutes = proxyquire('./../../../routes/public/authorization', { './../..
 var server = proxyquire('./../../../wiring-hapi', { './routes/public/authorization': authRoutes })
 
 lab.experiment('Authorization', () => {
-  lab.test('check authorization should return access true for allowed', (done) => {
-    authorizeMock.isUserAuthorized = (params, cb) => {
-      process.nextTick(() => {
-        cb(null, {access: true})
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'GET',
-      url: '/authorization/access/1/action_a/resource_a'
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result).to.equal({ access: true })
-
-      done()
-    })
-  })
-
-  lab.test('check authorization should return access false for denied', (done) => {
-    authorizeMock.isUserAuthorized = (params, cb) => {
-      process.nextTick(() => {
-        cb(null, {access: false})
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'GET',
-      url: '/authorization/access/1/action_a/resource_a'
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result).to.equal({ access: false })
-
-      done()
-    })
-  })
 
   lab.test('check authorization should return 500 for error case', (done) => {
     authorizeMock.isUserAuthorized = (params, cb) => {
@@ -78,35 +35,6 @@ lab.experiment('Authorization', () => {
     })
   })
 
-  lab.test('list authorizations should return actions allowed for the user', (done) => {
-    const actionListStub = {
-      actions: [
-        'action a',
-        'action b'
-      ]
-    }
-
-    authorizeMock.listAuthorizations = (params, cb) => {
-      process.nextTick(() => {
-        cb(null, actionListStub)
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'GET',
-      url: '/authorization/list/1/resource_a'
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result).to.equal(actionListStub)
-
-      done()
-    })
-  })
-
   lab.test('list authorizations should return 500 for error case', (done) => {
     authorizeMock.listAuthorizations = (params, cb) => {
       process.nextTick(() => {
@@ -124,61 +52,6 @@ lab.experiment('Authorization', () => {
 
       expect(response.statusCode).to.equal(500)
       expect(result).to.be.undefined
-
-      done()
-    })
-  })
-
-  lab.test('list authorizations should return actions allowed for the user when using an URI', (done) => {
-    const actionListStub = {
-      actions: [
-        'action a',
-        'action b'
-      ]
-    }
-
-    authorizeMock.listAuthorizations = (params, cb) => {
-      process.nextTick(() => {
-        cb(null, actionListStub)
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'GET',
-      url: '/authorization/list/1/my/resource/uri'
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result).to.equal(actionListStub)
-
-      done()
-    })
-  })
-
-  lab.test('check authorization should return access true for allowed on URI resource', (done) => {
-    authorizeMock.isUserAuthorized = (params, cb) => {
-      expect(params.userId).to.equal(1)
-      expect(params.action).to.equal('action_a')
-      expect(params.resource).to.equal('/my/resource/uri')
-
-      process.nextTick(() => {
-        cb(null, {access: true})
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'GET',
-      url: '/authorization/access/1/action_a//my/resource/uri'
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result).to.equal({ access: true })
 
       done()
     })

--- a/service/test/routes/public/organizationsTest.js
+++ b/service/test/routes/public/organizationsTest.js
@@ -36,8 +36,6 @@ lab.experiment('Organizations', () => {
     server.inject(options, (response) => {
       const result = response.result
 
-      console.log(result)
-
       expect(response.statusCode).to.equal(200)
       expect(result).to.equal(expected)
 
@@ -108,6 +106,7 @@ lab.experiment('Organizations', () => {
       name: 'nearForm',
       description: 'nearForm org',
       user: {
+        id: 'exampleId',
         name: 'example'
       }
     }

--- a/service/test/routes/public/usersTest.js
+++ b/service/test/routes/public/usersTest.js
@@ -13,37 +13,6 @@ var server = proxyquire('./../../../wiring-hapi', { './routes/public/users': use
 
 lab.experiment('Users', () => {
 
-  lab.test('get user list', (done) => {
-    var expected = [{
-      id: 1,
-      name: 'John'
-    }, {
-      id: 2,
-      name: 'Jack'
-    }]
-
-    userOps.listOrgUsers = function (params, cb) {
-      expect(params).to.equal({ organizationId: 'WONKA' })
-      process.nextTick(() => {
-        cb(null, expected)
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'GET',
-      url: '/authorization/users'
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result).to.equal(expected)
-
-      done()
-    })
-  })
-
   lab.test('get user list should return error for error case', (done) => {
     userOps.listOrgUsers = function (params, cb) {
       expect(params).to.equal({ organizationId: 'WONKA' })
@@ -67,39 +36,9 @@ lab.experiment('Users', () => {
     })
   })
 
-  lab.test('get single user', (done) => {
-    let expected = {
-      id: 1,
-      name: 'John',
-      policies: [],
-      teams: []
-    }
-
-    userOps.readUser = function (params, cb) {
-      expect(params).to.equal({ id: 1, organizationId: 'WONKA' })
-      process.nextTick(() => {
-        cb(null, expected)
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'GET',
-      url: '/authorization/users/1'
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result).to.equal(expected)
-
-      done()
-    })
-  })
-
   lab.test('get single user should return error for error case', (done) => {
     userOps.readUser = function (params, cb) {
-      expect(params).to.equal({ id: 99, organizationId: 'WONKA' })
+      expect(params).to.equal({ id: 'Myid', organizationId: 'WONKA' })
       process.nextTick(() => {
         cb(Boom.badImplementation())
       })
@@ -107,7 +46,7 @@ lab.experiment('Users', () => {
 
     const options = utils.requestOptions({
       method: 'GET',
-      url: '/authorization/users/99'
+      url: '/authorization/users/Myid'
     })
 
     server.inject(options, (response) => {
@@ -115,96 +54,6 @@ lab.experiment('Users', () => {
 
       expect(response.statusCode).to.equal(500)
       expect(result).to.be.undefined
-
-      done()
-    })
-  })
-
-  lab.test('create user for a specific organization being a SuperUser should return 201 for success', (done) => {
-    const newUserStub = {
-      id: 2,
-      name: 'Salman',
-      policies: [],
-      teams: []
-    }
-
-    userOps.createUser = function (params, cb) {
-      expect(params).to.equal({ name: 'Salman', organizationId: 'OILCOUSA' })
-      process.nextTick(() => {
-        cb(null, newUserStub)
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'POST',
-      url: '/authorization/users',
-      payload: {
-        name: 'Salman'
-      },
-      headers: {
-        authorization: 1,
-        org: 'OILCOUSA'
-      }
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(201)
-      expect(result).to.equal(newUserStub)
-
-      done()
-    })
-  })
-
-  lab.test('create user should return 201 for success', (done) => {
-    const newUserStub = {
-      id: 2,
-      name: 'Salman',
-      policies: [],
-      teams: []
-    }
-
-    userOps.createUser = function (params, cb) {
-      expect(params).to.equal({ name: 'Salman', organizationId: 'WONKA' })
-      process.nextTick(() => {
-        cb(null, newUserStub)
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'POST',
-      url: '/authorization/users',
-      payload: {
-        name: 'Salman'
-      }
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(201)
-      expect(result).to.equal(newUserStub)
-
-      done()
-    })
-  })
-
-  lab.test('create user should return 400 bad request if input validation fails', (done) => {
-    const options = utils.requestOptions({
-      method: 'POST',
-      url: '/authorization/users',
-      payload: {}
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(400)
-      expect(result).to.include({
-        statusCode: 400,
-        error: 'Bad Request'
-      })
 
       done()
     })
@@ -235,32 +84,9 @@ lab.experiment('Users', () => {
     })
   })
 
-  lab.test('delete user should return 204 if success', (done) => {
-    userOps.deleteUser = function (params, cb) {
-      expect(params).to.equal({ id: 1, organizationId: 'WONKA' })
-      process.nextTick(() => {
-        cb()
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'DELETE',
-      url: '/authorization/users/1'
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(204)
-      expect(result).to.be.undefined
-
-      done()
-    })
-  })
-
   lab.test('delete user should return error for error case', (done) => {
     userOps.deleteUser = function (params, cb) {
-      expect(params).to.equal({ id: 1, organizationId: 'WONKA' })
+      expect(params).to.equal({ id: 'MyId', organizationId: 'WONKA' })
       process.nextTick(() => {
         cb(Boom.badImplementation())
       })
@@ -268,7 +94,7 @@ lab.experiment('Users', () => {
 
     const options = utils.requestOptions({
       method: 'DELETE',
-      url: '/authorization/users/1'
+      url: '/authorization/users/MyId'
     })
 
     server.inject(options, (response) => {
@@ -276,40 +102,6 @@ lab.experiment('Users', () => {
 
       expect(response.statusCode).to.equal(500)
       expect(result).to.be.undefined
-
-      done()
-    })
-  })
-
-  lab.test('update user should return 200 for success', (done) => {
-    userOps.updateUser = function (params, cb) {
-      expect(params.id).to.equal(3)
-      expect(params.organizationId).to.equal('WONKA')
-      process.nextTick(() => {
-        cb(null, {
-          id: 3,
-          name: 'Joe'
-        })
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'PUT',
-      url: '/authorization/users/3',
-      payload: {
-        name: 'Joe',
-        teams: []
-      }
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result).to.equal({
-        id: 3,
-        name: 'Joe'
-      })
 
       done()
     })
@@ -317,7 +109,7 @@ lab.experiment('Users', () => {
 
   lab.test('update user should return error for error case', (done) => {
     userOps.updateUser = function (params, cb) {
-      expect(params.id).to.equal(1)
+      expect(params.id).to.equal('MyId')
       expect(params.organizationId).to.equal('WONKA')
       process.nextTick(() => {
         cb(Boom.badImplementation())
@@ -326,7 +118,7 @@ lab.experiment('Users', () => {
 
     const options = utils.requestOptions({
       method: 'PUT',
-      url: '/authorization/users/1',
+      url: '/authorization/users/MyId',
       payload: {
         name: 'Joe',
         teams: []
@@ -338,112 +130,6 @@ lab.experiment('Users', () => {
 
       expect(response.statusCode).to.equal(500)
       expect(result).to.be.undefined
-
-      done()
-    })
-  })
-
-  lab.test('add policies to a user', (done) => {
-    let expected = {
-      id: 1,
-      name: 'John',
-      policies: [{ id: 1, name: 'new policy' }],
-      teams: []
-    }
-
-    userOps.addUserPolicies = function (params, cb) {
-      expect(params).to.equal({ id: 1, organizationId: 'WONKA', policies: [ { id: 1 } ] })
-      process.nextTick(() => {
-        cb(null, expected)
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'PUT',
-      url: '/authorization/users/1/policies',
-      payload: {
-        policies: [{ id: 1 }]
-      }
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result).to.equal(expected)
-
-      done()
-    })
-  })
-
-  lab.test('clear and replace policies for a user', (done) => {
-    let expected = {
-      id: 1,
-      name: 'John',
-      policies: [],
-      teams: []
-    }
-
-    userOps.replaceUserPolicies = function (params, cb) {
-      expect(params).to.equal({ id: 1, organizationId: 'WONKA', policies: [ { id: 1 } ] })
-      process.nextTick(() => {
-        cb(null, expected)
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'POST',
-      url: '/authorization/users/1/policies',
-      payload: {
-        policies: [{ id: 1 }]
-      }
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result).to.equal(expected)
-
-      done()
-    })
-  })
-
-  lab.test('remove all user\'s policies', (done) => {
-    userOps.deleteUserPolicies = function (params, cb) {
-      expect(params).to.equal({ id: 1, organizationId: 'WONKA' })
-      process.nextTick(() => {
-        cb(null)
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'DELETE',
-      url: '/authorization/users/1/policies'
-    })
-
-    server.inject(options, (response) => {
-      expect(response.statusCode).to.equal(204)
-
-      done()
-    })
-  })
-
-  lab.test('remove one user\'s policies', (done) => {
-    userOps.deleteUserPolicy = function (params, cb) {
-      expect(params).to.equal({ userId: 33, policyId: 99, organizationId: 'WONKA' })
-      process.nextTick(() => {
-        cb(null)
-      })
-    }
-
-    const options = utils.requestOptions({
-      method: 'DELETE',
-      url: '/authorization/users/33/policies/99'
-    })
-
-    server.inject(options, (response) => {
-      expect(response.statusCode).to.equal(204)
 
       done()
     })

--- a/service/test/utils.js
+++ b/service/test/utils.js
@@ -9,7 +9,7 @@
 function requestOptions (customOptions) {
   const defaultOptions = {
     headers: {
-      authorization: 1,
+      authorization: 'ROOTid',
       org: 'WONKA'
     }
   }


### PR DESCRIPTION
This PR add the following functionality:

* The user id in the database is a string now
* When creating a user, the `id ` can be specified from the caller (it has to be unique)
* If the id is not specified it will be created as a uuid v4
