### PR TITLE
Update branding to udaru everywhere

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,49 +1,49 @@
 ## 2.0.0 - March 6, 2017
 
 Features, enhancements, fixes:
--   **Breaking change**: replace LABS_AUTH_SERVICE with UDARU_SERVICE prefix to environment variables: [commit](https://github.com/nearform/labs-authorization/commit/08684b1384c24afc2ed89aea0a3d3ab1cffbf511)
--   Increase user.name field length, fix org_policies.org_id: [commit](https://github.com/nearform/labs-authorization/commit/17fee68ce15f4780dcd8e46bdeccecd55a592695)
--   Enhanced tests, documentation and examples: [commit](https://github.com/nearform/labs-authorization/commit/298194275f46b4cff18036eb847a03d3d10d5ce5) and [commit](https://github.com/nearform/labs-authorization/commit/f5651e03a6657d8a62b1631cc8e605e92a614e3d)
+-   **Breaking change**: replace LABS_AUTH_SERVICE with UDARU_SERVICE prefix to environment variables: [commit](https://github.com/nearform/udaru/commit/08684b1384c24afc2ed89aea0a3d3ab1cffbf511)
+-   Increase user.name field length, fix org_policies.org_id: [commit](https://github.com/nearform/udaru/commit/17fee68ce15f4780dcd8e46bdeccecd55a592695)
+-   Enhanced tests, documentation and examples: [commit](https://github.com/nearform/udaru/commit/298194275f46b4cff18036eb847a03d3d10d5ce5) and [commit](https://github.com/nearform/udaru/commit/f5651e03a6657d8a62b1631cc8e605e92a614e3d)
 
 ## 1.1.0 - Feb 23, 2017
 
 Features, enhancements:
--   Added two new users endpoints for replace/delete teams: [commit](https://github.com/nearform/labs-authorization/commit/c9ded2083b0340e1040ea72c997dd26cf38dc9b7)
--   Add 4 new organization policy management endpoints: [commit](https://github.com/nearform/labs-authorization/commit/0049b7003ec0d8a426e0476853f12a6e6b1aa103)
--   Remove dependency on iam-js (iam-js was a wrapper for pbac): [commit](https://github.com/nearform/labs-authorization/commit/04767e1c5a0197f6a1853ada535419086a599b19)
--   Authorization documentation: [commit](https://github.com/nearform/labs-authorization/commit/0b1dc34a9a88834f756a6e3938612f3bee1b9c00)
--   Sql injection automated tests and sqlmap automated tests: [commit](https://github.com/nearform/labs-authorization/commit/9e27cde1eded0de6a9170646b6972e4572786ca9)
--   Removed not used admin account: [commit](https://github.com/nearform/labs-authorization/commit/6ef0e78d167eaf82d791648d72a21c7ce51abe9c)
--   Skip dropping the db in production env: [commit](https://github.com/nearform/labs-authorization/commit/0da70a8a59db632296056a5ae9489b2dc8094c56)
--   Enhanced Joi validation, better error handling for existing IDs: [commit](https://github.com/nearform/labs-authorization/commit/689550f42dcef528aefce1b34ad90e1811843f63)
--   Enhanced organization and inherited policies tests: [commit](https://github.com/nearform/labs-authorization/commit/5ce64b5d6374e4342350d8bf000678ca1bf55815) and [commit](https://github.com/nearform/labs-authorization/commit/ffe991088ae2a759e95f719e50f1fade95a99635)
+-   Added two new users endpoints for replace/delete teams: [commit](https://github.com/nearform/udaru/commit/c9ded2083b0340e1040ea72c997dd26cf38dc9b7)
+-   Add 4 new organization policy management endpoints: [commit](https://github.com/nearform/udaru/commit/0049b7003ec0d8a426e0476853f12a6e6b1aa103)
+-   Remove dependency on iam-js (iam-js was a wrapper for pbac): [commit](https://github.com/nearform/udaru/commit/04767e1c5a0197f6a1853ada535419086a599b19)
+-   Authorization documentation: [commit](https://github.com/nearform/udaru/commit/0b1dc34a9a88834f756a6e3938612f3bee1b9c00)
+-   Sql injection automated tests and sqlmap automated tests: [commit](https://github.com/nearform/udaru/commit/9e27cde1eded0de6a9170646b6972e4572786ca9)
+-   Removed not used admin account: [commit](https://github.com/nearform/udaru/commit/6ef0e78d167eaf82d791648d72a21c7ce51abe9c)
+-   Skip dropping the db in production env: [commit](https://github.com/nearform/udaru/commit/0da70a8a59db632296056a5ae9489b2dc8094c56)
+-   Enhanced Joi validation, better error handling for existing IDs: [commit](https://github.com/nearform/udaru/commit/689550f42dcef528aefce1b34ad90e1811843f63)
+-   Enhanced organization and inherited policies tests: [commit](https://github.com/nearform/udaru/commit/5ce64b5d6374e4342350d8bf000678ca1bf55815) and [commit](https://github.com/nearform/udaru/commit/ffe991088ae2a759e95f719e50f1fade95a99635)
 
 Fixes:
--   Fixes invalid ID handling for user and policy: [commit](https://github.com/nearform/labs-authorization/commit/90579222060070f473531e2f51890c9e74fdc4d4)
+-   Fixes invalid ID handling for user and policy: [commit](https://github.com/nearform/udaru/commit/90579222060070f473531e2f51890c9e74fdc4d4)
 
 
 ## 1.0.1 - Jan 30, 2017
 
-Fix problem with postgrator migrations [commit](https://github.com/nearform/labs-authorization/commit/3a1b6b1fd4dba3430f440c799334c2bf5cdb57c0)
+Fix problem with postgrator migrations [commit](https://github.com/nearform/udaru/commit/3a1b6b1fd4dba3430f440c799334c2bf5cdb57c0)
 
 ## 1.0.0 - Jan 30, 2017
 
 **Features**:
--   Separate udaru in 3 parts: core, plugin and server [commit](https://github.com/nearform/labs-authorization/commit/d1625ddf91d3835aad6c70965ac4547346b886f3) , [commit](https://github.com/nearform/labs-authorization/commit/9651465df93dfd26522d6fe0d47dcba8ebee6eee) and [commit](https://github.com/nearform/labs-authorization/commit/a6e6aa257e188584388779278769412864baafad)
--   The `statements` parameter now is an object instead of a string [commit](https://github.com/nearform/labs-authorization/commit/d495050026fa85502216f472648ae9484db7cc13)
--   Organization id is now optional as all other ids [commit](https://github.com/nearform/labs-authorization/commit/611345ee1e3e56835f2de8cc309129bd077e751a)
--   Added pagination to all list endpoint [commit](https://github.com/nearform/labs-authorization/commit/b92081b4951d2aed5d3dff30c44a98e42ee19367) , [commit](https://github.com/nearform/labs-authorization/commit/8ae242e7f4eb48892924eee8e44e381cd26707e2) , [commit](https://github.com/nearform/labs-authorization/commit/8c62585859d8122339ea82d5e69e7c398b6b0e64) and [commit](https://github.com/nearform/labs-authorization/commit/611345ee1e3e56835f2de8cc309129bd077e751a) . An example for the response structure is [here](https://github.com/nearform/labs-authorization/blob/master/lib/plugin/swagger.js#L68)
--   Added migrations script with postgrator [commit](https://github.com/nearform/labs-authorization/commit/08abae12431e44a0ae730529a84d964364f04e45) and [commit](https://github.com/nearform/labs-authorization/commit/a948ff18b1bf5c54b9683589a01bc94edda14892)
--   Enanche documentation [commit](https://github.com/nearform/labs-authorization/commit/03462b3c4e6b8eaf22a6da7481d7504bf0e8e754)
--   Removed `api` and `component` folder, made the repo contain only the service app [commit](https://github.com/nearform/labs-authorization/commit/bfd95a073752b643f81ec419c1bde0d454fe40d5)
--   Added framework for authentications tests [commit](https://github.com/nearform/labs-authorization/commit/3f230b555ffdd7f1e1e6ccac44df41fac319ae7b) , [commit](https://github.com/nearform/labs-authorization/commit/62de6d8ab793e54eeace1a37766d8706302a783a) , [commit](https://github.com/nearform/labs-authorization/commit/9c0db2f885c61e31eab6ebd69de0c54de5df0d97) and [commit](https://github.com/nearform/labs-authorization/commit/8a35b0fd7cba4e65b30a96fde289f39dc7d243bc)
--   Make a single SQL file for fixtures [commit](https://github.com/nearform/labs-authorization/commit/a7e0948471f332592a43655fdd9adccea0438659)
--   Added bech test framework [commit](https://github.com/nearform/labs-authorization/commit/f6014dc7e4e0f391ee495c53ecb5b07c19bd30e7)
--   Added travis for CI [commit](https://github.com/nearform/labs-authorization/commit/3d6f33ecb67807f85254715f6a6807cbed2edf32)
--   Added MIT license [commit](https://github.com/nearform/labs-authorization/commit/d052645183dd9150f7f63ab5a5329da6749437ac)
+-   Separate udaru in 3 parts: core, plugin and server [commit](https://github.com/nearform/udaru/commit/d1625ddf91d3835aad6c70965ac4547346b886f3) , [commit](https://github.com/nearform/udaru/commit/9651465df93dfd26522d6fe0d47dcba8ebee6eee) and [commit](https://github.com/nearform/udaru/commit/a6e6aa257e188584388779278769412864baafad)
+-   The `statements` parameter now is an object instead of a string [commit](https://github.com/nearform/udaru/commit/d495050026fa85502216f472648ae9484db7cc13)
+-   Organization id is now optional as all other ids [commit](https://github.com/nearform/udaru/commit/611345ee1e3e56835f2de8cc309129bd077e751a)
+-   Added pagination to all list endpoint [commit](https://github.com/nearform/udaru/commit/b92081b4951d2aed5d3dff30c44a98e42ee19367) , [commit](https://github.com/nearform/udaru/commit/8ae242e7f4eb48892924eee8e44e381cd26707e2) , [commit](https://github.com/nearform/udaru/commit/8c62585859d8122339ea82d5e69e7c398b6b0e64) and [commit](https://github.com/nearform/udaru/commit/611345ee1e3e56835f2de8cc309129bd077e751a) . An example for the response structure is [here](https://github.com/nearform/udaru/blob/master/lib/plugin/swagger.js#L68)
+-   Added migrations script with postgrator [commit](https://github.com/nearform/udaru/commit/08abae12431e44a0ae730529a84d964364f04e45) and [commit](https://github.com/nearform/udaru/commit/a948ff18b1bf5c54b9683589a01bc94edda14892)
+-   Enanche documentation [commit](https://github.com/nearform/udaru/commit/03462b3c4e6b8eaf22a6da7481d7504bf0e8e754)
+-   Removed `api` and `component` folder, made the repo contain only the service app [commit](https://github.com/nearform/udaru/commit/bfd95a073752b643f81ec419c1bde0d454fe40d5)
+-   Added framework for authentications tests [commit](https://github.com/nearform/udaru/commit/3f230b555ffdd7f1e1e6ccac44df41fac319ae7b) , [commit](https://github.com/nearform/udaru/commit/62de6d8ab793e54eeace1a37766d8706302a783a) , [commit](https://github.com/nearform/udaru/commit/9c0db2f885c61e31eab6ebd69de0c54de5df0d97) and [commit](https://github.com/nearform/udaru/commit/8a35b0fd7cba4e65b30a96fde289f39dc7d243bc)
+-   Make a single SQL file for fixtures [commit](https://github.com/nearform/udaru/commit/a7e0948471f332592a43655fdd9adccea0438659)
+-   Added bech test framework [commit](https://github.com/nearform/udaru/commit/f6014dc7e4e0f391ee495c53ecb5b07c19bd30e7)
+-   Added travis for CI [commit](https://github.com/nearform/udaru/commit/3d6f33ecb67807f85254715f6a6807cbed2edf32)
+-   Added MIT license [commit](https://github.com/nearform/udaru/commit/d052645183dd9150f7f63ab5a5329da6749437ac)
 
 Fixes:
--   **Fix bug in query fetching user policies** [commit](https://github.com/nearform/labs-authorization/commit/ae23dfd516bb541c4ef2f7f5dfa6b574cb3e4f40)
--   Fixed bug on adding a team without id [commit](https://github.com/nearform/labs-authorization/commit/275f48bbe4088f180e3e13fd6ca81d7113f4f0b0)
--   Fixed bug on adding policies fro other organizations [commit](https://github.com/nearform/labs-authorization/commit/540587cf8e82600b61598b32f4dcd85300981f05)
--   Fixed scoping by policies [commit](https://github.com/nearform/labs-authorization/commit/3f64348ebea4fb536d0ab37d7d7672875c5cc405)
+-   **Fix bug in query fetching user policies** [commit](https://github.com/nearform/udaru/commit/ae23dfd516bb541c4ef2f7f5dfa6b574cb3e4f40)
+-   Fixed bug on adding a team without id [commit](https://github.com/nearform/udaru/commit/275f48bbe4088f180e3e13fd6ca81d7113f4f0b0)
+-   Fixed bug on adding policies fro other organizations [commit](https://github.com/nearform/udaru/commit/540587cf8e82600b61598b32f4dcd85300981f05)
+-   Fixed scoping by policies [commit](https://github.com/nearform/udaru/commit/3f64348ebea4fb536d0ab37d7d7672875c5cc405)

--- a/README.md
+++ b/README.md
@@ -254,10 +254,10 @@ See the [sqlmap][] repository for more details.
 ## License
 Copyright nearForm Ltd 2017. Licensed under [MIT][license].
 
-[config]: https://github.com/nearform/labs-authorization/blob/master/lib/core/config/index.js
+[config]: https://github.com/nearform/udaru/blob/master/lib/core/config/index.js
 [license]: ./LICENSE.md
 [postgrator]: https://github.com/rickbergfalk/postgrator
-[prefix-link]: https://github.com/nearform/labs-authorization/blob/master/lib/core/config.js#L100
+[prefix-link]: https://github.com/nearform/udaru/blob/master/lib/core/config.js#L100
 [reconfig]: https://github.com/namshi/reconfig
 [swagger-link]: http://localhost:8080/documentation
 [Udaru Introduction]: docs/authorization-introduction.md
@@ -266,12 +266,12 @@ Copyright nearForm Ltd 2017. Licensed under [MIT][license].
 [sqlmap]: https://github.com/sqlmapproject/sqlmap
 [sqlmap config]: ./security/fixtures/injection-endpoints.json
 
-[travis-badge]: https://travis-ci.org/nearform/labs-authorization.svg?branch=master
-[travis-url]: https://travis-ci.org/nearform/labs-authorization
-[npm-badge]: https://badge.fury.io/js/labs-authorization.svg
-[npm-url]: https://npmjs.org/package/labs-authorization
+[travis-badge]: https://travis-ci.org/nearform/udaru.svg?branch=master
+[travis-url]: https://travis-ci.org/nearform/udaru
+[npm-badge]: https://badge.fury.io/js/udaru.svg
+[npm-url]: https://npmjs.org/package/udaru
 
-[coveralls-badge]: https://coveralls.io/repos/nearform/labs-authorization/badge.svg?branch=master&service=github
-[coveralls-url]: https://coveralls.io/github/nearform/labs-authorization?branch=master
-[snyk-badge]: https://snyk.io/test/github/nearform/labs-authorization/badge.svg
-[snyk-url]: https://snyk.io/test/github/nearform/labs-authorization
+[coveralls-badge]: https://coveralls.io/repos/nearform/udaru/badge.svg?branch=master&service=github
+[coveralls-url]: https://coveralls.io/github/nearform/udaru?branch=master
+[snyk-badge]: https://snyk.io/test/github/nearform/udaru/badge.svg
+[snyk-url]: https://snyk.io/test/github/nearform/udaru

--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -15,5 +15,5 @@
 13. Choose the tag version and a title matching the release and publish.
 14. Notify core maintainers of the release via email.
 
-[Test]: https://travis-ci.org/nearform/labs-authorization
-[Releases]: https://github.com/nearform/labs-authorization/releases
+[Test]: https://travis-ci.org/nearform/udaru
+[Releases]: https://github.com/nearform/udaru/releases

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "Nicolas Herment (https://github.com/nherment)",
     "Salman Mitha (https://github.com/salmanm)"
   ],
-  "homepage": "https://github.com/nearform/labs-authorization#readme",
+  "homepage": "https://github.com/nearform/udaru#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/nearform/labs-authorization.git"
+    "url": "git+https://github.com/nearform/udaru.git"
   },
   "bugs": {
-    "url": "https://github.com/nearform/labs-authorization/issues"
+    "url": "https://github.com/nearform/udaru/issues"
   },
   "main": "lib/index.js",
   "engines": {

--- a/test/integration/endToEnd/authorization.test.js
+++ b/test/integration/endToEnd/authorization.test.js
@@ -65,7 +65,7 @@ lab.experiment('Authorization', () => {
     const options = utils.requestOptions({
       method: 'GET',
       // TO BE DISCUSSED: We need double slashes "//" if we use a "/" at the beginning of a resource in the policies
-      // @see https://github.com/nearform/labs-authorization/issues/198
+      // @see https://github.com/nearform/udaru/issues/198
       url: '/authorization/list/ManyPoliciesId//myapp/users/filippo'
     })
 


### PR DESCRIPTION
Some badges/url do not exist yet :

- https://coveralls.io/github/nearform/udaru?branch=master still point to a `404`