### PR TITLE
Fix Links that don't work in the docsify site

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ As the Postgresql docker container has its 5432 port forwarded on the local mach
 To access the database using the pgAdmin you have to fill in also the container IP beside the database names and access credentials. The container IP can be seen with `docker ps`.  Use IP 127.0.0.1 and use postgres as username/password to connect to database server.
 
 ### Migrations
-We use [`postgrator`][postgrator] for database migrations. You can find the sql files in the [`database/migrations`](/database/migrations) folder. To run the migrations manually:
+We use [`postgrator`][postgrator] for database migrations. You can find the sql files in the [`database/migrations`](https://github.com/nearform/udaru/tree/master/database/migrations) folder. To run the migrations manually:
 
 ```
 node database/migrate.js --version=<version>`
@@ -270,7 +270,7 @@ Copyright nearForm Ltd 2017. Licensed under [MIT][license].
 [Authorization Model]: docs/authmodel.md
 [SQL Injection]: docs/sqlinjection.md
 [sqlmap]: https://github.com/sqlmapproject/sqlmap
-[sqlmap config]: ./security/fixtures/injection-endpoints.json
+[sqlmap config]: https://github.com/nearform/udaru/blob/master/security/fixtures/injection-endpoints.json
 [docs-site]: https://nearform.github.io/udaru
 [swagger-docs-url]: https://nearform.github.io/udaru/swagger/
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,6 +21,7 @@
     homepage: 'https://raw.githubusercontent.com/nearform/udaru/master/README.md',
     alias: {
       '\/docs\/(.*)': '/$1', // supports regexp
+      '/./LICENSE': 'https://raw.githubusercontent.com/nearform/udaru/master/LICENSE.md'
     }
   }
 </script>


### PR DESCRIPTION
Because of the funny way docsify handles relative links within a repo, sometimes they get a little messed up. e.g. the docsify sees the relative link to `database/migrations` and tries to render a `database/migrations.md` file.

Also, because the README is in the root of the repo but docsify operates in the context of the `/docs` folder this causes some issues too. This PR changes some links in the README file to use absolute links instead.