### PR TITLE
Added error handling for server startup 

### DIFF
--- a/lib/core/lib/mapping.js
+++ b/lib/core/lib/mapping.js
@@ -70,7 +70,7 @@ function mapTeamList (row) {
     description: row.description,
     path: row.path,
     organizationId: row.org_id,
-    usersCount: parseInt(row.users_count)
+    usersCount: parseInt(row.users_count, 10)
   }
 }
 

--- a/lib/core/lib/ops/teamOps.js
+++ b/lib/core/lib/ops/teamOps.js
@@ -256,7 +256,7 @@ function loadTeamUsers (job, next) {
   job.client.query(sql, function (err, result) {
     if (err) return next(Boom.badImplementation(err))
 
-    job.totalUsersCount = result.rowCount > 0 ? parseInt(result.rows[0].total_users_count) : 0
+    job.totalUsersCount = result.rowCount > 0 ? parseInt(result.rows[0].total_users_count, 10) : 0
     job.team.usersCount = result.rowCount
     job.team.users = result.rows.map(mapping.user.simple)
     next()

--- a/lib/server/start.js
+++ b/lib/server/start.js
@@ -1,6 +1,10 @@
 'use strict'
 
 const Server = require('./index')
-Server.start(() => {
+Server.start((err) => {
+  if (err) {
+    return console.log(`Failed to start server: ${err.message}`)
+  }
+
   console.log('Server started on: ' + Server.info.uri.toLowerCase())
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udaru",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A policy based authorization module",
   "license": "MIT",
   "author": "nearForm Ltd",


### PR DESCRIPTION
Hi, 

when i started udaru as service i got it crashing because another service was already running on default port `8080`. Unfortunately i didn't get any message on why udaru crashed. I've added a new  error handling while spinning up the server so that if that situation happen again you'll see something like this:

```
udaru git:(master) npm start

> udaru@2.0.1 start /Users/michele/Github/udaru
> node lib/server/start.js

Failed to start server: listen EADDRINUSE 127.0.0.1:8080
➜  udaru git:(master) ✗
```

I also fixed pending linting errors. 


