### PR TITLE
Add Script to generate static swagger API docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ docs/coverage.html
 sqlmap
 
 node_modules
+
+docs/udaru-swagger-site

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ script:
 
 after_script:
   - npm run coveralls
+  - npm run swagger-gen

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1106,6 +1106,26 @@
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=",
       "dev": true
     },
+    "fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "jsonfile": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+          "dev": true
+        }
+      }
+    },
     "fs.realpath": {
       "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
@@ -3918,6 +3938,20 @@
       "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
+    "swagger-gen": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-gen/-/swagger-gen-1.0.3.tgz",
+      "integrity": "sha512-p8H/F+ChSWVZC522XvNbrNQ0kjQ+DsWFThfE2VYYtwg2pPYceQRG3T7iVgijtRrQToqCeMzdPYlz5wgQ8CTuww==",
+      "dev": true,
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
     "swagger-methods": {
       "version": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.0.tgz",
       "integrity": "sha1-s5x3lX0wWmU1wKHgFQgRhbmdYfw="
@@ -3935,6 +3969,12 @@
     "swagger-schema-official": {
       "version": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
       "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
+    },
+    "swagger-ui-dist": {
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.0.18.tgz",
+      "integrity": "sha1-prD2dLlMYfrSs+fxKlQqQInKMxw=",
+      "dev": true
     },
     "table": {
       "version": "https://registry.npmjs.org/table/-/table-4.0.1.tgz",
@@ -4176,6 +4216,12 @@
     "unist-util-visit": {
       "version": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.1.1.tgz",
       "integrity": "sha1-6RejsTdlizNctEIMfaLnTZKOTpQ=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.0.tgz",
+      "integrity": "sha1-nrHEZR3rzGcMyU8adXYjMruWd3g=",
       "dev": true
     },
     "untildify": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "pg:migrate": "node database/migrate.js --version=3",
     "start": "node lib/server/start.js",
     "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 95",
-    "test:commit-check": "npm run doc:lint && npm run lint && npm run test"
+    "test:commit-check": "npm run doc:lint && npm run lint && npm run test",
+    "swagger-gen": "node scripts/getSwaggerJson.js | swagger-gen -d docs/udaru-swagger-site"
   },
   "remarkConfig": {
     "plugins": [
@@ -87,6 +88,7 @@
     "remark-cli": "^3.0.0",
     "remark-lint": "^6.0.0",
     "remark-preset-lint-recommended": "^2.0.0",
-    "standard": "^8.6.0"
+    "standard": "^8.6.0",
+    "swagger-gen": "^1.0.3"
   }
 }

--- a/scripts/getSwaggerJson.js
+++ b/scripts/getSwaggerJson.js
@@ -1,0 +1,31 @@
+const Server = require('../lib/server')
+const Joi = require('joi')
+
+const swaggerSchema = Joi.object({
+  swagger: Joi.string(),
+  host: Joi.string(),
+  basePath: Joi.string(),
+  schemes: Joi.array(),
+  info: Joi.object(),
+  tags: Joi.array(),
+  paths: Joi.object(),
+  definitions: Joi.object()
+})
+
+Server.start((err) => {
+  if (err) throw err
+  var requestOpts = {
+    method: 'GET',
+    url: `/swagger.json`
+  }
+  Server.inject(requestOpts, (response) => {
+    Joi.validate(response.result, swaggerSchema, {allowUnknown: true}, (err) => {
+      if (err) {
+        console.error('Error validating swagger definition', err)
+        process.exit(1)
+      }
+      console.log(JSON.stringify(response.result))
+      process.exit(0)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a new command `npm run swagger-gen`. The result is a static version of the swagger docs for Udaru placed in `docs/udaru-swagger-site`

I've also added this command to `travis.yml`

### How it works

There is a small script (`scripts/getSwaggerJson.js`) that spins up the Udaru server and injects a request to get the `swagger.json` file. The JSON is simply logged to stdout.

This JSON is then piped into a CLI tool I wrote called [swagger-gen](http://npm.im/swagger-gen).

The `npm run swagger-gen` command is simply running `node scripts/getSwaggerJson.js | swagger-gen -d docs/udaru-swagger-site`. The `-d` flag specifies the output destination.