### PR TITLE
hapi-swagger - group docs by tags

### DIFF
--- a/lib/server/index.js
+++ b/lib/server/index.js
@@ -17,6 +17,7 @@ server.connection({
 const swaggerOptions = {
   jsonEditor: true,
   reuseDefinitions: false,
+  grouping: 'tags',
   info: {
     title: 'Authorization API Documentation',
     version: packageJson.version


### PR DESCRIPTION
By default the Swagger definitions are grouped by path prefix e.g. `/cats` `/dogs`.

Every path except `/ping` in Udaru is prefixed with `/authorization` and the result is a giant unorganized list of paths shown in the image:

![](http://i.imgur.com/JdI3JIV.png)

This PR adds a tiny config change passed to `hapi-swagger` and the result of that is something like this:

![](http://i.imgur.com/soUD0GQ.png)

Now this does create duplication e.g. `/authorization/organizations` is listed under the `organizations` tag heading and it's also listed under the `service` tag heading. But really I find most of the tags are pretty useless so I propose we simplify the whole thing down, maybe to a maximum of two tags:

1. A tag that identifies the endpoint by function e.g. `organization` or `users` or `teams`
2. A tag that makes the distinction between public/private or admin/user oriented. @dberesford I can't remember the exact name you put on it but you should get the idea.

What do you think?