### PR TITLE
Remove core instance dependency at plugin level

### DIFF
--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -9,17 +9,15 @@ const buildDb = require('./lib/db')
 const buildConfig = require('../config')
 const defaultConfig = require('../config/default.core')
 
-function buildUdaruCore (options) {
-  options = options || {}
+function buildUdaruCore (dbPool, config) {
+  const fullConfig = buildConfig(defaultConfig, config || {})
+  const db = buildDb(dbPool, fullConfig)
 
-  const config = buildConfig(defaultConfig, options.config || {})
-  const db = buildDb(options.dbPool, config)
-
-  const userOps = buildUserOps(db, config)
-  const organizationOps = buildOrganizationOps(db, config)
-  const authorizeOps = buildAuthorizeOps(db, config)
-  const teamOps = buildTeamOps(db, config)
-  const policyOps = buildPolicyOps(db, config)
+  const userOps = buildUserOps(db, fullConfig)
+  const organizationOps = buildOrganizationOps(db, fullConfig)
+  const authorizeOps = buildAuthorizeOps(db, fullConfig)
+  const teamOps = buildTeamOps(db, fullConfig)
+  const policyOps = buildPolicyOps(db, fullConfig)
 
   return {
     config,

--- a/lib/core/lib/db/index.js
+++ b/lib/core/lib/db/index.js
@@ -58,9 +58,12 @@ function TransactionClient (client) {
 }
 
 function buildDb (pool, config) {
+  let releasePool = false
+
   if (!pool) {
     /** @see https://github.com/brianc/node-pg-pool#a-note-on-instances */
     pool = new pg.Pool(config.get('pgdb'))
+    releasePool = true
     pool.on('error', function (err, client) {
       // if an error is encountered by a client while it sits idle in the pool
       // the pool itself will emit an error event with both the error and
@@ -95,6 +98,10 @@ function buildDb (pool, config) {
   }
 
   function shutdown (cb) {
+    if (!releasePool) {
+      return cb()
+    }
+
     pool.connect(function (err, client, done) {
       if (err) return cb(err)
       client.query('SELECT now()', function (err, result) {

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -11,7 +11,12 @@ const defaultConfigCore = require('../config/default.core')
 
 function register (server, options, next) {
   const config = buildConfig(defaultConfigCore, defaultConfig, options.config || {})
+  const { decorateUdaruCore = true } = options
   const udaru = buildUdaru(options.dbPool, config)
+  if (decorateUdaruCore) {
+    server.decorate('request', 'udaruCore', udaru)
+  }
+  server.decorate('server', 'udaruConfig', config)
 
   const authorization = buildAuthorization(udaru, config)
   const HapiAuthService = buildHapiAuthService(udaru, config, authorization)
@@ -20,7 +25,7 @@ function register (server, options, next) {
   server.register(
     [
       {
-        register: require('./routes/public/users')(udaru, config)
+        register: require('./routes/public/users')
       },
       {
         register: require('./routes/public/policies')(udaru, config)

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -11,7 +11,7 @@ const defaultConfigCore = require('../config/default.core')
 
 function register (server, options, next) {
   const config = buildConfig(defaultConfigCore, defaultConfig, options.config || {})
-  const { decorateUdaruCore = true } = options
+  const { decorateUdaruCore = true } = config
   const udaru = buildUdaru(options.dbPool, config)
   if (decorateUdaruCore) {
     server.decorate('request', 'udaruCore', udaru)

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -18,9 +18,9 @@ function register (server, options, next) {
   }
   server.decorate('server', 'udaruConfig', config)
 
-  const authorization = buildAuthorization(udaru, config)
-  const HapiAuthService = buildHapiAuthService(udaru, config, authorization)
-  const authValidation = buildAuthValidation(udaru, config, authorization)
+  const authorization = buildAuthorization(config)
+  const HapiAuthService = buildHapiAuthService(authorization)
+  const authValidation = buildAuthValidation(authorization)
 
   server.register(
     [

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -28,22 +28,22 @@ function register (server, options, next) {
         register: require('./routes/public/users')
       },
       {
-        register: require('./routes/public/policies')(udaru, config)
+        register: require('./routes/public/policies')
       },
       {
-        register: require('./routes/public/teams')(udaru, config)
+        register: require('./routes/public/teams')
       },
       {
-        register: require('./routes/public/authorization')(udaru, config)
+        register: require('./routes/public/authorization')
       },
       {
-        register: require('./routes/public/organizations')(udaru, config)
+        register: require('./routes/public/organizations')
       },
       {
-        register: require('./routes/public/monitor')(udaru, config)
+        register: require('./routes/public/monitor')
       },
       {
-        register: require('./routes/private/policies')(udaru, config)
+        register: require('./routes/private/policies')
       },
       HapiAuthService
     ],

--- a/lib/plugin/routes/private/policies.js
+++ b/lib/plugin/routes/private/policies.js
@@ -6,6 +6,7 @@ const Boom = require('boom')
 const buildServiceKey = require('./../../security/serviceKey')
 const swagger = require('./../../swagger')
 const headers = require('./../headers')
+const validation = require('../../../core/lib/ops/validation').policies
 
 function buildPolicies (udaru, config) {
   function register (server, options, next) {
@@ -39,7 +40,7 @@ function buildPolicies (udaru, config) {
       },
       config: {
         validate: {
-          payload: _.pick(udaru.policies.create.validate, ['id', 'name', 'version', 'statements']),
+          payload: _.pick(validation.createPolicy, ['id', 'name', 'version', 'statements']),
           query: {
             sig: Joi.string().required()
           },
@@ -79,8 +80,8 @@ function buildPolicies (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.policies.update.validate, ['id']),
-          payload: _.pick(udaru.policies.update.validate, ['version', 'name', 'statements']),
+          params: _.pick(validation.updatePolicy, ['id']),
+          payload: _.pick(validation.updatePolicy, ['version', 'name', 'statements']),
           query: {
             sig: Joi.string().required()
           },
@@ -118,7 +119,7 @@ function buildPolicies (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.policies.delete.validate, ['id']),
+          params: _.pick(validation.deletePolicy, ['id']),
           query: {
             sig: Joi.string().required()
           },

--- a/lib/plugin/routes/private/policies.js
+++ b/lib/plugin/routes/private/policies.js
@@ -8,144 +8,138 @@ const swagger = require('./../../swagger')
 const headers = require('./../headers')
 const validation = require('../../../core/lib/ops/validation').policies
 
-function buildPolicies (udaru, config) {
-  function register (server, options, next) {
-    const serviceKey = buildServiceKey(config)
-    const Action = config.get('AuthConfig.Action')
+exports.register = function (server, options, next) {
+  const serviceKey = buildServiceKey(server.udaruConfig)
+  const Action = server.udaruConfig.get('AuthConfig.Action')
 
-    server.route({
-      method: 'POST',
-      path: '/authorization/policies',
-      handler: function (request, reply) {
-        if (!serviceKey.hasValidServiceKey(request)) return reply(Boom.forbidden())
+  server.route({
+    method: 'POST',
+    path: '/authorization/policies',
+    handler: function (request, reply) {
+      if (!serviceKey.hasValidServiceKey(request)) return reply(Boom.forbidden())
 
-        const { id, version, name, statements } = request.payload
-        const { organizationId } = request.udaru
+      const { id, version, name, statements } = request.payload
+      const { organizationId } = request.udaru
 
-        const params = {
-          id,
-          version,
-          name,
-          organizationId,
-          statements
+      const params = {
+        id,
+        version,
+        name,
+        organizationId,
+        statements
+      }
+
+      request.udaruCore.policies.create(params, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.policies.create(params, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply(res).code(201)
-        })
+        return reply(res).code(201)
+      })
+    },
+    config: {
+      validate: {
+        payload: _.pick(validation.createPolicy, ['id', 'name', 'version', 'statements']),
+        query: {
+          sig: Joi.string().required()
+        },
+        headers
       },
-      config: {
-        validate: {
-          payload: _.pick(validation.createPolicy, ['id', 'name', 'version', 'statements']),
-          query: {
-            sig: Joi.string().required()
-          },
-          headers
-        },
-        description: 'Create a policy for the current user organization',
-        notes: 'The POST /authorization/policies endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
-        tags: ['api', 'policies', 'private'],
-        plugins: {
-          auth: {
-            action: Action.CreatePolicy
-          }
-        },
-        response: {schema: swagger.Policy}
+      description: 'Create a policy for the current user organization',
+      notes: 'The POST /authorization/policies endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
+      tags: ['api', 'policies', 'private'],
+      plugins: {
+        auth: {
+          action: Action.CreatePolicy
+        }
+      },
+      response: { schema: swagger.Policy }
+    }
+  })
+
+  server.route({
+    method: 'PUT',
+    path: '/authorization/policies/{id}',
+    handler: function (request, reply) {
+      if (!serviceKey.hasValidServiceKey(request)) return reply(Boom.forbidden())
+
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const { version, name, statements } = request.payload
+
+      const params = {
+        id,
+        organizationId,
+        version,
+        name,
+        statements
       }
-    })
 
-    server.route({
-      method: 'PUT',
-      path: '/authorization/policies/{id}',
-      handler: function (request, reply) {
-        if (!serviceKey.hasValidServiceKey(request)) return reply(Boom.forbidden())
+      request.udaruCore.policies.update(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.updatePolicy, ['id']),
+        payload: _.pick(validation.updatePolicy, ['version', 'name', 'statements']),
+        query: {
+          sig: Joi.string().required()
+        },
+        headers
+      },
+      description: 'Update a policy of the current user organization',
+      notes: 'The PUT /authorization/policies/{id} endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
+      tags: ['api', 'policies', 'private'],
+      plugins: {
+        auth: {
+          action: Action.UpdatePolicy,
+          getParams: (request) => ({ policyId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Policy }
+    }
+  })
 
-        const { id } = request.params
-        const { organizationId } = request.udaru
-        const { version, name, statements } = request.payload
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/policies/{id}',
+    handler: function (request, reply) {
+      if (!serviceKey.hasValidServiceKey(request)) return reply(Boom.forbidden())
 
-        const params = {
-          id,
-          organizationId,
-          version,
-          name,
-          statements
+      const { id } = request.params
+      const { organizationId } = request.udaru
+
+      request.udaruCore.policies.delete({ id, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.policies.update(params, reply)
+        return reply(res).code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deletePolicy, ['id']),
+        query: {
+          sig: Joi.string().required()
+        },
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.updatePolicy, ['id']),
-          payload: _.pick(validation.updatePolicy, ['version', 'name', 'statements']),
-          query: {
-            sig: Joi.string().required()
-          },
-          headers
-        },
-        description: 'Update a policy of the current user organization',
-        notes: 'The PUT /authorization/policies/{id} endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
-        tags: ['api', 'policies', 'private'],
-        plugins: {
-          auth: {
-            action: Action.UpdatePolicy,
-            getParams: (request) => ({ policyId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Policy}
-      }
-    })
-
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/policies/{id}',
-      handler: function (request, reply) {
-        if (!serviceKey.hasValidServiceKey(request)) return reply(Boom.forbidden())
-
-        const { id } = request.params
-        const { organizationId } = request.udaru
-
-        udaru.policies.delete({ id, organizationId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply(res).code(204)
-        })
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.deletePolicy, ['id']),
-          query: {
-            sig: Joi.string().required()
-          },
-          headers
-        },
-        description: 'Delete a policy',
-        notes: 'The DELETE /authorization/policies/{id} endpoint is a private endpoint. It can be accessed only using a service key.\n\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
-        tags: ['api', 'policies', 'private'],
-        plugins: {
-          auth: {
-            action: Action.DeletePolicy,
-            getParams: (request) => ({ policyId: request.params.id })
-          }
+      description: 'Delete a policy',
+      notes: 'The DELETE /authorization/policies/{id} endpoint is a private endpoint. It can be accessed only using a service key.\n\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
+      tags: ['api', 'policies', 'private'],
+      plugins: {
+        auth: {
+          action: Action.DeletePolicy,
+          getParams: (request) => ({ policyId: request.params.id })
         }
       }
-    })
+    }
+  })
 
-    next()
-  }
-
-  register.attributes = {
-    name: 'private-policies',
-    version: '0.0.1'
-  }
-
-  return register
+  next()
 }
 
-module.exports = buildPolicies
+exports.register.attributes = {
+  name: 'private-policies',
+  version: '0.0.1'
+}

--- a/lib/plugin/routes/public/authorization.js
+++ b/lib/plugin/routes/public/authorization.js
@@ -5,119 +5,113 @@ const headers = require('./../headers')
 const swagger = require('./../../swagger')
 const validation = require('../../../core/lib/ops/validation').authorize
 
-function buildAuthorization (udaru, config) {
-  function register (server, options, next) {
-    const Action = config.get('AuthConfig.Action')
+exports.register = function (server, options, next) {
+  const Action = server.udaruConfig.get('AuthConfig.Action')
 
-    server.route({
-      method: 'GET',
-      path: '/authorization/access/{userId}/{action}/{resource*}',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const { resource, action, userId } = request.params
+  server.route({
+    method: 'GET',
+    path: '/authorization/access/{userId}/{action}/{resource*}',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const { resource, action, userId } = request.params
 
-        const params = {
-          userId,
-          action,
-          resource,
-          organizationId
-        }
-
-        udaru.authorize.isUserAuthorized(params, reply)
-      },
-      config: {
-        plugins: {
-          auth: {
-            action: Action.CheckAccess,
-            resource: 'authorization/access'
-          }
-        },
-        validate: {
-          params: _.pick(validation.isUserAuthorized, ['userId', 'action', 'resource']),
-          headers
-        },
-        description: 'Authorize user action against a resource',
-        notes: 'The GET /authorization/access/{userId}/{action}/{resource} endpoint answers if a user can perform an action\non a resource.\n',
-        tags: ['api', 'authorization'],
-        response: {schema: swagger.Access}
+      const params = {
+        userId,
+        action,
+        resource,
+        organizationId
       }
-    })
 
-    server.route({
-      method: 'GET',
-      path: '/authorization/list/{userId}/{resource*}',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const { resource, userId } = request.params
-        const params = {
-          userId,
-          resource,
-          organizationId
+      request.udaruCore.authorize.isUserAuthorized(params, reply)
+    },
+    config: {
+      plugins: {
+        auth: {
+          action: Action.CheckAccess,
+          resource: 'authorization/access'
         }
-
-        udaru.authorize.listActions(params, reply)
       },
-      config: {
-        plugins: {
-          auth: {
-            action: Action.ListActions,
-            resource: 'authorization/actions'
-          }
-        },
-        validate: {
-          params: _.pick(validation.listAuthorizations, ['userId', 'resource']),
-          headers
-        },
-        description: 'List all the actions a user can perform on a resource',
-        notes: 'The GET /authorization/list/{userId}/{resource} endpoint returns a list of all the actions a user\ncan perform on a given resource.\n',
-        tags: ['api', 'authorization'],
-        response: {schema: swagger.UserActions}
-      }
-    })
+      validate: {
+        params: _.pick(validation.isUserAuthorized, ['userId', 'action', 'resource']),
+        headers
+      },
+      description: 'Authorize user action against a resource',
+      notes: 'The GET /authorization/access/{userId}/{action}/{resource} endpoint answers if a user can perform an action\non a resource.\n',
+      tags: ['api', 'authorization'],
+      response: { schema: swagger.Access }
+    }
+  })
 
-    server.route({
-      method: 'GET',
-      path: '/authorization/list/{userId}',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const { userId } = request.params
-        const { resources } = request.query
-        const params = {
-          userId,
-          resources,
-          organizationId
+  server.route({
+    method: 'GET',
+    path: '/authorization/list/{userId}/{resource*}',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const { resource, userId } = request.params
+      const params = {
+        userId,
+        resource,
+        organizationId
+      }
+
+      request.udaruCore.authorize.listActions(params, reply)
+    },
+    config: {
+      plugins: {
+        auth: {
+          action: Action.ListActions,
+          resource: 'authorization/actions'
         }
-
-        udaru.authorize.listAuthorizationsOnResources(params, reply)
       },
-      config: {
-        plugins: {
-          auth: {
-            action: Action.ListActionsOnResources,
-            resource: 'authorization/actions/resources'
-          }
-        },
-        validate: {
-          params: _.pick(validation.listAuthorizationsOnResources, ['userId']),
-          query: _.pick(validation.listAuthorizationsOnResources, ['resources']),
-          headers
-        },
-        description: 'List all the actions a user can perform on a list of resources',
-        notes: 'The GET /authorization/list/{userId} endpoint returns a list of all the actions a user\ncan perform on a given list of resources.\n',
-        tags: ['api', 'authorization'],
-        response: {schema: swagger.UserActionsOnResources}
+      validate: {
+        params: _.pick(validation.listAuthorizations, ['userId', 'resource']),
+        headers
+      },
+      description: 'List all the actions a user can perform on a resource',
+      notes: 'The GET /authorization/list/{userId}/{resource} endpoint returns a list of all the actions a user\ncan perform on a given resource.\n',
+      tags: ['api', 'authorization'],
+      response: { schema: swagger.UserActions }
+    }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/authorization/list/{userId}',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const { userId } = request.params
+      const { resources } = request.query
+      const params = {
+        userId,
+        resources,
+        organizationId
       }
-    })
 
-    next()
-  }
+      request.udaruCore.authorize.listAuthorizationsOnResources(params, reply)
+    },
+    config: {
+      plugins: {
+        auth: {
+          action: Action.ListActionsOnResources,
+          resource: 'authorization/actions/resources'
+        }
+      },
+      validate: {
+        params: _.pick(validation.listAuthorizationsOnResources, ['userId']),
+        query: _.pick(validation.listAuthorizationsOnResources, ['resources']),
+        headers
+      },
+      description: 'List all the actions a user can perform on a list of resources',
+      notes: 'The GET /authorization/list/{userId} endpoint returns a list of all the actions a user\ncan perform on a given list of resources.\n',
+      tags: ['api', 'authorization'],
+      response: { schema: swagger.UserActionsOnResources }
+    }
+  })
 
-  register.attributes = {
-    name: 'authorization',
-    version: '0.0.1'
-  }
-
-  return register
+  next()
 }
 
-module.exports = buildAuthorization
+exports.register.attributes = {
+  name: 'authorization',
+  version: '0.0.1'
+}

--- a/lib/plugin/routes/public/authorization.js
+++ b/lib/plugin/routes/public/authorization.js
@@ -3,6 +3,7 @@
 const _ = require('lodash')
 const headers = require('./../headers')
 const swagger = require('./../../swagger')
+const validation = require('../../../core/lib/ops/validation').authorize
 
 function buildAuthorization (udaru, config) {
   function register (server, options, next) {
@@ -32,7 +33,7 @@ function buildAuthorization (udaru, config) {
           }
         },
         validate: {
-          params: _.pick(udaru.authorize.isUserAuthorized.validate, ['userId', 'action', 'resource']),
+          params: _.pick(validation.isUserAuthorized, ['userId', 'action', 'resource']),
           headers
         },
         description: 'Authorize user action against a resource',
@@ -64,7 +65,7 @@ function buildAuthorization (udaru, config) {
           }
         },
         validate: {
-          params: _.pick(udaru.authorize.listActions.validate, ['userId', 'resource']),
+          params: _.pick(validation.listAuthorizations, ['userId', 'resource']),
           headers
         },
         description: 'List all the actions a user can perform on a resource',
@@ -97,8 +98,8 @@ function buildAuthorization (udaru, config) {
           }
         },
         validate: {
-          params: _.pick(udaru.authorize.listAuthorizationsOnResources.validate, ['userId']),
-          query: _.pick(udaru.authorize.listAuthorizationsOnResources.validate, ['resources']),
+          params: _.pick(validation.listAuthorizationsOnResources, ['userId']),
+          query: _.pick(validation.listAuthorizationsOnResources, ['resources']),
           headers
         },
         description: 'List all the actions a user can perform on a list of resources',

--- a/lib/plugin/routes/public/monitor.js
+++ b/lib/plugin/routes/public/monitor.js
@@ -1,30 +1,24 @@
 'use strict'
 
-function buildMonitor (/* udaru, config */) {
-  function register (server, options, next) {
-    server.route({
-      method: 'GET',
-      path: '/ping',
-      handler: function (request, reply) {
-        reply()
-      },
-      config: {
-        auth: false,
-        description: 'Ping endpoint',
-        notes: 'The GET /ping endpoint will return 200 if the server is up and running.',
-        tags: ['api', 'monitoring']
-      }
-    })
+exports.register = function (server, options, next) {
+  server.route({
+    method: 'GET',
+    path: '/ping',
+    handler: function (request, reply) {
+      reply()
+    },
+    config: {
+      auth: false,
+      description: 'Ping endpoint',
+      notes: 'The GET /ping endpoint will return 200 if the server is up and running.',
+      tags: ['api', 'monitoring']
+    }
+  })
 
-    next()
-  }
-
-  register.attributes = {
-    name: 'monitor',
-    version: '0.0.1'
-  }
-
-  return register
+  next()
 }
 
-module.exports = buildMonitor
+exports.register.attributes = {
+  name: 'monitor',
+  version: '0.0.1'
+}

--- a/lib/plugin/routes/public/organizations.js
+++ b/lib/plugin/routes/public/organizations.js
@@ -3,6 +3,7 @@
 const _ = require('lodash')
 const swagger = require('./../../swagger')
 const headers = require('./../headers')
+const validation = require('../../../core/lib/ops/validation').organizations
 
 function buildOriganizations (udaru, config) {
   function register (server, options, next) {
@@ -40,7 +41,7 @@ function buildOriganizations (udaru, config) {
         },
         validate: {
           headers,
-          query: udaru.organizations.list.validate
+          query: validation.list
         },
         response: {schema: swagger.List(swagger.Organization).label('PagedOrganizations')}
       }
@@ -64,7 +65,7 @@ function buildOriganizations (udaru, config) {
         },
         validate: {
           params: {
-            id: udaru.organizations.read.validate
+            id: validation.readById
           },
           headers
         },
@@ -93,7 +94,7 @@ function buildOriganizations (udaru, config) {
       },
       config: {
         validate: {
-          payload: udaru.organizations.create.validate,
+          payload: validation.create,
           headers
         },
         description: 'Create an organization',
@@ -132,7 +133,7 @@ function buildOriganizations (udaru, config) {
         },
         validate: {
           params: {
-            id: udaru.organizations.delete.validate
+            id: validation.deleteById
           },
           headers
         }
@@ -150,8 +151,8 @@ function buildOriganizations (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.organizations.update.validate, ['id']),
-          payload: _.pick(udaru.organizations.update.validate, ['name', 'description']),
+          params: _.pick(validation.update, ['id']),
+          payload: _.pick(validation.update, ['name', 'description']),
           headers
         },
         description: 'Update an organization',
@@ -178,8 +179,8 @@ function buildOriganizations (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.organizations.addPolicies.validate, ['id']),
-          payload: _.pick(udaru.organizations.addPolicies.validate, ['policies']),
+          params: _.pick(validation.addOrganizationPolicies, ['id']),
+          payload: _.pick(validation.addOrganizationPolicies, ['policies']),
           headers
         },
         description: 'Add one or more policies to an organization',
@@ -206,8 +207,8 @@ function buildOriganizations (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.organizations.replacePolicies.validate, ['id']),
-          payload: _.pick(udaru.organizations.replacePolicies.validate, ['policies']),
+          params: _.pick(validation.replaceOrganizationPolicies, ['id']),
+          payload: _.pick(validation.replaceOrganizationPolicies, ['policies']),
           headers
         },
         description: 'Clear and replace the policies of an organization',
@@ -239,7 +240,7 @@ function buildOriganizations (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.organizations.deletePolicies.validate, ['id']),
+          params: _.pick(validation.deleteOrganizationPolicies, ['id']),
           headers
         },
         description: 'Clear all policies of the organization',
@@ -270,7 +271,7 @@ function buildOriganizations (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.organizations.deletePolicy.validate, ['id', 'policyId']),
+          params: _.pick(validation.deleteOrganizationPolicy, ['id', 'policyId']),
           headers
         },
         description: 'Remove a policy from one organization',

--- a/lib/plugin/routes/public/organizations.js
+++ b/lib/plugin/routes/public/organizations.js
@@ -5,298 +5,292 @@ const swagger = require('./../../swagger')
 const headers = require('./../headers')
 const validation = require('../../../core/lib/ops/validation').organizations
 
-function buildOriganizations (udaru, config) {
-  function register (server, options, next) {
-    const Action = config.get('AuthConfig.Action')
+exports.register = function (server, options, next) {
+  const Action = server.udaruConfig.get('AuthConfig.Action')
 
-    server.route({
-      method: 'GET',
-      path: '/authorization/organizations',
-      handler: function (request, reply) {
-        const limit = request.query.limit || config.get('authorization.defaultPageSize')
-        const page = request.query.page || 1
-        udaru.organizations.list({
-          limit: limit,
-          page: page
-        }, (err, data, total) => {
-          reply(
-            err,
-            err ? null : {
-              page: page,
-              limit: limit,
-              total: total,
-              data: data
-            }
-          )
-        })
-      },
-      config: {
-        description: 'List all the organizations',
-        notes: 'The GET /authorization/organizations endpoint returns a list of all organizations.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
-        tags: ['api', 'organizations'],
-        plugins: {
-          auth: {
-            action: Action.ListOrganizations
+  server.route({
+    method: 'GET',
+    path: '/authorization/organizations',
+    handler: function (request, reply) {
+      const limit = request.query.limit || server.udaruConfig.get('authorization.defaultPageSize')
+      const page = request.query.page || 1
+      request.udaruCore.organizations.list({
+        limit: limit,
+        page: page
+      }, (err, data, total) => {
+        reply(
+          err,
+          err ? null : {
+            page: page,
+            limit: limit,
+            total: total,
+            data: data
           }
-        },
-        validate: {
-          headers,
-          query: validation.list
-        },
-        response: {schema: swagger.List(swagger.Organization).label('PagedOrganizations')}
-      }
-    })
-
-    server.route({
-      method: 'GET',
-      path: '/authorization/organizations/{id}',
-      handler: function (request, reply) {
-        udaru.organizations.read(request.params.id, reply)
+        )
+      })
+    },
+    config: {
+      description: 'List all the organizations',
+      notes: 'The GET /authorization/organizations endpoint returns a list of all organizations.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
+      tags: ['api', 'organizations'],
+      plugins: {
+        auth: {
+          action: Action.ListOrganizations
+        }
       },
-      config: {
-        description: 'Get organization',
-        notes: 'The GET /authorization/organizations/{id} endpoint returns a single organization data.\n',
-        tags: ['api', 'organizations'],
-        plugins: {
-          auth: {
-            action: Action.ReadOrganization,
-            getParams: (request) => ({ organizationId: request.params.id })
-          }
-        },
-        validate: {
-          params: {
-            id: validation.readById
-          },
-          headers
-        },
-        response: {schema: swagger.Organization}
-      }
-    })
+      validate: {
+        headers,
+        query: validation.list
+      },
+      response: { schema: swagger.List(swagger.Organization).label('PagedOrganizations') }
+    }
+  })
 
-    server.route({
-      method: 'POST',
-      path: '/authorization/organizations',
-      handler: function (request, reply) {
-        const params = {
-          id: request.payload.id,
-          name: request.payload.name,
-          description: request.payload.description,
-          user: request.payload.user
+  server.route({
+    method: 'GET',
+    path: '/authorization/organizations/{id}',
+    handler: function (request, reply) {
+      request.udaruCore.organizations.read(request.params.id, reply)
+    },
+    config: {
+      description: 'Get organization',
+      notes: 'The GET /authorization/organizations/{id} endpoint returns a single organization data.\n',
+      tags: ['api', 'organizations'],
+      plugins: {
+        auth: {
+          action: Action.ReadOrganization,
+          getParams: (request) => ({ organizationId: request.params.id })
+        }
+      },
+      validate: {
+        params: {
+          id: validation.readById
+        },
+        headers
+      },
+      response: { schema: swagger.Organization }
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/authorization/organizations',
+    handler: function (request, reply) {
+      const params = {
+        id: request.payload.id,
+        name: request.payload.name,
+        description: request.payload.description,
+        user: request.payload.user
+      }
+
+      request.udaruCore.organizations.create(params, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.organizations.create(params, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply(res).code(201)
-        })
+        return reply(res).code(201)
+      })
+    },
+    config: {
+      validate: {
+        payload: validation.create,
+        headers
       },
-      config: {
-        validate: {
-          payload: validation.create,
-          headers
+      description: 'Create an organization',
+      notes: 'The POST /authorization/organizations endpoint creates a new organization, the default organization admin policy and (if provided) its admin.',
+      tags: ['api', 'organizations'],
+      plugins: {
+        auth: {
+          action: Action.CreateOrganization
+        }
+      },
+      response: { schema: swagger.OrganizationAndUser }
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/organizations/{id}',
+    handler: function (request, reply) {
+      request.udaruCore.organizations.delete(request.params.id, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply().code(204)
+      })
+    },
+    config: {
+      description: 'DELETE an organization',
+      notes: 'The DELETE /authorization/organizations/{id} endpoint will delete an organization.',
+      tags: ['api', 'organizations'],
+      plugins: {
+        auth: {
+          action: Action.DeleteOrganization,
+          getParams: (request) => ({ organizationId: request.params.id })
+        }
+      },
+      validate: {
+        params: {
+          id: validation.deleteById
         },
-        description: 'Create an organization',
-        notes: 'The POST /authorization/organizations endpoint creates a new organization, the default organization admin policy and (if provided) its admin.',
-        tags: ['api', 'organizations'],
-        plugins: {
-          auth: {
-            action: Action.CreateOrganization
-          }
-        },
-        response: {schema: swagger.OrganizationAndUser}
+        headers
       }
-    })
+    }
+  })
 
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/organizations/{id}',
-      handler: function (request, reply) {
-        udaru.organizations.delete(request.params.id, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
+  server.route({
+    method: 'PUT',
+    path: '/authorization/organizations/{id}',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { name, description } = request.payload
 
-          return reply().code(204)
-        })
+      request.udaruCore.organizations.update({ id, name, description }, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.update, ['id']),
+        payload: _.pick(validation.update, ['name', 'description']),
+        headers
       },
-      config: {
-        description: 'DELETE an organization',
-        notes: 'The DELETE /authorization/organizations/{id} endpoint will delete an organization.',
-        tags: ['api', 'organizations'],
-        plugins: {
-          auth: {
-            action: Action.DeleteOrganization,
-            getParams: (request) => ({ organizationId: request.params.id })
-          }
-        },
-        validate: {
-          params: {
-            id: validation.deleteById
-          },
-          headers
+      description: 'Update an organization',
+      notes: 'The PUT /authorization/organizations/{id} endpoint will update an organization name and description',
+      tags: ['api', 'organizations'],
+      plugins: {
+        auth: {
+          action: Action.UpdateOrganization,
+          getParams: (request) => ({ organizationId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Organization }
+    }
+  })
+
+  server.route({
+    method: 'PUT',
+    path: '/authorization/organizations/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { policies } = request.payload
+
+      request.udaruCore.organizations.addPolicies({ id, policies }, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.addOrganizationPolicies, ['id']),
+        payload: _.pick(validation.addOrganizationPolicies, ['policies']),
+        headers
+      },
+      description: 'Add one or more policies to an organization',
+      notes: 'The PUT /authorization/organizations/{id}/policies endpoint adds one or more policies to an organization.',
+      tags: ['api', 'organizations'],
+      plugins: {
+        auth: {
+          action: Action.AddOrganizationPolicy,
+          getParams: (request) => ({ organizationId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Organization }
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/authorization/organizations/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { policies } = request.payload
+
+      request.udaruCore.organizations.replacePolicies({ id, policies }, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.replaceOrganizationPolicies, ['id']),
+        payload: _.pick(validation.replaceOrganizationPolicies, ['policies']),
+        headers
+      },
+      description: 'Clear and replace the policies of an organization',
+      notes: 'The POST /authorization/organizations/{id}/policies endpoint replaces all the organization policies. The existing organization policies are removed.',
+      tags: ['api', 'organizations'],
+      plugins: {
+        auth: {
+          action: Action.ReplaceOrganizationPolicy,
+          getParams: (request) => ({ organizationId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Organization }
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/organizations/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+
+      request.udaruCore.organizations.deletePolicies({ id }, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteOrganizationPolicies, ['id']),
+        headers
+      },
+      description: 'Clear all policies of the organization',
+      notes: 'The DELETE /authorization/organizations/{id}/policies endpoint removes all the organization policies.\n',
+      tags: ['api', 'organizations'],
+      plugins: {
+        auth: {
+          action: Action.RemoveOrganizationPolicy,
+          getParams: (request) => ({ organizationId: request.params.id })
         }
       }
-    })
+    }
+  })
 
-    server.route({
-      method: 'PUT',
-      path: '/authorization/organizations/{id}',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { name, description } = request.payload
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/organizations/{id}/policies/{policyId}',
+    handler: function (request, reply) {
+      const { id, policyId } = request.params
 
-        udaru.organizations.update({id, name, description}, reply)
+      request.udaruCore.organizations.deletePolicy({ id, policyId }, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteOrganizationPolicy, ['id', 'policyId']),
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.update, ['id']),
-          payload: _.pick(validation.update, ['name', 'description']),
-          headers
-        },
-        description: 'Update an organization',
-        notes: 'The PUT /authorization/organizations/{id} endpoint will update an organization name and description',
-        tags: ['api', 'organizations'],
-        plugins: {
-          auth: {
-            action: Action.UpdateOrganization,
-            getParams: (request) => ({ organizationId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Organization}
-      }
-    })
-
-    server.route({
-      method: 'PUT',
-      path: '/authorization/organizations/{id}/policies',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { policies } = request.payload
-
-        udaru.organizations.addPolicies({id, policies}, reply)
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.addOrganizationPolicies, ['id']),
-          payload: _.pick(validation.addOrganizationPolicies, ['policies']),
-          headers
-        },
-        description: 'Add one or more policies to an organization',
-        notes: 'The PUT /authorization/organizations/{id}/policies endpoint adds one or more policies to an organization.',
-        tags: ['api', 'organizations'],
-        plugins: {
-          auth: {
-            action: Action.AddOrganizationPolicy,
-            getParams: (request) => ({ organizationId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Organization}
-      }
-    })
-
-    server.route({
-      method: 'POST',
-      path: '/authorization/organizations/{id}/policies',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { policies } = request.payload
-
-        udaru.organizations.replacePolicies({id, policies}, reply)
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.replaceOrganizationPolicies, ['id']),
-          payload: _.pick(validation.replaceOrganizationPolicies, ['policies']),
-          headers
-        },
-        description: 'Clear and replace the policies of an organization',
-        notes: 'The POST /authorization/organizations/{id}/policies endpoint replaces all the organization policies. The existing organization policies are removed.',
-        tags: ['api', 'organizations'],
-        plugins: {
-          auth: {
-            action: Action.ReplaceOrganizationPolicy,
-            getParams: (request) => ({ organizationId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Organization}
-      }
-    })
-
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/organizations/{id}/policies',
-      handler: function (request, reply) {
-        const { id } = request.params
-
-        udaru.organizations.deletePolicies({ id }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply().code(204)
-        })
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteOrganizationPolicies, ['id']),
-          headers
-        },
-        description: 'Clear all policies of the organization',
-        notes: 'The DELETE /authorization/organizations/{id}/policies endpoint removes all the organization policies.\n',
-        tags: ['api', 'organizations'],
-        plugins: {
-          auth: {
-            action: Action.RemoveOrganizationPolicy,
-            getParams: (request) => ({ organizationId: request.params.id })
-          }
+      description: 'Remove a policy from one organization',
+      notes: 'The DELETE /authorization/organizations/{id}/policies/{policyId} endpoint removes a specific policy from the organization.\n',
+      tags: ['api', 'organizations'],
+      plugins: {
+        auth: {
+          action: Action.RemoveOrganizationPolicy,
+          getParams: (request) => ({
+            organizationId: request.params.id,
+            policyId: request.params.policyId
+          })
         }
       }
-    })
-
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/organizations/{id}/policies/{policyId}',
-      handler: function (request, reply) {
-        const { id, policyId } = request.params
-
-        udaru.organizations.deletePolicy({ id, policyId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply().code(204)
-        })
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteOrganizationPolicy, ['id', 'policyId']),
-          headers
-        },
-        description: 'Remove a policy from one organization',
-        notes: 'The DELETE /authorization/organizations/{id}/policies/{policyId} endpoint removes a specific policy from the organization.\n',
-        tags: ['api', 'organizations'],
-        plugins: {
-          auth: {
-            action: Action.RemoveOrganizationPolicy,
-            getParams: (request) => ({
-              organizationId: request.params.id,
-              policyId: request.params.policyId
-            })
-          }
-        }
-      }
-    })
-    next()
-  }
-
-  register.attributes = {
-    name: 'organizations',
-    version: '0.0.1'
-  }
-
-  return register
+    }
+  })
+  next()
 }
 
-module.exports = buildOriganizations
+exports.register.attributes = {
+  name: 'organizations',
+  version: '0.0.1'
+}

--- a/lib/plugin/routes/public/policies.js
+++ b/lib/plugin/routes/public/policies.js
@@ -3,6 +3,7 @@
 const _ = require('lodash')
 const swagger = require('./../../swagger')
 const headers = require('./../headers')
+const validation = require('../../../core/lib/ops/validation').policies
 
 function buildPolicies (udaru, config) {
   function register (server, options, next) {
@@ -42,7 +43,7 @@ function buildPolicies (udaru, config) {
         },
         validate: {
           headers,
-          query: _.pick(udaru.policies.list.validate, ['page', 'limit'])
+          query: _.pick(validation.listByOrganization, ['page', 'limit'])
         },
         response: {schema: swagger.List(swagger.Policy).label('PagedPolicies')}
       }
@@ -59,7 +60,7 @@ function buildPolicies (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.policies.read.validate, ['id']),
+          params: _.pick(validation.readPolicy, ['id']),
           headers
         },
         description: 'Fetch all the defined policies',

--- a/lib/plugin/routes/public/policies.js
+++ b/lib/plugin/routes/public/policies.js
@@ -5,86 +5,80 @@ const swagger = require('./../../swagger')
 const headers = require('./../headers')
 const validation = require('../../../core/lib/ops/validation').policies
 
-function buildPolicies (udaru, config) {
-  function register (server, options, next) {
-    const Action = config.get('AuthConfig.Action')
+exports.register = function (server, options, next) {
+  const Action = server.udaruConfig.get('AuthConfig.Action')
 
-    server.route({
-      method: 'GET',
-      path: '/authorization/policies',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const limit = request.query.limit || config.get('authorization.defaultPageSize')
-        const page = request.query.page || 1
-        udaru.policies.list({
-          organizationId,
-          limit: limit,
-          page: page
-        }, (err, data, total) => {
-          reply(
-            err,
-            !data ? null : {
-              page: page,
-              limit: limit,
-              total: total,
-              data: data
-            }
-          )
-        })
-      },
-      config: {
-        description: 'Fetch all the defined policies',
-        notes: 'The GET /authorization/policies endpoint returns a list of all the defined policies\nthe policies will contain only the ID, version and name. No statements.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
-        tags: ['api', 'policies'],
-        plugins: {
-          auth: {
-            action: Action.ListPolicies
+  server.route({
+    method: 'GET',
+    path: '/authorization/policies',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const limit = request.query.limit || server.udaruConfig.get('authorization.defaultPageSize')
+      const page = request.query.page || 1
+      request.udaruCore.policies.list({
+        organizationId,
+        limit: limit,
+        page: page
+      }, (err, data, total) => {
+        reply(
+          err,
+          !data ? null : {
+            page: page,
+            limit: limit,
+            total: total,
+            data: data
           }
-        },
-        validate: {
-          headers,
-          query: _.pick(validation.listByOrganization, ['page', 'limit'])
-        },
-        response: {schema: swagger.List(swagger.Policy).label('PagedPolicies')}
-      }
-    })
-
-    server.route({
-      method: 'GET',
-      path: '/authorization/policies/{id}',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const { id } = request.params
-
-        udaru.policies.read({ id, organizationId }, reply)
+        )
+      })
+    },
+    config: {
+      description: 'Fetch all the defined policies',
+      notes: 'The GET /authorization/policies endpoint returns a list of all the defined policies\nthe policies will contain only the ID, version and name. No statements.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
+      tags: ['api', 'policies'],
+      plugins: {
+        auth: {
+          action: Action.ListPolicies
+        }
       },
-      config: {
-        validate: {
-          params: _.pick(validation.readPolicy, ['id']),
-          headers
-        },
-        description: 'Fetch all the defined policies',
-        notes: 'The GET /authorization/policies/{id} endpoint returns a policy based on its ID.\n',
-        tags: ['api', 'policies'],
-        plugins: {
-          auth: {
-            action: Action.ReadPolicy,
-            getParams: (request) => ({ policyId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Policy}
-      }
-    })
+      validate: {
+        headers,
+        query: _.pick(validation.listByOrganization, ['page', 'limit'])
+      },
+      response: { schema: swagger.List(swagger.Policy).label('PagedPolicies') }
+    }
+  })
 
-    next()
-  }
+  server.route({
+    method: 'GET',
+    path: '/authorization/policies/{id}',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const { id } = request.params
 
-  register.attributes = {
-    name: 'policies',
-    version: '0.0.1'
-  }
+      request.udaruCore.policies.read({ id, organizationId }, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.readPolicy, ['id']),
+        headers
+      },
+      description: 'Fetch all the defined policies',
+      notes: 'The GET /authorization/policies/{id} endpoint returns a policy based on its ID.\n',
+      tags: ['api', 'policies'],
+      plugins: {
+        auth: {
+          action: Action.ReadPolicy,
+          getParams: (request) => ({ policyId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Policy }
+    }
+  })
 
-  return register
+  next()
 }
 
-module.exports = buildPolicies
+exports.register.attributes = {
+  name: 'policies',
+  version: '0.0.1'
+}

--- a/lib/plugin/routes/public/teams.js
+++ b/lib/plugin/routes/public/teams.js
@@ -6,571 +6,565 @@ const swagger = require('./../../swagger')
 const headers = require('./../headers')
 const validation = require('../../../core/lib/ops/validation').teams
 
-function buildTeams (udaru, config) {
-  function register (server, options, next) {
-    const Action = config.get('AuthConfig.Action')
+exports.register = function (server, options, next) {
+  const Action = server.udaruConfig.get('AuthConfig.Action')
 
-    server.route({
-      method: 'GET',
-      path: '/authorization/teams',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const limit = request.query.limit || config.get('authorization.defaultPageSize')
-        const page = request.query.page || 1
-        udaru.teams.list({
-          organizationId,
-          limit: limit,
-          page: page
-        }, (err, data, total) => {
-          reply(
-            err,
-            err ? null : {
-              page: page,
-              limit: limit,
-              total: total,
-              data: data
-            }
-          )
-        })
-      },
-      config: {
-        description: 'Fetch all teams from the current user organization',
-        notes: 'The GET /authorization/teams endpoint returns a list of all teams from the current organization.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.ListTeams
+  server.route({
+    method: 'GET',
+    path: '/authorization/teams',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const limit = request.query.limit || server.udaruConfig.get('authorization.defaultPageSize')
+      const page = request.query.page || 1
+      request.udaruCore.teams.list({
+        organizationId,
+        limit: limit,
+        page: page
+      }, (err, data, total) => {
+        reply(
+          err,
+          err ? null : {
+            page: page,
+            limit: limit,
+            total: total,
+            data: data
           }
-        },
-        validate: {
-          headers,
-          query: _.pick(validation.listOrgTeams, ['page', 'limit'])
-        },
-        response: {schema: swagger.List(swagger.Team).label('PagedTeams')}
+        )
+      })
+    },
+    config: {
+      description: 'Fetch all teams from the current user organization',
+      notes: 'The GET /authorization/teams endpoint returns a list of all teams from the current organization.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.ListTeams
+        }
+      },
+      validate: {
+        headers,
+        query: _.pick(validation.listOrgTeams, ['page', 'limit'])
+      },
+      response: { schema: swagger.List(swagger.Team).label('PagedTeams') }
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/authorization/teams',
+    handler: function (request, reply) {
+      const { id, name, description, user } = request.payload
+      const { organizationId } = request.udaru
+
+      const params = {
+        id,
+        name,
+        description,
+        parentId: null,
+        organizationId,
+        user
       }
-    })
 
-    server.route({
-      method: 'POST',
-      path: '/authorization/teams',
-      handler: function (request, reply) {
-        const { id, name, description, user } = request.payload
-        const { organizationId } = request.udaru
-
-        const params = {
-          id,
-          name,
-          description,
-          parentId: null,
-          organizationId,
-          user
+      request.udaruCore.teams.create(params, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.teams.create(params, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply(res).code(201)
-        })
+        return reply(res).code(201)
+      })
+    },
+    config: {
+      validate: {
+        payload: _.pick(validation.createTeam, ['id', 'name', 'description', 'user']),
+        headers
       },
-      config: {
-        validate: {
-          payload: _.pick(validation.createTeam, ['id', 'name', 'description', 'user']),
-          headers
-        },
-        description: 'Create a team',
-        notes: 'The POST /authorization/teams endpoint creates a new team from its payload data.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.CreateTeam
-          }
-        },
-        response: {schema: swagger.Team}
-      }
-    })
-
-    server.route({
-      method: 'GET',
-      path: '/authorization/teams/{id}',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const { id } = request.params
-
-        udaru.teams.read({ id, organizationId }, reply)
+      description: 'Create a team',
+      notes: 'The POST /authorization/teams endpoint creates a new team from its payload data.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.CreateTeam
+        }
       },
-      config: {
-        validate: {
-          params: _.pick(validation.readTeam, ['id']),
-          headers
-        },
-        description: 'Fetch a team given its identifier',
-        notes: 'The GET /authorization/teams/{id} endpoint returns a single team data.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.ReadTeam,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Team}
+      response: { schema: swagger.Team }
+    }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/authorization/teams/{id}',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const { id } = request.params
+
+      request.udaruCore.teams.read({ id, organizationId }, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.readTeam, ['id']),
+        headers
+      },
+      description: 'Fetch a team given its identifier',
+      notes: 'The GET /authorization/teams/{id} endpoint returns a single team data.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.ReadTeam,
+          getParams: (request) => ({ teamId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Team }
+    }
+  })
+
+  server.route({
+    method: 'PUT',
+    path: '/authorization/teams/{id}',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const { name, description } = request.payload
+
+      const params = {
+        id,
+        name,
+        description,
+        organizationId
       }
-    })
 
-    server.route({
-      method: 'PUT',
-      path: '/authorization/teams/{id}',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-        const { name, description } = request.payload
+      request.udaruCore.teams.update(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.updateTeam, ['id']),
+        payload: Joi.object(_.pick(validation.updateTeam, ['name', 'description'])).or('name', 'description'),
+        headers
+      },
+      description: 'Update a team',
+      notes: 'The PUT /authorization/teams/{id} endpoint updates a team data.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.UpdateTeam,
+          getParams: (request) => ({ teamId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Team }
+    }
+  })
 
-        const params = {
-          id,
-          name,
-          description,
-          organizationId
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/teams/{id}',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+
+      request.udaruCore.teams.delete({ id, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.teams.update(params, reply)
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteTeam, ['id']),
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.updateTeam, ['id']),
-          payload: Joi.object(_.pick(validation.updateTeam, ['name', 'description'])).or('name', 'description'),
-          headers
-        },
-        description: 'Update a team',
-        notes: 'The PUT /authorization/teams/{id} endpoint updates a team data.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.UpdateTeam,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Team}
-      }
-    })
-
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/teams/{id}',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-
-        udaru.teams.delete({ id, organizationId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply().code(204)
-        })
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteTeam, ['id']),
-          headers
-        },
-        description: 'Delete a team',
-        notes: 'The DELETE /authorization/teams endpoint deletes a team.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.DeleteTeam,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
+      description: 'Delete a team',
+      notes: 'The DELETE /authorization/teams endpoint deletes a team.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.DeleteTeam,
+          getParams: (request) => ({ teamId: request.params.id })
         }
       }
-    })
+    }
+  })
 
-    server.route({
-      method: 'PUT',
-      path: '/authorization/teams/{id}/nest',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
+  server.route({
+    method: 'PUT',
+    path: '/authorization/teams/{id}/nest',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
 
-        const params = {
-          id: request.params.id,
-          parentId: request.payload.parentId,
-          organizationId
+      const params = {
+        id: request.params.id,
+        parentId: request.payload.parentId,
+        organizationId
+      }
+
+      request.udaruCore.teams.move(params, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.teams.move(params, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply(res).code(200)
-        })
+        return reply(res).code(200)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.moveTeam, ['id']),
+        payload: {
+          parentId: validation.moveTeam.parentId.required()
+        },
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.moveTeam, ['id']),
-          payload: {
-            parentId: validation.moveTeam.parentId.required()
-          },
-          headers
-        },
-        description: 'Nest a team',
-        notes: 'The PUT /authorization/teams/{id}/nest endpoint nests a team.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.ManageTeams,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Team}
+      description: 'Nest a team',
+      notes: 'The PUT /authorization/teams/{id}/nest endpoint nests a team.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.ManageTeams,
+          getParams: (request) => ({ teamId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Team }
+    }
+  })
+
+  server.route({
+    method: 'PUT',
+    path: '/authorization/teams/{id}/unnest',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+
+      const params = {
+        id: request.params.id,
+        parentId: null,
+        organizationId
       }
-    })
 
-    server.route({
-      method: 'PUT',
-      path: '/authorization/teams/{id}/unnest',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-
-        const params = {
-          id: request.params.id,
-          parentId: null,
-          organizationId
+      request.udaruCore.teams.move(params, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.teams.move(params, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply(res).code(200)
-        })
+        return reply(res).code(200)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.moveTeam, ['id']),
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.moveTeam, ['id']),
-          headers
-        },
-        description: 'Unnest a team',
-        notes: 'The PUT /authorization/teams/{id}/unnest endpoint unnests a team.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.ManageTeams,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Team}
-      }
-    })
-
-    server.route({
-      method: 'PUT',
-      path: '/authorization/teams/{id}/policies',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-        const { policies } = request.payload
-
-        const params = {
-          id,
-          organizationId,
-          policies
+      description: 'Unnest a team',
+      notes: 'The PUT /authorization/teams/{id}/unnest endpoint unnests a team.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.ManageTeams,
+          getParams: (request) => ({ teamId: request.params.id })
         }
-        udaru.teams.addPolicies(params, reply)
       },
-      config: {
-        validate: {
-          params: _.pick(validation.addTeamPolicies, ['id']),
-          payload: _.pick(validation.addTeamPolicies, ['policies']),
-          headers
-        },
-        description: 'Add one or more policies to a team',
-        notes: 'The PUT /authorization/teams/{id}/policies endpoint adds one or more new policies to a team.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.AddTeamPolicy,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Team}
+      response: { schema: swagger.Team }
+    }
+  })
+
+  server.route({
+    method: 'PUT',
+    path: '/authorization/teams/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const { policies } = request.payload
+
+      const params = {
+        id,
+        organizationId,
+        policies
       }
-    })
-
-    server.route({
-      method: 'POST',
-      path: '/authorization/teams/{id}/policies',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-        const { policies } = request.payload
-
-        const params = {
-          id,
-          organizationId,
-          policies
+      request.udaruCore.teams.addPolicies(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.addTeamPolicies, ['id']),
+        payload: _.pick(validation.addTeamPolicies, ['policies']),
+        headers
+      },
+      description: 'Add one or more policies to a team',
+      notes: 'The PUT /authorization/teams/{id}/policies endpoint adds one or more new policies to a team.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.AddTeamPolicy,
+          getParams: (request) => ({ teamId: request.params.id })
         }
-
-        udaru.teams.replacePolicies(params, reply)
       },
-      config: {
-        validate: {
-          params: _.pick(validation.replaceTeamPolicies, ['id']),
-          payload: _.pick(validation.replaceTeamPolicies, ['policies']),
-          headers
-        },
-        description: 'Clear and replace policies for a team',
-        notes: 'The POST /authorization/teams/{id}/policies endpoint replaces all the team policies. Existing policies are removed.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.ReplaceTeamPolicy,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Team}
+      response: { schema: swagger.Team }
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/authorization/teams/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const { policies } = request.payload
+
+      const params = {
+        id,
+        organizationId,
+        policies
       }
-    })
 
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/teams/{id}/policies',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-
-        udaru.teams.deletePolicies({ id, organizationId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply().code(204)
-        })
+      request.udaruCore.teams.replacePolicies(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.replaceTeamPolicies, ['id']),
+        payload: _.pick(validation.replaceTeamPolicies, ['policies']),
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteTeamPolicies, ['id']),
-          headers
-        },
-        description: 'Clear all team policies',
-        notes: 'The DELETE /authorization/teams/{id}/policies endpoint removes all the team policies.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.RemoveTeamPolicy,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
+      description: 'Clear and replace policies for a team',
+      notes: 'The POST /authorization/teams/{id}/policies endpoint replaces all the team policies. Existing policies are removed.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.ReplaceTeamPolicy,
+          getParams: (request) => ({ teamId: request.params.id })
         }
-      }
-    })
-
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/teams/{teamId}/policies/{policyId}',
-      handler: function (request, reply) {
-        const { teamId, policyId } = request.params
-        const { organizationId } = request.udaru
-
-        udaru.teams.deletePolicy({ teamId, policyId, organizationId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply().code(204)
-        })
       },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteTeamPolicy, ['teamId', 'policyId']),
-          headers
-        },
-        description: 'Remove a team policy',
-        notes: 'The DELETE /authorization/teams/{teamId}/policies/{policyId} endpoint removes a specific team policy.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.RemoveTeamPolicy,
-            getParams: (request) => ({ teamId: request.params.teamId })
-          }
-        }
-      }
-    })
+      response: { schema: swagger.Team }
+    }
+  })
 
-    server.route({
-      method: 'GET',
-      path: '/authorization/teams/{id}/users',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-        const limit = request.query.limit || config.get('authorization.defaultPageSize')
-        const page = request.query.page || 1
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/teams/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
 
-        udaru.teams.listUsers({ id, page, limit, organizationId }, reply)
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.readTeamUsers, ['id']),
-          query: _.pick(validation.readTeamUsers, ['page', 'limit']),
-          headers
-        },
-        description: 'Fetch team users given its identifier',
-        notes: 'The GET /authorization/teams/{id}/users endpoint returns the team users and pagination metadata.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.ReadTeam,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
-        },
-        response: {schema: swagger.List(swagger.User).label('PagedUsers')}
-      }
-    })
-
-    server.route({
-      method: 'PUT',
-      path: '/authorization/teams/{id}/users',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-        const { users } = request.payload
-
-        const params = {
-          id,
-          users,
-          organizationId
+      request.udaruCore.teams.deletePolicies({ id, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.teams.addUsers(params, reply)
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteTeamPolicies, ['id']),
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.addUsersToTeam, ['id']),
-          payload: _.pick(validation.addUsersToTeam, ['users']),
-          headers
-        },
-        description: 'Add team users',
-        notes: 'The PUT /authorization/teams/{id}/users endpoint adds one or more team users.',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.AddTeamMember,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Team}
-      }
-    })
-
-    server.route({
-      method: 'POST',
-      path: '/authorization/teams/{id}/users',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-        const { users } = request.payload
-
-        const params = {
-          id,
-          users,
-          organizationId
-        }
-
-        udaru.teams.replaceUsers(params, reply)
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.replaceUsersInTeam, ['id']),
-          payload: _.pick(validation.replaceUsersInTeam, ['users']),
-          headers
-        },
-        description: 'Replace team users with the given ones',
-        notes: 'The POST /authorization/teams/{id}/users endpoint replaces all team users. Existing team users are removed.',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.ReplaceTeamMember,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
-        },
-        response: {schema: swagger.Team}
-      }
-    })
-
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/teams/{id}/users',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-
-        udaru.teams.deleteMembers({ id, organizationId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply().code(204)
-        })
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteTeamMembers, ['id']),
-          headers
-        },
-        description: 'Delete all team users',
-        notes: 'The DELETE /authorization/teams/{id}/users endpoint removes all team users.',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.RemoveTeamMember,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
+      description: 'Clear all team policies',
+      notes: 'The DELETE /authorization/teams/{id}/policies endpoint removes all the team policies.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.RemoveTeamPolicy,
+          getParams: (request) => ({ teamId: request.params.id })
         }
       }
-    })
+    }
+  })
 
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/teams/{id}/users/{userId}',
-      handler: function (request, reply) {
-        const { id, userId } = request.params
-        const { organizationId } = request.udaru
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/teams/{teamId}/policies/{policyId}',
+    handler: function (request, reply) {
+      const { teamId, policyId } = request.params
+      const { organizationId } = request.udaru
 
-        udaru.teams.deleteMember({ id, userId, organizationId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
+      request.udaruCore.teams.deletePolicy({ teamId, policyId, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
 
-          return reply().code(204)
-        })
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteTeamPolicy, ['teamId', 'policyId']),
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteTeamMember, ['id', 'userId']),
-          headers
-        },
-        description: 'Delete one team member',
-        notes: 'The DELETE /authorization/teams/{id}/users/{userId} endpoint removes one user from a team.',
-        tags: ['api', 'teams'],
-        plugins: {
-          auth: {
-            action: Action.RemoveTeamMember,
-            getParams: (request) => ({ teamId: request.params.id })
-          }
+      description: 'Remove a team policy',
+      notes: 'The DELETE /authorization/teams/{teamId}/policies/{policyId} endpoint removes a specific team policy.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.RemoveTeamPolicy,
+          getParams: (request) => ({ teamId: request.params.teamId })
         }
       }
-    })
+    }
+  })
 
-    next()
-  }
+  server.route({
+    method: 'GET',
+    path: '/authorization/teams/{id}/users',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const limit = request.query.limit || server.udaruConfig.get('authorization.defaultPageSize')
+      const page = request.query.page || 1
 
-  register.attributes = {
-    name: 'teams',
-    version: '0.0.1'
-  }
+      request.udaruCore.teams.listUsers({ id, page, limit, organizationId }, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.readTeamUsers, ['id']),
+        query: _.pick(validation.readTeamUsers, ['page', 'limit']),
+        headers
+      },
+      description: 'Fetch team users given its identifier',
+      notes: 'The GET /authorization/teams/{id}/users endpoint returns the team users and pagination metadata.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.ReadTeam,
+          getParams: (request) => ({ teamId: request.params.id })
+        }
+      },
+      response: { schema: swagger.List(swagger.User).label('PagedUsers') }
+    }
+  })
 
-  return register
+  server.route({
+    method: 'PUT',
+    path: '/authorization/teams/{id}/users',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const { users } = request.payload
+
+      const params = {
+        id,
+        users,
+        organizationId
+      }
+
+      request.udaruCore.teams.addUsers(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.addUsersToTeam, ['id']),
+        payload: _.pick(validation.addUsersToTeam, ['users']),
+        headers
+      },
+      description: 'Add team users',
+      notes: 'The PUT /authorization/teams/{id}/users endpoint adds one or more team users.',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.AddTeamMember,
+          getParams: (request) => ({ teamId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Team }
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/authorization/teams/{id}/users',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const { users } = request.payload
+
+      const params = {
+        id,
+        users,
+        organizationId
+      }
+
+      request.udaruCore.teams.replaceUsers(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.replaceUsersInTeam, ['id']),
+        payload: _.pick(validation.replaceUsersInTeam, ['users']),
+        headers
+      },
+      description: 'Replace team users with the given ones',
+      notes: 'The POST /authorization/teams/{id}/users endpoint replaces all team users. Existing team users are removed.',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.ReplaceTeamMember,
+          getParams: (request) => ({ teamId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Team }
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/teams/{id}/users',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+
+      request.udaruCore.teams.deleteMembers({ id, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteTeamMembers, ['id']),
+        headers
+      },
+      description: 'Delete all team users',
+      notes: 'The DELETE /authorization/teams/{id}/users endpoint removes all team users.',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.RemoveTeamMember,
+          getParams: (request) => ({ teamId: request.params.id })
+        }
+      }
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/teams/{id}/users/{userId}',
+    handler: function (request, reply) {
+      const { id, userId } = request.params
+      const { organizationId } = request.udaru
+
+      request.udaruCore.teams.deleteMember({ id, userId, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteTeamMember, ['id', 'userId']),
+        headers
+      },
+      description: 'Delete one team member',
+      notes: 'The DELETE /authorization/teams/{id}/users/{userId} endpoint removes one user from a team.',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.RemoveTeamMember,
+          getParams: (request) => ({ teamId: request.params.id })
+        }
+      }
+    }
+  })
+
+  next()
 }
 
-module.exports = buildTeams
+exports.register.attributes = {
+  name: 'teams',
+  version: '0.0.1'
+}

--- a/lib/plugin/routes/public/teams.js
+++ b/lib/plugin/routes/public/teams.js
@@ -4,6 +4,7 @@ const _ = require('lodash')
 const Joi = require('joi')
 const swagger = require('./../../swagger')
 const headers = require('./../headers')
+const validation = require('../../../core/lib/ops/validation').teams
 
 function buildTeams (udaru, config) {
   function register (server, options, next) {
@@ -43,7 +44,7 @@ function buildTeams (udaru, config) {
         },
         validate: {
           headers,
-          query: _.pick(udaru.teams.list.validate, ['page', 'limit'])
+          query: _.pick(validation.listOrgTeams, ['page', 'limit'])
         },
         response: {schema: swagger.List(swagger.Team).label('PagedTeams')}
       }
@@ -75,7 +76,7 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          payload: _.pick(udaru.teams.create.validate, ['id', 'name', 'description', 'user']),
+          payload: _.pick(validation.createTeam, ['id', 'name', 'description', 'user']),
           headers
         },
         description: 'Create a team',
@@ -101,7 +102,7 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.read.validate, ['id']),
+          params: _.pick(validation.readTeam, ['id']),
           headers
         },
         description: 'Fetch a team given its identifier',
@@ -136,8 +137,8 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.update.validate, ['id']),
-          payload: Joi.object(_.pick(udaru.teams.update.validate, ['name', 'description'])).or('name', 'description'),
+          params: _.pick(validation.updateTeam, ['id']),
+          payload: Joi.object(_.pick(validation.updateTeam, ['name', 'description'])).or('name', 'description'),
           headers
         },
         description: 'Update a team',
@@ -170,7 +171,7 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.delete.validate, ['id']),
+          params: _.pick(validation.deleteTeam, ['id']),
           headers
         },
         description: 'Delete a team',
@@ -207,9 +208,9 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.move.validate, ['id']),
+          params: _.pick(validation.moveTeam, ['id']),
           payload: {
-            parentId: udaru.teams.move.validate.parentId.required()
+            parentId: validation.moveTeam.parentId.required()
           },
           headers
         },
@@ -248,7 +249,7 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.move.validate, ['id']),
+          params: _.pick(validation.moveTeam, ['id']),
           headers
         },
         description: 'Unnest a team',
@@ -281,8 +282,8 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.addPolicies.validate, ['id']),
-          payload: _.pick(udaru.teams.addPolicies.validate, ['policies']),
+          params: _.pick(validation.addTeamPolicies, ['id']),
+          payload: _.pick(validation.addTeamPolicies, ['policies']),
           headers
         },
         description: 'Add one or more policies to a team',
@@ -316,8 +317,8 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.replacePolicies.validate, ['id']),
-          payload: _.pick(udaru.teams.replacePolicies.validate, ['policies']),
+          params: _.pick(validation.replaceTeamPolicies, ['id']),
+          payload: _.pick(validation.replaceTeamPolicies, ['policies']),
           headers
         },
         description: 'Clear and replace policies for a team',
@@ -350,7 +351,7 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.deletePolicies.validate, ['id']),
+          params: _.pick(validation.deleteTeamPolicies, ['id']),
           headers
         },
         description: 'Clear all team policies',
@@ -382,7 +383,7 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.deletePolicy.validate, ['teamId', 'policyId']),
+          params: _.pick(validation.deleteTeamPolicy, ['teamId', 'policyId']),
           headers
         },
         description: 'Remove a team policy',
@@ -410,8 +411,8 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.listUsers.validate, ['id']),
-          query: _.pick(udaru.teams.listUsers.validate, ['page', 'limit']),
+          params: _.pick(validation.readTeamUsers, ['id']),
+          query: _.pick(validation.readTeamUsers, ['page', 'limit']),
           headers
         },
         description: 'Fetch team users given its identifier',
@@ -445,8 +446,8 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.addUsers.validate, ['id']),
-          payload: _.pick(udaru.teams.addUsers.validate, ['users']),
+          params: _.pick(validation.addUsersToTeam, ['id']),
+          payload: _.pick(validation.addUsersToTeam, ['users']),
           headers
         },
         description: 'Add team users',
@@ -480,8 +481,8 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.replaceUsers.validate, ['id']),
-          payload: _.pick(udaru.teams.replaceUsers.validate, ['users']),
+          params: _.pick(validation.replaceUsersInTeam, ['id']),
+          payload: _.pick(validation.replaceUsersInTeam, ['users']),
           headers
         },
         description: 'Replace team users with the given ones',
@@ -514,7 +515,7 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.deleteMembers.validate, ['id']),
+          params: _.pick(validation.deleteTeamMembers, ['id']),
           headers
         },
         description: 'Delete all team users',
@@ -546,7 +547,7 @@ function buildTeams (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.teams.deleteMember.validate, ['id', 'userId']),
+          params: _.pick(validation.deleteTeamMember, ['id', 'userId']),
           headers
         },
         description: 'Delete one team member',

--- a/lib/plugin/routes/public/users.js
+++ b/lib/plugin/routes/public/users.js
@@ -5,384 +5,378 @@ const swagger = require('./../../swagger')
 const headers = require('./../headers')
 const validation = require('../../../core/lib/ops/validation').users
 
-function buildUsers (udaru, config) {
-  function register (server, options, next) {
-    const Action = config.get('AuthConfig.Action')
+exports.register = function (server, options, next) {
+  const Action = server.udaruConfig.get('AuthConfig.Action')
 
-    server.route({
-      method: 'GET',
-      path: '/authorization/users',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const limit = request.query.limit || config.get('authorization.defaultPageSize')
-        const page = request.query.page || 1
+  server.route({
+    method: 'GET',
+    path: '/authorization/users',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const limit = request.query.limit || server.udaruConfig.get('authorization.defaultPageSize')
+      const page = request.query.page || 1
 
-        udaru.users.list({organizationId, limit, page}, (err, data, total) => {
-          reply(
-            err,
-            err ? null : {
-              page: page,
-              limit: limit,
-              total: total,
-              data: data
-            }
-          )
-        })
-      },
-      config: {
-        description: 'Fetch all users from the current user organization',
-        notes: 'The GET /authorization/users endpoint returns a list of all users from the current organization.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.ListUsers
+      request.udaruCore.users.list({ organizationId, limit, page }, (err, data, total) => {
+        reply(
+          err,
+          err ? null : {
+            page: page,
+            limit: limit,
+            total: total,
+            data: data
           }
-        },
-        validate: {
-          headers,
-          query: _.pick(validation.listOrgUsers, ['page', 'limit'])
-        },
-        response: {schema: swagger.List(swagger.User).label('PagedUsers')}
-      }
-    })
-
-    server.route({
-      method: 'GET',
-      path: '/authorization/users/{id}',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const id = request.params.id
-
-        udaru.users.read({ id, organizationId }, reply)
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.readUser, ['id']),
-          headers
-        },
-        description: 'Fetch a user given its identifier',
-        notes: 'The GET /authorization/users/{id} endpoint returns a single user data.\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.ReadUser,
-            getParams: (request) => ({ userId: request.params.id })
-          }
-        },
-        response: {schema: swagger.User}
-      }
-    })
-
-    server.route({
-      method: 'POST',
-      path: '/authorization/users',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const { id, name } = request.payload
-
-        udaru.users.create({ id, name, organizationId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply(res).code(201)
-        })
-      },
-      config: {
-        validate: {
-          payload: _.pick(validation.createUser, ['id', 'name']),
-          headers
-        },
-        description: 'Create a new user',
-        notes: 'The POST /authorization/users endpoint creates a new user given its data.\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.CreateUser
-          }
-        },
-        response: {schema: swagger.User}
-      }
-    })
-
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/users/{id}',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const id = request.params.id
-
-        udaru.users.delete({ id, organizationId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply().code(204)
-        })
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteUser, ['id']),
-          headers
-        },
-        description: 'Delete a user',
-        notes: 'The DELETE /authorization/users/{id} endpoint deletes a user.\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.DeleteUser,
-            getParams: (request) => ({ userId: request.params.id })
-          }
+        )
+      })
+    },
+    config: {
+      description: 'Fetch all users from the current user organization',
+      notes: 'The GET /authorization/users endpoint returns a list of all users from the current organization.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.ListUsers
         }
-      }
-    })
-
-    server.route({
-      method: 'PUT',
-      path: '/authorization/users/{id}',
-      handler: function (request, reply) {
-        const { organizationId } = request.udaru
-        const id = request.params.id
-        const { name } = request.payload
-
-        const params = {
-          id,
-          organizationId,
-          name
-        }
-        udaru.users.update(params, reply)
       },
-      config: {
-        validate: {
-          params: _.pick(validation.updateUser, ['id']),
-          payload: _.pick(validation.updateUser, ['name']),
-          headers
-        },
-        description: 'Update a user',
-        notes: 'The PUT /authorization/users/{id} endpoint updates the user data.\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.UpdateUser,
-            getParams: (request) => ({ userId: request.params.id })
-          }
-        },
-        response: {schema: swagger.User}
-      }
-    })
-
-    server.route({
-      method: 'PUT',
-      path: '/authorization/users/{id}/policies',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-        const { policies } = request.payload
-
-        const params = {
-          id,
-          organizationId,
-          policies
-        }
-        udaru.users.addPolicies(params, reply)
+      validate: {
+        headers,
+        query: _.pick(validation.listOrgUsers, ['page', 'limit'])
       },
-      config: {
-        validate: {
-          params: _.pick(validation.addUserPolicies, ['id']),
-          payload: _.pick(validation.addUserPolicies, ['policies']),
-          headers
-        },
-        description: 'Add one or more policies to a user',
-        notes: 'The PUT /authorization/users/{id}/policies endpoint adds one or more policies to a user.\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.AddUserPolicy,
-            getParams: (request) => ({ userId: request.params.id })
-          }
-        },
-        response: {schema: swagger.User}
-      }
-    })
+      response: { schema: swagger.List(swagger.User).label('PagedUsers') }
+    }
+  })
 
-    server.route({
-      method: 'POST',
-      path: '/authorization/users/{id}/policies',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-        const { policies } = request.payload
+  server.route({
+    method: 'GET',
+    path: '/authorization/users/{id}',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const id = request.params.id
 
-        const params = {
-          id,
-          organizationId,
-          policies
+      request.udaruCore.users.read({ id, organizationId }, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.readUser, ['id']),
+        headers
+      },
+      description: 'Fetch a user given its identifier',
+      notes: 'The GET /authorization/users/{id} endpoint returns a single user data.\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.ReadUser,
+          getParams: (request) => ({ userId: request.params.id })
+        }
+      },
+      response: { schema: swagger.User }
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/authorization/users',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const { id, name } = request.payload
+
+      request.udaruCore.users.create({ id, name, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.users.replacePolicies(params, reply)
+        return reply(res).code(201)
+      })
+    },
+    config: {
+      validate: {
+        payload: _.pick(validation.createUser, ['id', 'name']),
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.replaceUserPolicies, ['id']),
-          payload: _.pick(validation.replaceUserPolicies, ['policies']),
-          headers
-        },
-        description: 'Clear and replace policies for a user',
-        notes: 'The POST /authorization/users/{id}/policies endpoint replaces all the user policies. Existing user policies are removed.\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.ReplaceUserPolicy,
-            getParams: (request) => ({ userId: request.params.id })
-          }
-        },
-        response: {schema: swagger.User}
-      }
-    })
-
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/users/{id}/policies',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-
-        udaru.users.deletePolicies({ id, organizationId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply().code(204)
-        })
-      },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteUserPolicies, ['id']),
-          headers
-        },
-        description: 'Clear all user\'s policies',
-        notes: 'The DELETE /authorization/users/{id}/policies endpoint removes all the user policies.\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.RemoveUserPolicy,
-            getParams: (request) => ({ userId: request.params.id })
-          }
+      description: 'Create a new user',
+      notes: 'The POST /authorization/users endpoint creates a new user given its data.\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.CreateUser
         }
-      }
-    })
-
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/users/{userId}/policies/{policyId}',
-      handler: function (request, reply) {
-        const { userId, policyId } = request.params
-        const { organizationId } = request.udaru
-
-        udaru.users.deletePolicy({ userId, policyId, organizationId }, function (err, res) {
-          if (err) {
-            return reply(err)
-          }
-
-          return reply().code(204)
-        })
       },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteUserPolicy, ['userId', 'policyId']),
-          headers
-        },
-        description: 'Remove a user\'s policy',
-        notes: 'The DELETE /authorization/users/{userId}/policies/{policyId} endpoint removes a specific user\'s policy.\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.RemoveUserPolicy,
-            getParams: (request) => ({
-              userId: request.params.userId,
-              policyId: request.params.policyId
-            })
-          }
-        }
-      }
-    })
+      response: { schema: swagger.User }
+    }
+  })
 
-    server.route({
-      method: 'POST',
-      path: '/authorization/users/{id}/teams',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
-        const { teams } = request.payload
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/users/{id}',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const id = request.params.id
 
-        const params = {
-          id,
-          organizationId,
-          teams
+      request.udaruCore.users.delete({ id, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.users.replaceTeams(params, reply)
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteUser, ['id']),
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.replaceUserTeams, ['id']),
-          payload: _.pick(validation.replaceUserTeams, ['teams']),
-          headers
-        },
-        description: 'Clear and replace user teams',
-        notes: 'The POST /authorization/users/{id}/teams endpoint replaces all the user teams. This can be use to move a user from a team to another (or a set of teams to another).\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.ReplaceUserTeams,
-            getParams: (request) => ({ userId: request.params.id })
-          }
-        },
-        response: {schema: swagger.User}
+      description: 'Delete a user',
+      notes: 'The DELETE /authorization/users/{id} endpoint deletes a user.\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.DeleteUser,
+          getParams: (request) => ({ userId: request.params.id })
+        }
       }
-    })
+    }
+  })
 
-    server.route({
-      method: 'DELETE',
-      path: '/authorization/users/{id}/teams',
-      handler: function (request, reply) {
-        const { id } = request.params
-        const { organizationId } = request.udaru
+  server.route({
+    method: 'PUT',
+    path: '/authorization/users/{id}',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const id = request.params.id
+      const { name } = request.payload
 
-        const params = {
-          id,
-          organizationId
+      const params = {
+        id,
+        organizationId,
+        name
+      }
+      request.udaruCore.users.update(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.updateUser, ['id']),
+        payload: _.pick(validation.updateUser, ['name']),
+        headers
+      },
+      description: 'Update a user',
+      notes: 'The PUT /authorization/users/{id} endpoint updates the user data.\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.UpdateUser,
+          getParams: (request) => ({ userId: request.params.id })
+        }
+      },
+      response: { schema: swagger.User }
+    }
+  })
+
+  server.route({
+    method: 'PUT',
+    path: '/authorization/users/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const { policies } = request.payload
+
+      const params = {
+        id,
+        organizationId,
+        policies
+      }
+      request.udaruCore.users.addPolicies(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.addUserPolicies, ['id']),
+        payload: _.pick(validation.addUserPolicies, ['policies']),
+        headers
+      },
+      description: 'Add one or more policies to a user',
+      notes: 'The PUT /authorization/users/{id}/policies endpoint adds one or more policies to a user.\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.AddUserPolicy,
+          getParams: (request) => ({ userId: request.params.id })
+        }
+      },
+      response: { schema: swagger.User }
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/authorization/users/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const { policies } = request.payload
+
+      const params = {
+        id,
+        organizationId,
+        policies
+      }
+
+      request.udaruCore.users.replacePolicies(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.replaceUserPolicies, ['id']),
+        payload: _.pick(validation.replaceUserPolicies, ['policies']),
+        headers
+      },
+      description: 'Clear and replace policies for a user',
+      notes: 'The POST /authorization/users/{id}/policies endpoint replaces all the user policies. Existing user policies are removed.\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.ReplaceUserPolicy,
+          getParams: (request) => ({ userId: request.params.id })
+        }
+      },
+      response: { schema: swagger.User }
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/users/{id}/policies',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+
+      request.udaruCore.users.deletePolicies({ id, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
         }
 
-        udaru.users.deleteTeams(params, reply)
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteUserPolicies, ['id']),
+        headers
       },
-      config: {
-        validate: {
-          params: _.pick(validation.deleteUserFromTeams, ['id']),
-          headers
-        },
-        description: 'Delete teams for a user',
-        notes: 'The DELETE /authorization/users/{id}/teams endpoint deletes user from all her teams.\n',
-        tags: ['api', 'users'],
-        plugins: {
-          auth: {
-            action: Action.DeleteUserTeams,
-            getParams: (request) => ({ userId: request.params.id })
-          }
-        },
-        response: {schema: swagger.User}
+      description: 'Clear all user\'s policies',
+      notes: 'The DELETE /authorization/users/{id}/policies endpoint removes all the user policies.\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.RemoveUserPolicy,
+          getParams: (request) => ({ userId: request.params.id })
+        }
       }
-    })
+    }
+  })
 
-    next()
-  }
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/users/{userId}/policies/{policyId}',
+    handler: function (request, reply) {
+      const { userId, policyId } = request.params
+      const { organizationId } = request.udaru
 
-  register.attributes = {
-    name: 'users',
-    version: '0.0.1'
-  }
+      request.udaruCore.users.deletePolicy({ userId, policyId, organizationId }, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
 
-  return register
+        return reply().code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteUserPolicy, ['userId', 'policyId']),
+        headers
+      },
+      description: 'Remove a user\'s policy',
+      notes: 'The DELETE /authorization/users/{userId}/policies/{policyId} endpoint removes a specific user\'s policy.\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.RemoveUserPolicy,
+          getParams: (request) => ({
+            userId: request.params.userId,
+            policyId: request.params.policyId
+          })
+        }
+      }
+    }
+  })
+
+  server.route({
+    method: 'POST',
+    path: '/authorization/users/{id}/teams',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+      const { teams } = request.payload
+
+      const params = {
+        id,
+        organizationId,
+        teams
+      }
+
+      request.udaruCore.users.replaceTeams(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.replaceUserTeams, ['id']),
+        payload: _.pick(validation.replaceUserTeams, ['teams']),
+        headers
+      },
+      description: 'Clear and replace user teams',
+      notes: 'The POST /authorization/users/{id}/teams endpoint replaces all the user teams. This can be use to move a user from a team to another (or a set of teams to another).\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.ReplaceUserTeams,
+          getParams: (request) => ({ userId: request.params.id })
+        }
+      },
+      response: { schema: swagger.User }
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/users/{id}/teams',
+    handler: function (request, reply) {
+      const { id } = request.params
+      const { organizationId } = request.udaru
+
+      const params = {
+        id,
+        organizationId
+      }
+
+      request.udaruCore.users.deleteTeams(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteUserFromTeams, ['id']),
+        headers
+      },
+      description: 'Delete teams for a user',
+      notes: 'The DELETE /authorization/users/{id}/teams endpoint deletes user from all her teams.\n',
+      tags: ['api', 'users'],
+      plugins: {
+        auth: {
+          action: Action.DeleteUserTeams,
+          getParams: (request) => ({ userId: request.params.id })
+        }
+      },
+      response: { schema: swagger.User }
+    }
+  })
+
+  next()
 }
 
-module.exports = buildUsers
+exports.register.attributes = {
+  name: 'users',
+  version: '0.0.1'
+}

--- a/lib/plugin/routes/public/users.js
+++ b/lib/plugin/routes/public/users.js
@@ -3,6 +3,7 @@
 const _ = require('lodash')
 const swagger = require('./../../swagger')
 const headers = require('./../headers')
+const validation = require('../../../core/lib/ops/validation').users
 
 function buildUsers (udaru, config) {
   function register (server, options, next) {
@@ -39,7 +40,7 @@ function buildUsers (udaru, config) {
         },
         validate: {
           headers,
-          query: _.pick(udaru.users.list.validate, ['page', 'limit'])
+          query: _.pick(validation.listOrgUsers, ['page', 'limit'])
         },
         response: {schema: swagger.List(swagger.User).label('PagedUsers')}
       }
@@ -56,7 +57,7 @@ function buildUsers (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.users.read.validate, ['id']),
+          params: _.pick(validation.readUser, ['id']),
           headers
         },
         description: 'Fetch a user given its identifier',
@@ -89,7 +90,7 @@ function buildUsers (udaru, config) {
       },
       config: {
         validate: {
-          payload: _.pick(udaru.users.create.validate, ['id', 'name']),
+          payload: _.pick(validation.createUser, ['id', 'name']),
           headers
         },
         description: 'Create a new user',
@@ -121,7 +122,7 @@ function buildUsers (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.users.delete.validate, ['id']),
+          params: _.pick(validation.deleteUser, ['id']),
           headers
         },
         description: 'Delete a user',
@@ -153,8 +154,8 @@ function buildUsers (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.users.update.validate, ['id']),
-          payload: _.pick(udaru.users.update.validate, ['name']),
+          params: _.pick(validation.updateUser, ['id']),
+          payload: _.pick(validation.updateUser, ['name']),
           headers
         },
         description: 'Update a user',
@@ -187,8 +188,8 @@ function buildUsers (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.users.addPolicies.validate, ['id']),
-          payload: _.pick(udaru.users.addPolicies.validate, ['policies']),
+          params: _.pick(validation.addUserPolicies, ['id']),
+          payload: _.pick(validation.addUserPolicies, ['policies']),
           headers
         },
         description: 'Add one or more policies to a user',
@@ -222,8 +223,8 @@ function buildUsers (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.users.replacePolicies.validate, ['id']),
-          payload: _.pick(udaru.users.replacePolicies.validate, ['policies']),
+          params: _.pick(validation.replaceUserPolicies, ['id']),
+          payload: _.pick(validation.replaceUserPolicies, ['policies']),
           headers
         },
         description: 'Clear and replace policies for a user',
@@ -256,7 +257,7 @@ function buildUsers (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.users.deletePolicies.validate, ['id']),
+          params: _.pick(validation.deleteUserPolicies, ['id']),
           headers
         },
         description: 'Clear all user\'s policies',
@@ -288,7 +289,7 @@ function buildUsers (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.users.deletePolicy.validate, ['userId', 'policyId']),
+          params: _.pick(validation.deleteUserPolicy, ['userId', 'policyId']),
           headers
         },
         description: 'Remove a user\'s policy',
@@ -324,8 +325,8 @@ function buildUsers (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.users.replaceTeams.validate, ['id']),
-          payload: _.pick(udaru.users.replaceTeams.validate, ['teams']),
+          params: _.pick(validation.replaceUserTeams, ['id']),
+          payload: _.pick(validation.replaceUserTeams, ['teams']),
           headers
         },
         description: 'Clear and replace user teams',
@@ -357,7 +358,7 @@ function buildUsers (udaru, config) {
       },
       config: {
         validate: {
-          params: _.pick(udaru.users.deleteTeams.validate, ['id']),
+          params: _.pick(validation.deleteUserFromTeams, ['id']),
           headers
         },
         description: 'Delete teams for a user',

--- a/lib/plugin/security/authorization.js
+++ b/lib/plugin/security/authorization.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
 const Boom = require('boom')
 const async = require('async')
 
-function buildAuthorization (udaru, config) {
+function buildAuthorization (config) {
   const Action = config.get('AuthConfig.Action')
   const actionsNeedingValidation = [Action.ReplaceUserTeams, Action.DeleteUserTeams]
 
@@ -31,7 +31,7 @@ function buildAuthorization (udaru, config) {
       const requestParams = authParams.getParams ? authParams.getParams(request) : {}
       const organizationId = request.headers.org || currentUser.organizationId
 
-      udaru.users.read({ id: requestParams.userId, organizationId }, function (err, user) {
+      request.udaruCore.users.read({ id: requestParams.userId, organizationId }, function (err, user) {
         if (err) return callback(err)
 
         return callback(null, user.teams.map(t => t.id))
@@ -56,7 +56,7 @@ function buildAuthorization (udaru, config) {
       const { user: currentUser } = request.udaru
       const authParams = getAuthParams(request)
       const resourceType = request.route.path.split('/')[2]
-      const resourceBuilder = config.get('AuthConfig.resources')[resourceType]
+      const resourceBuilder = server.udaruConfig.get('AuthConfig.resources')[resourceType]
 
       if (!resourceBuilder) {
         return reply(Boom.badImplentation('Resource builder not found'))
@@ -72,7 +72,7 @@ function buildAuthorization (udaru, config) {
         const { action } = authParams
 
         return function check (callback) {
-          udaru.authorize.isUserAuthorized({ userId: currentUser.id, action, resource, organizationId: currentUser.organizationId }, (err, result) => {
+          request.udaruCore.authorize.isUserAuthorized({ userId: currentUser.id, action, resource, organizationId: currentUser.organizationId }, (err, result) => {
             if (err || !result || !result.access) return callback(err || new Error(`Not enough permissions to modify team ${team}`))
             callback()
           })

--- a/lib/plugin/security/hapi-auth-service.js
+++ b/lib/plugin/security/hapi-auth-service.js
@@ -2,7 +2,7 @@
 
 const Hoek = require('hoek')
 
-function buildHapiAuthService (udaru, config, authorization) {
+function buildHapiAuthService (authorization) {
   const internals = {}
   internals.implementation = function (server, options) {
     Hoek.assert(options, 'Missing service auth strategy options')

--- a/lib/plugin/security/hapi-auth-validation.js
+++ b/lib/plugin/security/hapi-auth-validation.js
@@ -3,9 +3,9 @@
 const async = require('async')
 const Boom = require('boom')
 
-function buildAuthValidation (udaru, config, authorization) {
-  function canImpersonate (options, user) {
-    return user.organizationId === config.get('authorization.superUser.organization.id')
+function buildAuthValidation (authorization) {
+  function canImpersonate (request, user) {
+    return user.organizationId === request.server.udaruConfig.get('authorization.superUser.organization.id')
   }
 
   function loadUser (job, next) {
@@ -27,7 +27,7 @@ function buildAuthValidation (udaru, config, authorization) {
     const { currentUser } = job
     job.organizationId = currentUser.organizationId
 
-    if (canImpersonate(job.options, currentUser) && job.requestedOrganizationId) {
+    if (canImpersonate(job.request, currentUser) && job.requestedOrganizationId) {
       job.organizationId = job.requestedOrganizationId
     }
 
@@ -73,7 +73,7 @@ function buildAuthValidation (udaru, config, authorization) {
     }
 
     const resourceType = request.route.path.split('/')[2]
-    const resourceBuilder = config.get('AuthConfig.resources')[resourceType]
+    const resourceBuilder = request.server.udaruConfig.get('AuthConfig.resources')[resourceType]
 
     if (!resourceBuilder) {
       return done(new Error('Resource builder not found'))
@@ -108,6 +108,7 @@ function buildAuthValidation (udaru, config, authorization) {
 
   function authValidation (options, server, request, userId, callback) {
     const authParams = authorization.getAuthParams(request)
+    const udaru = request.udaruCore
 
     if (!authParams) {
       return callback(Boom.forbidden('Invalid credentials', 'udaru'))

--- a/lib/policiesLoader.js
+++ b/lib/policiesLoader.js
@@ -2,7 +2,7 @@
 
 const jsonfile = require('jsonfile')
 const config = require('./config/build-all')()
-const udaru = require('./core')({config})
+const udaru = require('./core')(null, config)
 const db = require('./core/lib/db')(null, config)
 
 function exit (message) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1893,6 +1893,15 @@
       "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
       "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
     },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "fs-extra": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
@@ -3167,6 +3176,12 @@
       "integrity": "sha1-OGchPo3Xm/Ho8jAMDPwe+xgsDfE=",
       "dev": true
     },
+    "just-extend": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.22.tgz",
+      "integrity": "sha1-MzCvdWyralQnAMZLLk5KoGLVL/8=",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -3488,6 +3503,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.5.tgz",
       "integrity": "sha1-euTsJXMC/XkNVXyxDJcQDYV7AFY=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.1.3.tgz",
+      "integrity": "sha512-BdHq78SeI+6PAUtl4atDuCt7L6E4fab3mSRtqxm4ywaXe4uP7jZ0TTcFNuU20syUjxZc2l7jFqKVMJ+AX0LnpQ==",
       "dev": true
     },
     "longest": {
@@ -3812,6 +3833,12 @@
         "node-pre-gyp": "0.6.36"
       }
     },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3829,6 +3856,27 @@
       "requires": {
         "hoek": "4.2.0",
         "vise": "2.0.2"
+      }
+    },
+    "nise": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.1.1.tgz",
+      "integrity": "sha512-f5DMJB0MqBaSuP2NAwPx7HyVKPdaozds0KsNe9XIP3npKWt/QUg73l5TTLRTSwfG/Y3AB0ktacuxX4QNcg6vVw==",
+      "dev": true,
+      "requires": {
+        "formatio": "1.2.0",
+        "just-extend": "1.1.22",
+        "lolex": "1.6.0",
+        "path-to-regexp": "1.7.0",
+        "text-encoding": "0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+          "dev": true
+        }
       }
     },
     "no-arrowception": {
@@ -4109,6 +4157,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "pbac": {
       "version": "0.1.3",
@@ -5083,6 +5148,12 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
+    },
     "seedrandom": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
@@ -5168,6 +5239,24 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "sinon": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.0.1.tgz",
+      "integrity": "sha512-4qIY0pCWCvGCJpV/1JkFu9kbsNEZ9O34cG1oru/c7OCDtrEs50Gq/VjkA2ID5ZwLyoNx1i1ws118oh/p6fVeDg==",
+      "dev": true,
+      "requires": {
+        "diff": "3.3.0",
+        "formatio": "1.2.0",
+        "lodash.get": "4.4.2",
+        "lolex": "2.1.3",
+        "native-promise-only": "0.8.1",
+        "nise": "1.1.1",
+        "path-to-regexp": "1.7.0",
+        "samsam": "1.3.0",
+        "text-encoding": "0.6.4",
+        "type-detect": "4.0.3"
+      }
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -5930,6 +6019,12 @@
         "sprintf": "0.1.5"
       }
     },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -6079,6 +6174,12 @@
       "requires": {
         "prelude-ls": "1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "remark-cli": "^4.0.0",
     "remark-lint": "^6.0.0",
     "remark-preset-lint-recommended": "^3.0.0",
+    "sinon": "^4.0.1",
     "standard": "^8.6.0",
     "swagger-gen": "^1.1.3"
   },

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -8,7 +8,7 @@ const buildConfig = require('../lib/config')
 
 const fullConfig = buildConfig({}, config)
 const db = buildDb(null, fullConfig)
-const udaru = buildUdaru(fullConfig)
+const udaru = buildUdaru(null, fullConfig)
 
 function createOrganization (job, next) {
   const superOrganizationData = config.get('authorization.superUser.organization')

--- a/test/factory.js
+++ b/test/factory.js
@@ -4,7 +4,6 @@ const async = require('async')
 const _ = require('lodash')
 
 const utils = require('./utils')
-const { udaru } = utils
 
 const DEFAULT_POLICY = {
   version: '2016-07-01',
@@ -19,7 +18,8 @@ const DEFAULT_POLICY = {
   organizationId: 'WONKA'
 }
 
-function Factory (lab, data) {
+function Factory (lab, data, udaruCore) {
+  const udaru = udaruCore || utils.udaru
   const records = {}
 
   function createUsers (done) {

--- a/test/unit/db.test.js
+++ b/test/unit/db.test.js
@@ -2,6 +2,7 @@
 
 const expect = require('code').expect
 const Lab = require('lab')
+const Sinon = require('sinon')
 const lab = exports.lab = Lab.script()
 
 const logs = []
@@ -11,7 +12,8 @@ var client = {
   query: function (sql, callback) {
     logs.push(sql)
     callback()
-  }
+  },
+  end: () => {}
 }
 
 const tasks = [
@@ -37,6 +39,14 @@ lab.experiment('bd', () => {
     logs.length = 0
 
     done()
+  })
+
+  lab.test('pool passed from outside is not ended when shutdown called', (done) => {
+    const endSpy = Sinon.spy(client, 'end')
+    db.shutdown(() => {
+      expect(endSpy.callCount).to.equal(0)
+      done()
+    })
   })
 
   lab.test('run simple query will call the pool.query helper method', (done) => {


### PR DESCRIPTION
The purpose of this PR is to remove the dependency on a common Udaru Core instance passed as parameter to routes and other functionality at the plugin level.

The changes are the following:
- All routes expect a decorated Udaru instance on request,
- Routes Joi validation is used by directly requiring the Joi validation files. Validation is not gathered any more from a common Udaru instance,
- The authorization checks made at route level are using the Udaru core instance decorated on request
- The service has an option with wich the Udaru core decoration can be disabled (it is enabled by default). This allows Udaru core to be passed from outside from the service level.
- Added a small change on the Factory used by tests to generate data in db. As it was using a default Udaru core (with default settings) added the possibility to pass the Udaru core instance from outside.

While doing the changes did also two fixes:
- A db pool passed from outside should not be released by Udaru core,
- config params were not properly passed from the plugin level to Udaru core level.

This dependency removal offers the users of Udaru the option to pass from outside their own Udaru core instance and in a multitenant environment pass different per tenant Udaru core Instances on each request. https://github.com/nearform/udaru/issues/430

Each step is made as a separate commit to make the review easier.