### PR TITLE
Endpoint for listing allowed actions on Multiple Resources

### DIFF
--- a/bench/access.bench.js
+++ b/bench/access.bench.js
@@ -12,5 +12,30 @@ module.exports = [
         }
       }
     }
+  },
+  {
+    tag: 'GET authorization/list/{userId}/{resource}',
+    handler: () => {
+      return {
+        path: '/authorization/list/ROOTid/resource-a',
+        method: 'GET',
+        headers: {
+          authorization: 'ROOTid'
+        }
+      }
+    }
+  },
+  {
+    tag: 'GET authorization/list/{userId}',
+    handler: () => {
+      return {
+        path: '/authorization/list/ManyPoliciesId?resources=/myapp/users/filippo&resources=/myapp/documents/no_access&resources=/myapp/teams/foo&resources=/myapp/teams/foo1&resources=/myapp/teams/foo2&resources=/myapp/teams/foo3&resources=/myapp/teams/foo4&resources=/myapp/teams/foo5&resources=/myapp/teams/foo6&resources=/myapp/teams/foo7',
+        method: 'GET',
+        headers: {
+          authorization: 'ROOTid',
+          org: 'WONKA'
+        }
+      }
+    }
   }
 ]

--- a/docs/example.md
+++ b/docs/example.md
@@ -208,3 +208,82 @@ curl -X GET --header 'Accept: application/json' --header 'authorization: ROOTid'
 }
 ```
 
+Let's list the actions Alfred can perform on a number of resources. First we'll need to create some extra policies.
+
+*   Create a policy that allows the `Drive` action on the `batmobile`
+
+```bash
+curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'authorization: ROOTid' --header 'org: WayneManor' -d '{"id":"DriveBatmobile","name":"batmobile","version":"1","statements":{"Statement":[{"Effect":"Allow","Action":["drive"],"Resource":["/waynemanor/batmobile"],"Sid":"1","Condition":{}}]}}' 'http://localhost:8080/authorization/policies?sig=123456789'
+```
+
+*   Create a policy that explicitly denies the `login` action on the `batcomputer`
+
+```bash
+curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'authorization: ROOTid' --header 'org: WayneManor' -d '{"id":"DenyBatcomputer","name":"batcomputer","version":"1","statements":{"Statement":[{"Effect":"Deny","Action":["login"],"Resource":["/waynemanor/batcomputer"],"Sid":"1","Condition":{}}]}}' 'http://localhost:8080/authorization/policies?sig=123456789'
+```
+
+*   Associate these new policies with Alfred:
+
+```bash
+curl -X PUT --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'authorization: BruceWayne'  -d '{"policies":["DriveBatmobile", "DenyBatcomputer"]}' 'http://localhost:8080/authorization/users/Alfred/policies'
+```
+
+*   Once more, verify the policies are associated with Alfred:
+
+```bash
+curl -X GET --header 'Accept: application/json' --header 'authorization: BruceWayne'  'http://localhost:8080/authorization/users/Alfred'
+```
+
+```js
+{
+  "id": "Alfred",
+  "name": "Alfred the butler",
+  "organizationId": "WayneManor",
+  "teams": [],
+  "policies": [
+    {
+      "id": "AccessBatCave",
+      "name": "batcave",
+      "version": "1"
+    },
+    {
+      "id": "DenyBatcomputer",
+      "name": "batcomputer",
+      "version": "1"
+    },
+    {
+      "id": "DriveBatmobile",
+      "name": "batmobile",
+      "version": "1"
+    }
+  ]
+}
+```
+
+*   Now, let's list the actions Alfred can perform on the `batcave`, the `batmobile` and the `batcomputer` resources.
+
+```bash
+curl -X GET --header 'Accept: application/json' --header 'authorization: ROOTid' --header 'org: WayneManor' 'http://localhost:8080/authorization/list/Alfred?resources=/waynemanor/batcave&resources=/waynemanor/batmobile&resources=/waynemanor/batcomputer'
+```
+
+```js
+[
+  {
+    "resource": "/waynemanor/batcave",
+    "actions": [
+      "enter",
+      "exit"
+    ]
+  },
+  {
+    "resource": "/waynemanor/batmobile",
+    "actions": [
+      "drive"
+    ]
+  },
+  {
+    "resource": "/waynemanor/batcomputer",
+    "actions": []
+  }
+]
+```

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -101,6 +101,7 @@ A brief overview of the Authorization API calls are as follows, see the live [Sw
 |delete|/authorization/policies/{id}|Delete a policy|
 |put|/authorization/policies/{id}|Update a policy of the current user organization|
 |get|/authorization/list/{userId}/{resource*}|List all the actions a user can perform on a resource|
+|get|/authorization/list/{userId}|List all the actions a user can perform on a given list of resources|
 
 
 ## How the Authorization model works

--- a/lib/core/config/config.auth.js
+++ b/lib/core/config/config.auth.js
@@ -63,7 +63,8 @@ const Actions = {
 
   // authorization
   CheckAccess: 'authorization:authn:access',
-  ListActions: 'authorization:authn:actions'
+  ListActions: 'authorization:authn:actions',
+  ListActionsOnResources: 'authorization:authn:resources:actions'
 }
 
 module.exports = {

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -13,7 +13,8 @@ module.exports = {
 
   authorize: {
     isUserAuthorized: authorizeOps.isUserAuthorized,
-    listActions: authorizeOps.listAuthorizations
+    listActions: authorizeOps.listAuthorizations,
+    listAuthorizationsOnResources: authorizeOps.listAuthorizationsOnResources
   },
 
   organizations: {

--- a/lib/core/lib/ops/authorizeOps.js
+++ b/lib/core/lib/ops/authorizeOps.js
@@ -62,10 +62,31 @@ const authorize = {
     ], function (err, actions) {
       cb(err, { actions })
     })
+  },
+
+  /**
+   * List all user's actions on a given list of resources
+   *
+   * @param  {Object}   options { userId, resources }
+   * @param  {Function} cb
+   */
+  listAuthorizationsOnResources: function listAuthorizationsOnResources ({ userId, resources, organizationId }, cb) {
+    async.waterfall([
+      function validate (next) {
+        Joi.validate({ userId, resources, organizationId }, validationRules.listAuthorizationsOnResources, badRequestWrap(next))
+      },
+      function listPolicies (result, next) {
+        policyOps.listAllUserPolicies({ userId, organizationId }, badImplementationWrap(next))
+      },
+      function listAuthorizationsOnResources (policies, next) {
+        iam(policies).actionsOnResources({ resources }, badImplementationWrap(next))
+      }
+    ], cb)
   }
 }
 
 authorize.isUserAuthorized.validate = validationRules.isUserAuthorized
 authorize.listAuthorizations.validate = validationRules.listAuthorizations
+authorize.listAuthorizationsOnResources.validate = validationRules.listAuthorizationsOnResources
 
 module.exports = authorize

--- a/lib/core/lib/ops/authorizeOps.js
+++ b/lib/core/lib/ops/authorizeOps.js
@@ -35,7 +35,7 @@ const authorize = {
         policyOps.listAllUserPolicies({ userId, organizationId }, badImplementationWrap(next))
       },
       function check (policies, next) {
-        iam(policies).isAuthorized({ resource, action }, badImplementationWrap(next))
+        next(null, iam(policies).isAuthorized({ resource, action }))
       }
     ], function (err, access) {
       cb(err, { access })

--- a/lib/core/lib/ops/iam.js
+++ b/lib/core/lib/ops/iam.js
@@ -7,7 +7,7 @@ module.exports = function (policies) {
   const pbac = new PBAC(policies)
 
   function isAuthorized (params, done) {
-    return done(null, pbac.evaluate(params))
+    return pbac.evaluate(params)
   }
 
   function actions ({ resource }, done) {
@@ -21,10 +21,9 @@ module.exports = function (policies) {
           statement.Resource.forEach((r) => {
             if (pbac.conditions.StringLike(r, resource)) {
               statement.Action.forEach((action) => {
-                isAuthorized({ resource, action }, (err, access) => {
-                  if (err) return
-                  if (access) actions.push(action)
-                })
+                if (isAuthorized({resource, action})) {
+                  actions.push(action)
+                }
               })
             }
           })
@@ -57,10 +56,9 @@ module.exports = function (policies) {
             statement.Resource.forEach((r) => {
               if (pbac.conditions.StringLike(r, resource)) {
                 statement.Action.forEach((action) => {
-                  isAuthorized({resource, action}, (err, access) => {
-                    if (err) return
-                    if (access) resultMap[resource].push(action)
-                  })
+                  if (isAuthorized({resource, action})) {
+                    resultMap[resource].push(action)
+                  }
                 })
               }
             })

--- a/lib/core/lib/ops/iam.js
+++ b/lib/core/lib/ops/iam.js
@@ -42,8 +42,48 @@ module.exports = function (policies) {
     }
   }
 
+  function actionsOnResources ({ resources }, done) {
+    try {
+      const resultMap = {}
+
+      const statements = _(policies).reduce((statements, policy) => {
+        return _.concat(statements, policy.Statement)
+      }, [])
+
+      resources.forEach((resource) => {
+        resultMap[resource] = []
+        statements.forEach((statement) => {
+          if (statement.Effect === 'Allow') {
+            statement.Resource.forEach((r) => {
+              if (pbac.conditions.StringLike(r, resource)) {
+                statement.Action.forEach((action) => {
+                  isAuthorized({resource, action}, (err, access) => {
+                    if (err) return
+                    if (access) resultMap[resource].push(action)
+                  })
+                })
+              }
+            })
+          }
+        })
+        resultMap[resource] = _.uniq(resultMap[resource])
+      })
+
+      let result = _(resultMap)
+        .reduce((result, actions, resource) => {
+          result.push({resource, actions})
+          return result
+        }, [])
+
+      return done(null, result)
+    } catch (e) {
+      return done(e)
+    }
+  }
+
   return {
     isAuthorized: isAuthorized,
-    actions: actions
+    actions: actions,
+    actionsOnResources: actionsOnResources
   }
 }

--- a/lib/core/lib/ops/validation.js
+++ b/lib/core/lib/ops/validation.js
@@ -30,6 +30,7 @@ const validationRules = {
   users: Joi.array().required().items(requiredString).description('User IDs'),
   policies: Joi.array().required().items(requiredString).description('Policies IDs'),
   teams: Joi.array().required().items(requiredString).description('Teams IDs'),
+  resources: Joi.array().max(10).items(requiredString.description('A single resource')).single().required().description('A list of Resources'),
 
   statements: Joi.object({
     Statement: Joi.array().items(Joi.object({
@@ -251,6 +252,11 @@ const authorize = {
   listAuthorizations: {
     userId: validationRules.userId,
     resource: requiredString.description('The resource that the user wants to perform the action on'),
+    organizationId: validationRules.organizationId
+  },
+  listAuthorizationsOnResources: {
+    userId: validationRules.userId,
+    resources: validationRules.resources,
     organizationId: validationRules.organizationId
   }
 }

--- a/lib/plugin/routes/public/authorization.js
+++ b/lib/plugin/routes/public/authorization.js
@@ -75,6 +75,40 @@ exports.register = function (server, options, next) {
     }
   })
 
+  server.route({
+    method: 'GET',
+    path: '/authorization/list/{userId}',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const { userId } = request.params
+      const { resources } = request.query
+      const params = {
+        userId,
+        resources,
+        organizationId
+      }
+
+      udaru.authorize.listAuthorizationsOnResources(params, reply)
+    },
+    config: {
+      plugins: {
+        auth: {
+          action: Action.ListActionsOnResources,
+          resource: 'authorization/actions/resources'
+        }
+      },
+      validate: {
+        params: _.pick(udaru.authorize.listAuthorizationsOnResources.validate, ['userId']),
+        query: _.pick(udaru.authorize.listAuthorizationsOnResources.validate, ['resources']),
+        headers
+      },
+      description: 'List all the actions a user can perform on a list of resources',
+      notes: 'The GET /authorization/list/{userId} endpoint returns a list of all the actions a user\ncan perform on a given list of resources.\n',
+      tags: ['api', 'authorization'],
+      response: {schema: swagger.UserActionsOnResources}
+    }
+  })
+
   next()
 }
 

--- a/lib/plugin/swagger.js
+++ b/lib/plugin/swagger.js
@@ -83,10 +83,16 @@ const UserActions = Joi.object({
   actions: Joi.array().items(Joi.string())
 }).label('UserActions')
 
+const UserActionsOnResources = Joi.array().items(Joi.object({
+  resource: Joi.string(),
+  actions: Joi.array().items(Joi.string())
+})).label('UserActionsOnResources')
+
 module.exports = {
   List,
   User,
   UserActions,
+  UserActionsOnResources,
   Team,
   Policy,
   PolicyRef,

--- a/test/integration/authorization/authorization.test.js
+++ b/test/integration/authorization/authorization.test.js
@@ -108,5 +108,48 @@ lab.experiment('Routes Authorizations', () => {
         }])
         .shouldRespond(403)
     })
+
+    lab.experiment('GET /authorization/list/{userId}', () => {
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'GET',
+          url: '/authorization/list/ModifyId?resources=not/my/resource',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with correct policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:authn:resources:actions'],
+          Resource: ['authorization/actions/resources']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:authn:dummy'],
+          Resource: ['authorization/actions']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:authn:actions:resources'],
+          Resource: ['authorization/dummy']
+        }])
+        .shouldRespond(403)
+    })
   })
 })

--- a/test/integration/endToEnd/authorization.test.js
+++ b/test/integration/endToEnd/authorization.test.js
@@ -78,4 +78,30 @@ lab.experiment('Authorization', () => {
       done()
     })
   })
+
+  lab.test('list authorizations should return actions allowed for the user', (done) => {
+    const actionList = [
+      {
+        resource: '/myapp/users/filippo',
+        actions: ['Read']
+      },
+      {
+        resource: '/myapp/documents/no_access',
+        actions: []
+      }
+    ]
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/list/ManyPoliciesId?resources=/myapp/users/filippo&resources=/myapp/documents/no_access'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal(actionList)
+
+      done()
+    })
+  })
 })

--- a/test/unit/iam/actions.test.js
+++ b/test/unit/iam/actions.test.js
@@ -13,7 +13,8 @@ lab.describe('actions function', () => {
       Statement: [
         {
           Effect: 'Allow',
-          Action: ['foo:bar:clone',
+          Action: [
+            'foo:bar:clone',
             'foo:bar:delete',
             'foo:bar:list',
             'foo:bar:read',
@@ -21,9 +22,48 @@ lab.describe('actions function', () => {
           Resource: ['resources/thing1/*']
         },
         {
+          Effect: 'Allow',
+          Action: [
+            'foo:bar:clone',
+            'foo:bar:list',
+            'foo:bar:read'],
+          Resource: ['resources/duplicatething']
+        },
+        {
+          Effect: 'Allow',
+          Action: [
+            'foo:bar:clone',
+            'foo:bar:list',
+            'foo:bar:read',
+            'foo:bar:delete'],
+          Resource: ['resources/duplicatething']
+        },
+        {
+          Effect: 'Allow',
+          Action: [
+            'foo:bar:clone',
+            'foo:bar:list',
+            'foo:bar:read',
+            'foo:bar:publish'],
+          Resource: ['resources/thing2/*']
+        },
+        {
           Effect: 'Deny',
           Action: ['foo:bar:*'],
           Resource: ['resources/nothing/*']
+        },
+        {
+          Effect: 'Allow',
+          Action: [
+            'foo:bar:publish',
+            'foo:bar:read'
+          ],
+          Resource: ['resources/thing3']
+        },
+        {
+          Effect: 'Deny',
+          Action: ['foo:bar:publish'],
+          Resource: ['resources/thing3']
         }
       ]
     },
@@ -103,5 +143,117 @@ lab.describe('actions function', () => {
 
       done()
     })
+  })
+
+  lab.test('should list actions for a list of mutiple resources', done => {
+    iam.actionsOnResources({ resources: ['resources/thing1/something', 'resources/thing2/something'] }, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.equal([
+        {
+          resource: 'resources/thing1/something',
+          actions: [
+            'foo:bar:clone',
+            'foo:bar:delete',
+            'foo:bar:list',
+            'foo:bar:read',
+            'foo:bar:publish'
+          ]
+        },
+        {
+          resource: 'resources/thing2/something',
+          actions: [
+            'foo:bar:clone',
+            'foo:bar:list',
+            'foo:bar:read',
+            'foo:bar:publish'
+          ]
+        }
+      ])
+
+      done()
+    })
+  })
+
+  lab.test('should list actions for multiple resources including resources defined in multiple policies', done => {
+    iam.actionsOnResources({ resources: ['resources/thing1/something', 'resources/multi/something'] }, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.equal([
+        {
+          resource: 'resources/thing1/something',
+          actions: [
+            'foo:bar:clone',
+            'foo:bar:delete',
+            'foo:bar:list',
+            'foo:bar:read',
+            'foo:bar:publish'
+          ]
+        },
+        {
+          resource: 'resources/multi/something',
+          actions: [
+            'foo:baz:clone',
+            'foo:baz:delete',
+            'foo:baz:list',
+            'foo:baz:read',
+            'foo:baz:publish',
+            'foo:bar:clone',
+            'foo:bar:delete',
+            'foo:bar:list',
+            'foo:bar:read',
+            'foo:bar:publish'
+          ]
+        }
+      ])
+
+      done()
+    })
+  })
+
+  lab.test('should not return duplicate actions on resources that are defined in multiple policies', done => {
+    iam.actionsOnResources({ resources: ['resources/duplicatething', 'resources/multi/something'] }, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.equal([
+        {
+          resource: 'resources/duplicatething',
+          actions: [
+            'foo:bar:clone',
+            'foo:bar:list',
+            'foo:bar:read',
+            'foo:bar:delete'
+          ]
+        },
+        {
+          resource: 'resources/multi/something',
+          actions: [
+            'foo:baz:clone',
+            'foo:baz:delete',
+            'foo:baz:list',
+            'foo:baz:read',
+            'foo:baz:publish',
+            'foo:bar:clone',
+            'foo:bar:delete',
+            'foo:bar:list',
+            'foo:bar:read',
+            'foo:bar:publish'
+          ]
+        }
+      ])
+    })
+    done()
+  })
+
+  lab.test('Should maintain that Deny statements take precedence over Allow ', done => {
+    iam.actionsOnResources({ resources: ['resources/thing3'] }, (err, result) => {
+      expect(err).to.not.exist()
+      expect(result).to.equal([
+        {
+          resource: 'resources/thing3',
+          actions: [
+            'foo:bar:read'
+          ]
+        }
+      ])
+    })
+    done()
   })
 })

--- a/test/unit/iam/basic.test.js
+++ b/test/unit/iam/basic.test.js
@@ -20,20 +20,14 @@ lab.describe('Basic access tests', () => {
   let iam = Iam(policies)
 
   lab.test('should allow', done => {
-    iam.isAuthorized({ resource: 'resources/thing1/something', action: 'foo:bar:list' }, (err, result) => {
-      expect(err).to.not.exist()
-      expect(result).to.be.true()
-
-      done()
-    })
+    let access = iam.isAuthorized({ resource: 'resources/thing1/something', action: 'foo:bar:list' })
+    expect(access).to.be.true()
+    done()
   })
 
   lab.test('should not allow', done => {
-    iam.isAuthorized({ resource: 'resources/thing2', action: 'foo:bar:list' }, (err, result) => {
-      expect(err).to.not.exist()
-      expect(result).to.be.false()
-
-      done()
-    })
+    let access = iam.isAuthorized({ resource: 'resources/thing2', action: 'foo:bar:list' })
+    expect(access).to.be.false()
+    done()
   })
 })

--- a/test/unit/iam/ownership.test.js
+++ b/test/unit/iam/ownership.test.js
@@ -21,20 +21,14 @@ lab.describe('Ownership', () => {
   let iam = Iam(policies)
 
   lab.test('should allow', done => {
-    iam.isAuthorized({ resource: 'resources/bob/something', action: 'foo:bar:list', variables: { req: { UserName: 'bob' } } }, (err, result) => {
-      expect(err).to.not.exist()
-      expect(result).to.be.true()
-
-      done()
-    })
+    let access = iam.isAuthorized({ resource: 'resources/bob/something', action: 'foo:bar:list', variables: { req: { UserName: 'bob' } } })
+    expect(access).to.be.true()
+    done()
   })
 
   lab.test('should not allow', done => {
-    iam.isAuthorized({ resource: 'resources/fred/anotherthing', action: 'foo:bar:list' }, (err, result) => {
-      expect(err).to.not.exist()
-      expect(result).to.be.false()
-
-      done()
-    })
+    let access = iam.isAuthorized({ resource: 'resources/fred/anotherthing', action: 'foo:bar:list' })
+    expect(access).to.be.false()
+    done()
   })
 })

--- a/test/unit/routes/public/authorization.test.js
+++ b/test/unit/routes/public/authorization.test.js
@@ -67,4 +67,28 @@ lab.experiment('Authorization', () => {
       done()
     })
   })
+
+  lab.test.skip('list authorizations for resources should return 500 for error case', (done) => {
+    udaru.authorize = {
+      listAuthorizationsOnResources: (params, cb) => {
+        process.nextTick(() => {
+          cb(Boom.badImplementation())
+        })
+      }
+    }
+
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/list/1/?resources=resource_a'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(500)
+      expect(result).to.be.undefined
+
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This new endpoint allows us to list the actions a user can perform on a list of resources

### Summary
When calling, the endpoint looks like this:

```
GET /authorization/list/some-user-id?resources=foo&resources=bar&resources=baz
```

which will return a list like this:

```
 [
  {
    resource: 'foo',
    actions: ['Read']
  },
  {
    resource: 'bar',
    actions: ['*']
  },
  {
    resource: 'baz',
    actions: []
  }
]
```

__Small Note on Validation__
The endpoint will still work if only one resource is passed in the querystring.

The Joi schema for resources uses ['Array.single()`](https://github.com/hapijs/joi/blob/v10.6.0/API.md#arraysingleenabled) which will optionally accept a single value and put it in an array. e.g.

```
GET /authorization/list/some-user-id?resources=foo
```

will result in `request.query.resources === ['foo']`

### How to Test

Assuming a fresh install, load in the test data with

```
npm run pg:init-test-db
```

and then we can test the endpoint using some of the data inserted by the `fixtures.sql` script with the following:

```
curl -X GET --header 'Accept: application/json' --header 'authorization: ROOTid' --header 'org: WONKA' 'http://localhost:8080/authorization/list/ManyPoliciesId?resources=/myapp/users/dara&resources=/myapp/documents/no_access&resources=/myapp/teams/*'
```

which will give back:

```
[
  {
    "resource": "/myapp/users/dara",
    "actions": [
      "Read"
    ]
  },
  {
    "resource": "/myapp/documents/no_access",
    "actions": []
  },
  {
    "resource": "/myapp/teams/*",
    "actions": [
      "Read",
      "Delete",
      "Edit"
    ]
  }
]
```

