### PR TITLE
Add better scoping by organization for team members / user policies handling

### DIFF
--- a/service/lib/config/index.js
+++ b/service/lib/config/index.js
@@ -1,6 +1,5 @@
 const Reconfig = require('reconfig')
 const AuthConfig = require('./config.auth')
-
 const Action = AuthConfig.Action
 const resources = AuthConfig.resources
 

--- a/service/lib/ops/teamOps.js
+++ b/service/lib/ops/teamOps.js
@@ -5,6 +5,7 @@ const db = require('./../db')
 const async = require('async')
 const policyOps = require('./policyOps')
 const userOps = require('./userOps')
+const utils = require('./utils')
 const SQL = require('./../db/SQL')
 const mapping = require('./../mapping')
 
@@ -18,8 +19,8 @@ function loadTeamDescendants (job, next) {
     org_id = ${job.organizationId}
     AND path @ ${job.teamId.toString()}`
   job.client.query(sql, (err, res) => {
-    if (err) return next(err)
-    if (res.rowCount === 0) return next(Boom.notFound())
+    if (err) return next(Boom.badImplementation(err))
+    if (res.rowCount === 0) return next(Boom.notFound(`No team with ${job.teamId} has been found`))
 
     job.teamIds = res.rows.map(getId)
     next()
@@ -48,7 +49,7 @@ function insertTeam (job, next) {
   sql.append(SQL`)RETURNING id`)
 
   job.client.query(sql, (err, res) => {
-    if (err) return next(err)
+    if (err) return next(Boom.badImplementation(err))
     job.team = res.rows[0]
     next()
   })
@@ -56,7 +57,7 @@ function insertTeam (job, next) {
 
 function createDefaultPolicies (job, next) {
   policyOps.createTeamDefaultPolicies(job.client, job.params.organizationId, job.team.id, (err, res) => {
-    if (err) return next(err)
+    if (err) return next(Boom.badImplementation(err))
     job.policyIds = res.rows.map(getId)
     next()
   })
@@ -68,7 +69,7 @@ function createDefaultUser (job, next) {
   const { organizationId } = job.params
 
   userOps.insertUser(job.client, { id, name, organizationId }, (err, user) => {
-    if (err) return next(err)
+    if (err) return next(Boom.badImplementation(err))
 
     job.user = user.rows[0]
     next()
@@ -78,7 +79,7 @@ function createDefaultUser (job, next) {
 function assignDefaultUserToTeam (job, next) {
   if (!job.user) return next()
 
-  job.client.query(SQL`INSERT INTO team_members (team_id, user_id) VALUES (${job.team.id}, ${job.user.id})`, next)
+  job.client.query(SQL`INSERT INTO team_members (team_id, user_id) VALUES (${job.team.id}, ${job.user.id})`, utils.boomErrorWrapper(next))
 }
 
 function makeDefaultUserAdmin (job, next) {
@@ -91,35 +92,37 @@ function makeDefaultUserAdmin (job, next) {
     sql.append(SQL`, (${userId},${policyId})`)
   })
 
-  job.client.query(sql, next)
+  job.client.query(sql, utils.boomErrorWrapper(next))
 }
 
 function removeTeams (job, next) {
-  job.client.query(SQL`DELETE FROM teams WHERE id = ANY (${job.teamIds})`, (err, result) => {
-    if (err) return next(err)
-    if (result.rowCount === 0) return next(Boom.notFound())
+  const { teamIds, organizationId } = job
+
+  job.client.query(SQL`DELETE FROM teams WHERE id = ANY (${teamIds}) AND org_id = ${organizationId}`, (err, result) => {
+    if (err) return next(Boom.badImplementation(err))
+    if (result.rowCount !== teamIds.length) return next(Boom.notFound('Could not find all teams to be deleted'))
     next()
   })
 }
 
 function deleteTeamsPolicies (job, next) {
-  job.client.query(SQL`DELETE FROM team_policies WHERE team_id = ANY(${job.teamIds})`, next)
+  job.client.query(SQL`DELETE FROM team_policies WHERE team_id = ANY(${job.teamIds})`, utils.boomErrorWrapper(next))
 }
 
 function deleteTeamsMembers (job, next) {
-  job.client.query(SQL`DELETE FROM team_members WHERE team_id = ANY(${job.teamIds})`, next)
+  job.client.query(SQL`DELETE FROM team_members WHERE team_id = ANY(${job.teamIds})`, utils.boomErrorWrapper(next))
 }
 
 function clearTeamPolicies (job, next) {
-  job.client.query(SQL`DELETE FROM team_policies WHERE team_id = ${job.teamId}`, next)
+  job.client.query(SQL`DELETE FROM team_policies WHERE team_id = ${job.teamId}`, utils.boomErrorWrapper(next))
 }
 
 function deleteTeamUsers (job, next) {
-  job.client.query(SQL`DELETE FROM team_members WHERE team_id = ${job.teamId}`, next)
+  job.client.query(SQL`DELETE FROM team_members WHERE team_id = ${job.teamId}`, utils.boomErrorWrapper(next))
 }
 
 function deleteTeamUser (job, next) {
-  job.client.query(SQL`DELETE FROM team_members WHERE team_id = ${job.teamId} AND user_id = ${job.userId}`, next)
+  job.client.query(SQL`DELETE FROM team_members WHERE team_id = ${job.teamId} AND user_id = ${job.userId}`, utils.boomErrorWrapper(next))
 }
 
 function insertTeamMembers (job, next) {
@@ -134,7 +137,7 @@ function insertTeamMembers (job, next) {
     sql.append(SQL`, (${userId},${teamId})`)
   })
   sql.append(SQL` ON CONFLICT ON CONSTRAINT team_member_link DO NOTHING`)
-  job.client.query(sql, next)
+  job.client.query(sql, utils.boomErrorWrapper(next))
 }
 
 function insertTeamPolicies (job, next) {
@@ -149,7 +152,7 @@ function insertTeamPolicies (job, next) {
     sql.append(SQL`, (${policyId},${teamId})`)
   })
   sql.append(SQL` ON CONFLICT ON CONSTRAINT team_policy_link DO NOTHING`)
-  job.client.query(sql, next)
+  job.client.query(sql, utils.boomErrorWrapper(next))
 }
 
 
@@ -158,7 +161,7 @@ function readDefaultPoliciesIds (job, next) {
 
   async.each(job.teamIds, (teamId, done) => {
     policyOps.readTeamDefaultPolicies(job.client, job.organizationId, teamId, function (err, res) {
-      if (err) return done(err)
+      if (err) return done(Boom.badImplementation(err))
       job.policies.push(...res.rows.map(getId))
       done()
     })
@@ -166,7 +169,7 @@ function readDefaultPoliciesIds (job, next) {
 }
 
 function deleteDefaultPolicies (job, next) {
-  policyOps.deleteAllPolicyByIds(job.client, job.policies, next)
+  policyOps.deleteAllPolicyByIds(job.client, job.policies, utils.boomErrorWrapper(next))
 }
 
 function moveTeamSql (job, next) {
@@ -184,7 +187,7 @@ function moveTeamSql (job, next) {
   sql.append(SQL`
     WHERE id = ${teamId}
   `)
-  job.client.query(sql, next)
+  job.client.query(sql, utils.boomErrorWrapper(next))
 }
 
 function moveTeamDescendants (job, next) {
@@ -196,7 +199,7 @@ function moveTeamDescendants (job, next) {
     AND id != ${teamId}
   `
 
-  job.client.query(sql, next)
+  job.client.query(sql, utils.boomErrorWrapper(next))
 }
 
 function removeTeamPolicy (job, next) {
@@ -207,7 +210,39 @@ function removeTeamPolicy (job, next) {
     WHERE team_id = ${teamId}
     AND policy_id = ${policyId}
   `
-  job.client.query(sqlQuery, next)
+  job.client.query(sqlQuery, utils.boomErrorWrapper(next))
+}
+
+function checkUsersOrg (job, cb) {
+  const { users } = job.params
+  const { organizationId } = job
+
+  job.client.query(SQL`SELECT id FROM users WHERE id = ANY (${users}) AND org_id = ${organizationId}`, (err, result) => {
+    if (err) {
+      return cb(Boom.badImplementation(err))
+    }
+
+    if (result.rowCount !== users.length) {
+      return cb(Boom.badRequest(`Some users [${users.join(',')}] were not found`))
+    }
+
+    cb()
+  })
+}
+
+function checkBothTeamsFromSameOrg (job, cb) {
+  const { id, parentId, organizationId } = job.params
+  const ids = [id]
+
+  if (parentId) ids.push(parentId)
+  const sql = SQL`SELECT id FROM teams WHERE id = ANY(${ids}) AND org_id = ${organizationId}`
+
+  job.client.query(sql, (err, result) => {
+    if (err) return cb(Boom.badImplementation(err))
+    if (result.rowCount !== ids.length) return cb(Boom.badRequest('Team or parent team was not found'))
+
+    cb()
+  })
 }
 
 function checkTeamExists (job, next) {
@@ -220,8 +255,8 @@ function checkTeamExists (job, next) {
     AND org_id = ${organizationId}
   `
   job.client.query(sqlQuery, (err, result) => {
-    if (err) return next(err)
-    if (result.rowCount === 0) return next(Boom.notFound())
+    if (err) return next(Boom.badImplementation(err))
+    if (result.rowCount === 0) return next(Boom.notFound(`Team with id ${teamId} could not be found`))
 
     next()
   })
@@ -245,7 +280,7 @@ var teamOps = {
       ORDER BY UPPER(name)
     `
     db.query(sqlQuery, function (err, result) {
-      if (err) return cb(Boom.badImplementation(err))
+      if (err) return cb(err)
 
       return cb(null, result.rows.map(mapping.team))
     })
@@ -282,7 +317,7 @@ var teamOps = {
     }
 
     db.withTransaction(tasks, (err, res) => {
-      if (err) return cb(Boom.badImplementation(err))
+      if (err) return cb(err)
 
       teamOps.readTeam({ id: res.team.id, organizationId: params.organizationId }, cb)
     })
@@ -307,8 +342,8 @@ var teamOps = {
       `
 
       db.query(sql, (err, result) => {
-        if (err) return next(err)
-        if (result.rowCount === 0) return next(Boom.notFound())
+        if (err) return next(Boom.badImplementation(err))
+        if (result.rowCount === 0) return next(Boom.notFound(`Team with id ${id} could not be found`))
 
         team = mapping.team(result.rows[0])
 
@@ -327,7 +362,7 @@ var teamOps = {
         ORDER BY UPPER(users.name)
       `
       db.query(sql, function (err, result) {
-        if (err) return next(err)
+        if (err) return next(Boom.badImplementation(err))
 
         team.users = result.rows.map(mapping.user.simple)
         next()
@@ -343,7 +378,7 @@ var teamOps = {
         ORDER BY UPPER(pol.name)
       `
       db.query(sql, function (err, result) {
-        if (err) return next(err)
+        if (err) return next(Boom.badImplementation(err))
 
         team.policies = result.rows.map(mapping.policy.simple)
         next()
@@ -351,7 +386,7 @@ var teamOps = {
     })
 
     async.series(tasks, (err) => {
-      if (err) return cb(err.isBoom ? err : Boom.badImplementation(err))
+      if (err) return cb(err)
 
       return cb(null, team)
     })
@@ -374,9 +409,10 @@ var teamOps = {
       AND org_id = ${organizationId}
     `)
 
+
     db.query(sql, (err, res) => {
-      if (err) return cb(err)
-      if (res.rowCount === 0) return cb(Boom.notFound())
+      if (err) return cb(Boom.badImplementation(err))
+      if (res.rowCount === 0) return cb(Boom.notFound(`Team with id ${id} could not be found`))
 
       teamOps.readTeam({ id, organizationId }, cb)
     })
@@ -402,11 +438,17 @@ var teamOps = {
       deleteDefaultPolicies,
       removeTeams
     ], (err) => {
-      if (err) return cb(err.isBoom ? err : Boom.badImplementation(err))
+      if (err) return cb(err)
       cb()
     })
   },
 
+  /**
+   * Nest/Un-nest a team
+   *
+   * @param  {Object}   params { id, parentId = null, organizationId }
+   * @param  {Function} cb
+   */
   moveTeam: function moveTeam (params, cb) {
     const { id, organizationId } = params
 
@@ -415,10 +457,11 @@ var teamOps = {
         job.params = params
         next()
       },
+      checkBothTeamsFromSameOrg,
       moveTeamSql,
       moveTeamDescendants
     ], (err) => {
-      if (err) return cb(err.isBoom ? err : Boom.badImplementation(err))
+      if (err) return cb(err)
 
       teamOps.readTeam({id, organizationId}, cb)
     })
@@ -445,9 +488,7 @@ var teamOps = {
     ]
 
     db.withTransaction(tasks, (err, res) => {
-      if (err) {
-        return cb(Boom.badImplementation(err))
-      }
+      if (err) return cb(err)
 
       teamOps.readTeam({ id, organizationId }, cb)
     })
@@ -463,9 +504,7 @@ var teamOps = {
     const { id, organizationId, policies } = params
 
     insertTeamPolicies({ client: db, teamId: id, policies }, (err, res) => {
-      if (err) {
-        return cb(Boom.badImplementation(err))
-      }
+      if (err) return cb(err)
 
       teamOps.readTeam({ id, organizationId }, cb)
     })
@@ -481,9 +520,7 @@ var teamOps = {
     const { id, organizationId } = params
 
     clearTeamPolicies({ teamId: id, client: db }, (err, res) => {
-      if (err) {
-        return cb(Boom.badImplementation(err))
-      }
+      if (err) return cb(err)
 
       teamOps.readTeam({ id, organizationId }, cb)
     })
@@ -499,9 +536,7 @@ var teamOps = {
     const { teamId, organizationId, policyId } = params
 
     removeTeamPolicy({ client: db, teamId, policyId }, (err, res) => {
-      if (err) {
-        return cb(Boom.badImplementation(err))
-      }
+      if (err) return cb(err)
 
       teamOps.readTeam({ id: teamId, organizationId }, cb)
     })
@@ -523,12 +558,13 @@ var teamOps = {
 
         next()
       },
+      checkUsersOrg,
       checkTeamExists,
       insertTeamMembers
     ]
 
     db.withTransaction(tasks, (err, res) => {
-      if (err) return cb(Boom.badImplementation(err))
+      if (err) return cb(err)
 
       teamOps.readTeam({ id, organizationId }, cb)
     })
@@ -550,13 +586,14 @@ var teamOps = {
 
         next()
       },
+      checkUsersOrg,
       checkTeamExists,
       deleteTeamUsers,
       insertTeamMembers
     ]
 
     db.withTransaction(tasks, (err, res) => {
-      if (err) return cb(Boom.badImplementation(err))
+      if (err) return cb(err)
 
       teamOps.readTeam({ id, organizationId }, cb)
     })
@@ -583,7 +620,7 @@ var teamOps = {
     ]
 
     db.withTransaction(tasks, (err, res) => {
-      if (err) return cb(Boom.badImplementation(err))
+      if (err) return cb(err)
 
       cb()
     })
@@ -610,7 +647,7 @@ var teamOps = {
     ]
 
     db.withTransaction(tasks, (err, res) => {
-      if (err) return cb(Boom.badImplementation(err))
+      if (err) return cb(err)
 
       cb()
     })

--- a/service/lib/ops/utils.js
+++ b/service/lib/ops/utils.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const Boom = require('boom')
+
+function boomErrorWrapper (next) {
+  return function wrapAsBadImplementation (err, result) {
+    next(err ? Boom.badImplementation(err) : null, result)
+  }
+}
+
+module.exports = {
+  boomErrorWrapper: boomErrorWrapper
+}

--- a/service/routes/public/teams.js
+++ b/service/routes/public/teams.js
@@ -391,8 +391,7 @@ exports.register = function (server, options, next) {
           action: Action.RemoveTeamPolicy,
           getParams: (request) => ({ teamId: request.params.id })
         }
-      },
-      response: {schema: swagger.Team}
+      }
     }
   })
 

--- a/service/test/endToEnd/usersTest.js
+++ b/service/test/endToEnd/usersTest.js
@@ -5,9 +5,11 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const utils = require('./../utils')
 const userOps = require('../../lib/ops/userOps')
+const organizationOps = require('../../lib/ops/organizationOps')
+const policyOps = require('../../lib/ops/policyOps')
 const server = require('./../../wiring-hapi')
 
-lab.experiment('Users', () => {
+lab.experiment('Users: read - delete - update', () => {
 
   lab.test('get user list', (done) => {
     const options = utils.requestOptions({
@@ -106,105 +108,9 @@ lab.experiment('Users', () => {
     })
   })
 
-  lab.test('add policies to a user', (done) => {
-    const options = utils.requestOptions({
-      method: 'PUT',
-      url: '/authorization/users/ModifyId/policies',
-      payload: {
-        policies: [1]
-      }
-    })
+})
 
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result.policies).to.equal([{
-        id: 1,
-        name: 'Director',
-        version: '0.1'
-      }])
-
-      userOps.deleteUserPolicies({ id: 'ModifyId', organizationId: 'WONKA' }, done)
-    })
-  })
-
-  lab.test('clear and replace policies for a user', (done) => {
-    const options = utils.requestOptions({
-      method: 'POST',
-      url: '/authorization/users/ModifyId/policies',
-      payload: {
-        policies: [1]
-      }
-    })
-
-    server.inject(options, (response) => {
-      const result = response.result
-
-      expect(response.statusCode).to.equal(200)
-      expect(result.policies).to.equal([{
-        id: 1,
-        name: 'Director',
-        version: '0.1'
-      }])
-
-      options.payload.policies = [2, 3]
-      server.inject(options, (response) => {
-        const result = response.result
-
-        expect(response.statusCode).to.equal(200)
-        expect(result.policies).to.equal([
-          {
-            id: 2,
-            name: 'Accountant',
-            version: '0.1'
-          },
-          {
-            id: 3,
-            name: 'Sys admin',
-            version: '0.1'
-          }
-        ])
-
-        userOps.deleteUserPolicies({ id: 'ModifyId', organizationId: 'WONKA' }, done)
-      })
-    })
-  })
-
-  lab.test('remove all user\'s policies', (done) => {
-    const options = utils.requestOptions({
-      method: 'DELETE',
-      url: '/authorization/users/ManyPoliciesId/policies'
-    })
-
-    server.inject(options, (response) => {
-      expect(response.statusCode).to.equal(204)
-      userOps.readUser({ id: 'ManyPoliciesId', organizationId: 'WONKA' }, (err, user) => {
-        expect(err).not.to.exist()
-        expect(user.policies).to.equal([])
-
-        userOps.replaceUserPolicies({ id: 'ManyPoliciesId', organizationId: 'WONKA', policies: [10, 11, 12, 13, 14] }, done)
-      })
-    })
-  })
-
-  lab.test('remove one user\'s policies', (done) => {
-    const options = utils.requestOptions({
-      method: 'DELETE',
-      url: '/authorization/users/ManyPoliciesId/policies/10'
-    })
-
-    server.inject(options, (response) => {
-      expect(response.statusCode).to.equal(204)
-      userOps.readUser({ id: 'ManyPoliciesId', organizationId: 'WONKA' }, (err, user) => {
-        expect(err).not.to.exist()
-        expect(user.policies.map(p => p.id)).to.equal([14, 13, 12, 11])
-
-        userOps.replaceUserPolicies({ id: 'ManyPoliciesId', organizationId: 'WONKA', policies: [10, 11, 12, 13, 14] }, done)
-      })
-    })
-  })
-
+lab.experiment('Users - create', () => {
   lab.test('create user for a non existent organization', (done) => {
     const options = utils.requestOptions({
       method: 'POST',
@@ -326,6 +232,165 @@ lab.experiment('Users', () => {
         error: 'Bad Request'
       })
 
+      done()
+    })
+  })
+})
+
+lab.experiment('Users - manage policies', () => {
+  lab.test('add policies to a user', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/users/ModifyId/policies',
+      payload: {
+        policies: [1]
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.policies).to.equal([{
+        id: 1,
+        name: 'Director',
+        version: '0.1'
+      }])
+
+      userOps.deleteUserPolicies({ id: 'ModifyId', organizationId: 'WONKA' }, done)
+    })
+  })
+
+  lab.test('clear and replace policies for a user', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users/ModifyId/policies',
+      payload: {
+        policies: [1]
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.policies).to.equal([{
+        id: 1,
+        name: 'Director',
+        version: '0.1'
+      }])
+
+      options.payload.policies = [2, 3]
+      server.inject(options, (response) => {
+        const result = response.result
+
+        expect(response.statusCode).to.equal(200)
+        expect(result.policies).to.equal([
+          {
+            id: 2,
+            name: 'Accountant',
+            version: '0.1'
+          },
+          {
+            id: 3,
+            name: 'Sys admin',
+            version: '0.1'
+          }
+        ])
+
+        userOps.deleteUserPolicies({ id: 'ModifyId', organizationId: 'WONKA' }, done)
+      })
+    })
+  })
+
+  lab.test('remove all user\'s policies', (done) => {
+    const options = utils.requestOptions({
+      method: 'DELETE',
+      url: '/authorization/users/ManyPoliciesId/policies'
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(204)
+      userOps.readUser({ id: 'ManyPoliciesId', organizationId: 'WONKA' }, (err, user) => {
+        expect(err).not.to.exist()
+        expect(user.policies).to.equal([])
+
+        userOps.replaceUserPolicies({ id: 'ManyPoliciesId', organizationId: 'WONKA', policies: [10, 11, 12, 13, 14] }, done)
+      })
+    })
+  })
+
+  lab.test('remove one user\'s policies', (done) => {
+    const options = utils.requestOptions({
+      method: 'DELETE',
+      url: '/authorization/users/ManyPoliciesId/policies/10'
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(204)
+      userOps.readUser({ id: 'ManyPoliciesId', organizationId: 'WONKA' }, (err, user) => {
+        expect(err).not.to.exist()
+        expect(user.policies.map(p => p.id)).to.equal([14, 13, 12, 11])
+
+        userOps.replaceUserPolicies({ id: 'ManyPoliciesId', organizationId: 'WONKA', policies: [10, 11, 12, 13, 14] }, done)
+      })
+    })
+  })
+})
+
+lab.experiment('Users - checking org_id scoping', () => {
+  let policyId
+
+  lab.before((done) => {
+    organizationOps.create({ id: 'NEWORG', name: 'new org', description: 'new org' }, (err, org) => {
+      if (err) return done(err)
+
+      const policyData = {
+        version: 1,
+        name: 'Documents Admin',
+        organizationId: 'NEWORG',
+        statements: '{"Statement":[{"Effect":"Allow","Action":["documents:Read"],"Resource":["wonka:documents:/public/*"]}]}'
+      }
+
+      policyOps.createPolicy(policyData, (err, policy) => {
+        if (err) return done(err)
+
+        policyId = policy.id
+        done()
+      })
+    })
+  })
+
+  lab.after((done) => {
+    organizationOps.deleteById('NEWORG', done)
+  })
+
+  lab.test('add policies from a different organization should not be allowed', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/users/ModifyId/policies',
+      payload: {
+        policies: [policyId]
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      done()
+    })
+  })
+
+  lab.test('replace policies from a different organization should not be allowed', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/users/ModifyId/policies',
+      payload: {
+        policies: [policyId]
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
       done()
     })
   })

--- a/service/test/lib/integration/teamOpsTest.js
+++ b/service/test/lib/integration/teamOpsTest.js
@@ -23,7 +23,7 @@ const updateData = {
   organizationId: 'WONKA'
 }
 const updateTeamMembersData = {
-  users: ['ROOTid', 'CharlieId'],
+  users: ['MikeId', 'CharlieId'],
   organizationId: 'WONKA'
 }
 
@@ -106,7 +106,7 @@ lab.experiment('TeamOps', () => {
 
   lab.test('Add twice the same user to a team', (done) => {
     updateData.id = testTeamId
-    updateData.users = ['ROOTid', 'ROOTid', 'CharlieId']
+    updateData.users = ['MikeId', 'MikeId', 'CharlieId']
 
     teamOps.updateTeam(updateData, (err, result) => {
       expect(err).to.not.exist()
@@ -307,7 +307,7 @@ lab.experiment('TeamOps', () => {
           teamOps.readTeam({ id: childId, organizationId: 'WONKA' }, (err) => {
             expect(err).to.exist()
             expect(err.isBoom).to.be.true()
-            expect(err.message).to.equal('Not Found')
+            expect(err.message).to.match(/Team with id [\d]+ could not be found/)
             done()
           })
         })


### PR DESCRIPTION
This PRs make sure that scoping is done in each query that needs it in teams and users operations.

It also adds :

* better handling for errors (some of them were forces to be 500 even if they were not).
* end-to-end tests for managing team policies and nest-unnest teams

Ref. issue #241 