### PR TITLE
fix wrong shape of policies passed from route to userOps

### DIFF
--- a/service/routes/public/users.js
+++ b/service/routes/public/users.js
@@ -172,7 +172,7 @@ exports.register = function (server, options, next) {
       const params = {
         id,
         organizationId,
-        policies
+        policies: policies.map(({id}) => id)
       }
       userOps.addUserPolicies(params, reply)
     },

--- a/service/test/routes/public/usersTest.js
+++ b/service/test/routes/public/usersTest.js
@@ -352,7 +352,7 @@ lab.experiment('Users', () => {
     }
 
     userOps.addUserPolicies = function (params, cb) {
-      expect(params).to.equal({ id: 1, organizationId: 'WONKA', policies: [ { id: 1 } ] })
+      expect(params).to.equal({ id: 1, organizationId: 'WONKA', policies: [1] })
       process.nextTick(() => {
         cb(null, expected)
       })


### PR DESCRIPTION
was passing objects instead of ids, and db query was therefore failing

note that I cannot run tests locally, please double check