### PR TITLE
use --no-try-out option with swagger-gen

### DIFF
--- a/docs/swagger/index.html
+++ b/docs/swagger/index.html
@@ -27,6 +27,12 @@
       background: #fafafa;
     }
   </style>
+
+  <style>
+    .try-out {
+      display: none;
+    }
+  </style>
 </head>
 
 <body>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -27,13 +27,11 @@
     },
     "ajv": {
       "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.6.tgz",
-      "integrity": "sha1-lH6TBJeQlCsqLWCoKJsokk05+Yc=",
-      "dev": true
+      "integrity": "sha1-lH6TBJeQlCsqLWCoKJsokk05+Yc="
     },
     "ajv-keywords": {
       "version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-      "dev": true
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw="
     },
     "align-text": {
       "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -46,11 +44,6 @@
     "ammo": {
       "version": "https://registry.npmjs.org/ammo/-/ammo-2.0.3.tgz",
       "integrity": "sha1-kUu89lsEPtD1ioqdAZbiUOxR5qc="
-    },
-    "ansi": {
-      "version": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
-      "dev": true
     },
     "ansi-escapes": {
       "version": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
@@ -418,8 +411,7 @@
     },
     "co": {
       "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "code": {
       "version": "https://registry.npmjs.org/code/-/code-4.0.0.tgz",
@@ -1847,13 +1839,11 @@
     },
     "generate-function": {
       "version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
     },
     "generate-object-property": {
       "version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
     },
     "generic-pool": {
       "version": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.3.tgz",
@@ -2198,8 +2188,7 @@
     },
     "has-unicode": {
       "version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
     "hawk": {
       "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
@@ -2405,8 +2394,7 @@
     },
     "is-my-json-valid": {
       "version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM="
     },
     "is-natural-number": {
       "version": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.1.1.tgz",
@@ -2460,8 +2448,7 @@
     },
     "is-property": {
       "version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-      "dev": true
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-redirect": {
       "version": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
@@ -2501,11 +2488,6 @@
     "is-url": {
       "version": "https://registry.npmjs.org/is-url/-/is-url-1.2.2.tgz",
       "integrity": "sha1-SYkFpZO/R8wtnn9zg3K792lsfyY=",
-      "dev": true
-    },
-    "is-utf8": {
-      "version": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
       "dev": true
     },
     "is-valid-glob": {
@@ -2591,8 +2573,7 @@
     },
     "json-stable-stringify": {
       "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
     },
     "json-stringify-safe": {
       "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -2605,13 +2586,11 @@
     },
     "jsonify": {
       "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonpointer": {
       "version": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-      "dev": true
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk="
     },
     "jsprim": {
       "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
@@ -2797,21 +2776,6 @@
     "lodash.merge": {
       "version": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
       "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
-    },
-    "lodash.pad": {
-      "version": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
-      "dev": true
-    },
-    "lodash.padend": {
-      "version": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
-      "dev": true
-    },
-    "lodash.padstart": {
-      "version": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
-      "dev": true
     },
     "lodash.restparam": {
       "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
@@ -3281,13 +3245,11 @@
     },
     "pinkie": {
       "version": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
     },
     "pino": {
       "version": "https://registry.npmjs.org/pino/-/pino-3.4.0.tgz",
@@ -3717,8 +3679,7 @@
     },
     "slice-ansi": {
       "version": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
-      "dev": true
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
     },
     "sliced": {
       "version": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
@@ -3939,18 +3900,10 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
     },
     "swagger-gen": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/swagger-gen/-/swagger-gen-1.0.3.tgz",
-      "integrity": "sha512-p8H/F+ChSWVZC522XvNbrNQ0kjQ+DsWFThfE2VYYtwg2pPYceQRG3T7iVgijtRrQToqCeMzdPYlz5wgQ8CTuww==",
-      "dev": true,
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/swagger-gen/-/swagger-gen-1.1.3.tgz",
+      "integrity": "sha512-/5YCpBx8NeD6nMLWks2u1Ll9eult/qtL341rb5ldK5oexGRXHjbqikt1FoxE7JemXeWqyKjlO6QL89Rm/wCatQ==",
+      "dev": true
     },
     "swagger-methods": {
       "version": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "start": "node lib/server/start.js",
     "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 95",
     "test:commit-check": "npm run doc:lint && npm run lint && npm run test",
-    "swagger-gen": "node scripts/getSwaggerJson.js | swagger-gen -d docs/swagger"
+    "swagger-gen": "node scripts/getSwaggerJson.js | swagger-gen -d docs/swagger --no-try-out"
   },
   "remarkConfig": {
     "plugins": [
@@ -89,7 +89,7 @@
     "remark-lint": "^6.0.0",
     "remark-preset-lint-recommended": "^2.0.0",
     "standard": "^8.6.0",
-    "swagger-gen": "^1.0.3"
+    "swagger-gen": "^1.1.3"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
So I spent some time updating the [swagger-gen](http://npm.im/swagger-gen) module to have a new `--no-try-out` option. Which basically injects some extra CSS into the UI which stops the 'Try it out' buttons being rendered. This PR makes use of that new option and also updates the docs accordingly.

Example Screenshot: 

<img width="1449" alt="screen shot 2017-07-31 at 17 02 48" src="https://user-images.githubusercontent.com/8656188/28786853-6fcc69e8-7612-11e7-8128-32f20ccf9000.png">
