### PR TITLE
Introduce policy templates

### DIFF
--- a/database/migrations/004.do.sql
+++ b/database/migrations/004.do.sql
@@ -1,0 +1,4 @@
+
+ALTER TABLE user_policies ADD column variables JSONB DEFAULT '{}';
+ALTER TABLE team_policies ADD column variables JSONB DEFAULT '{}';
+ALTER TABLE organization_policies ADD column variables JSONB DEFAULT '{}';

--- a/database/migrations/004.do.sql
+++ b/database/migrations/004.do.sql
@@ -2,3 +2,12 @@
 ALTER TABLE user_policies ADD column variables JSONB DEFAULT '{}';
 ALTER TABLE team_policies ADD column variables JSONB DEFAULT '{}';
 ALTER TABLE organization_policies ADD column variables JSONB DEFAULT '{}';
+
+ALTER TABLE user_policies DROP CONSTRAINT user_policy_link;
+ALTER TABLE user_policies ADD CONSTRAINT user_policy_link PRIMARY KEY(policy_id, user_id, variables);
+
+ALTER TABLE team_policies DROP CONSTRAINT team_policy_link;
+ALTER TABLE team_policies ADD CONSTRAINT team_policy_link PRIMARY KEY(policy_id, team_id, variables);
+
+ALTER TABLE organization_policies DROP CONSTRAINT org_policy_link;
+ALTER TABLE organization_policies ADD CONSTRAINT org_policy_link PRIMARY KEY(policy_id, org_id, variables);

--- a/database/migrations/004.undo.sql
+++ b/database/migrations/004.undo.sql
@@ -1,0 +1,4 @@
+
+ALTER TABLE user_policies DROP column variables;
+ALTER TABLE team_policies DROP column variables;
+ALTER TABLE organization_policies DROP column variables;

--- a/database/migrations/004.undo.sql
+++ b/database/migrations/004.undo.sql
@@ -1,4 +1,13 @@
 
+ALTER TABLE user_policies DROP CONSTRAINT user_policy_link;
+ALTER TABLE user_policies ADD CONSTRAINT user_policy_link PRIMARY KEY(policy_id, user_id);
+
+ALTER TABLE team_policies DROP CONSTRAINT team_policy_link;
+ALTER TABLE team_policies ADD CONSTRAINT team_policy_link PRIMARY KEY(policy_id, team_id);
+
+ALTER TABLE organization_policies DROP CONSTRAINT org_policy_link;
+ALTER TABLE organization_policies ADD CONSTRAINT org_policy_link PRIMARY KEY(policy_id, org_id);
+
 ALTER TABLE user_policies DROP column variables;
 ALTER TABLE team_policies DROP column variables;
 ALTER TABLE organization_policies DROP column variables;

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -146,6 +146,62 @@ Note that wildcards can be used in Action and Resource names, as can certain var
 
 For a detailed description of Policies, see the [AWS Policy Elements Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html).
 
+## Template Policies
+
+In order to reduce complexity and duplication Udaru introduces template policies.
+
+For an example let's assume we want to create a generic policy "can read document".
+
+The regular way to do it would be with something like
+
+```javascript
+{
+  id: 'Policy ID',
+  version: '2016-07-01',
+  name: 'Read document 1',
+  statements: { Statement: [{
+    Effect: 'Allow',
+    Action: ['Documents:Read'],
+    Resource: ['wonka:documents:/public/document-1']
+  }] }
+}
+```
+
+This will work, but is fixed to "document-1".
+
+With policy templates you could create
+
+```javascript
+{
+  id: 'Policy ID',
+  version: '2016-07-01',
+  name: 'Read generic document',
+  statements: { Statement: [{
+    Effect: 'Allow',
+    Action: ['Documents:Read'],
+    Resource: ['wonka:documents:/public/${documentId}']
+  }] }
+}
+```
+
+And then provide the value for `documentId` when assigning the policy to a user with
+
+```javascript
+{
+  id: 'Policy ID',
+  variables: {documentId: 'document-1'}
+}
+```
+
+This will reduce the number of policies required, while still being specific on the documents a user can read.
+
+
+Template policies are actually regular policies that use variables. The difference is that the value of the variables, rather than being obtained from context at run time, is defined on policy assignment.
+
+When a policy is assigned to a user (or a team) an additional object can be provided whose properties will be used as the value for the variables in the policy itself.
+
+Currently we support variables in the Resource part of the policy statement (similar o what PBAC already does)
+
 ## Super User
 
 In Udaru all operations are performed in the organization context: for each user request Udaru finds the organization to which the user belongs to and from there all middleware checks and element queries are made in the organization context. One user can't perform operations outside the organization to which it belongs to. The user identifier is passed in the Http headers as the `authorization` field.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -200,7 +200,7 @@ Template policies are actually regular policies that use variables. The differen
 
 When a policy is assigned to a user (or a team) an additional object can be provided whose properties will be used as the value for the variables in the policy itself.
 
-Currently we support variables in the Resource part of the policy statement (similar o what PBAC already does)
+Currently we support variables in the Resource part of the policy statement (similar to what PBAC already does)
 
 ## Super User
 

--- a/lib/core/lib/mapping.js
+++ b/lib/core/lib/mapping.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const _ = require('lodash')
+
 function mapOrganization (row) {
   return {
     id: row.id,
@@ -17,11 +19,27 @@ function mapPolicy (row) {
   }
 }
 
+function compileStatements (statements, variables) {
+  _.each(statements, function (statement) {
+    if (statement.Resource) {
+      statement.Resource = _.map(statement.Resource, function (resource) {
+        return resource.replace(/\${(.+?)}/g, function (match, variable) {
+          return _.get(variables, variable, match)
+        })
+      })
+    }
+  })
+
+  return statements
+}
+
 function mapIamPolicy (row) {
+  const variables = row.variables || {}
+
   return {
     Version: row.version,
     Name: row.name,
-    Statement: row.statements.Statement
+    Statement: compileStatements(row.statements.Statement, variables)
   }
 }
 
@@ -29,7 +47,8 @@ function mapPolicySimple (row) {
   return {
     id: row.id,
     name: row.name,
-    version: row.version
+    version: row.version,
+    variables: row.variables || {}
   }
 }
 

--- a/lib/core/lib/ops/organizationOps.js
+++ b/lib/core/lib/ops/organizationOps.js
@@ -143,7 +143,7 @@ function buildOrganizationOps (db, config) {
         if (err) return next(err)
         job.user.id = res.rows[0].id
 
-        userOps.insertPolicies(job.client, job.user.id, [job.adminPolicyId], utils.boomErrorWrapper(next))
+        userOps.insertPolicies(job.client, job.user.id, [{id: job.adminPolicyId}], utils.boomErrorWrapper(next))
       })
 
       return
@@ -230,7 +230,7 @@ function buildOrganizationOps (db, config) {
 
       tasks.push((next) => {
         const sqlQuery = SQL`
-          SELECT pol.id, pol.name, pol.version
+          SELECT pol.id, pol.name, pol.version, org_pol.variables
           FROM organization_policies org_pol, policies pol
           WHERE org_pol.org_id = ${id} AND org_pol.policy_id = pol.id
           ORDER BY UPPER(pol.name)
@@ -380,7 +380,7 @@ function buildOrganizationOps (db, config) {
         },
         (job, next) => {
           job.id = id
-          job.policies = policies
+          job.policies = utils.preparePolicies(policies)
 
           next()
         },
@@ -423,7 +423,7 @@ function buildOrganizationOps (db, config) {
         },
         (job, next) => {
           job.id = id
-          job.policies = policies
+          job.policies = utils.preparePolicies(policies)
 
           next()
         },
@@ -505,16 +505,21 @@ function buildOrganizationOps (db, config) {
     },
 
     insertPolicies: function insertPolicies (client, id, policies, cb) {
+      if (policies.length === 0) return cb()
+
       const sqlQuery = SQL`
         INSERT INTO organization_policies (
-          policy_id, org_id
+          policy_id, org_id, variables
         ) VALUES
       `
-      sqlQuery.append(SQL`(${policies[0]}, ${id})`)
-      policies.slice(1).forEach((policyId) => {
-        sqlQuery.append(SQL`, (${policyId}, ${id})`)
+      sqlQuery.append(SQL`(${policies[0].id}, ${id}, ${policies[0].variables})`)
+      policies.slice(1).forEach((policy) => {
+        sqlQuery.append(SQL`, (${policy.id}, ${id}, ${policy.variables})`)
       })
-      sqlQuery.append(SQL` ON CONFLICT ON CONSTRAINT org_policy_link DO NOTHING`)
+      sqlQuery.append(SQL` ON CONFLICT ON CONSTRAINT org_policy_link
+        DO UPDATE SET variables = excluded.variables
+        WHERE organization_policies.policy_id = excluded.policy_id
+        AND organization_policies.org_id = excluded.org_id`)
 
       client.query(sqlQuery, utils.boomErrorWrapper(cb))
     }

--- a/lib/core/lib/ops/organizationOps.js
+++ b/lib/core/lib/ops/organizationOps.js
@@ -143,7 +143,7 @@ function buildOrganizationOps (db, config) {
         if (err) return next(err)
         job.user.id = res.rows[0].id
 
-        userOps.insertPolicies(job.client, job.user.id, [{id: job.adminPolicyId}], utils.boomErrorWrapper(next))
+        userOps.insertPolicies(job.client, job.user.id, [{id: job.adminPolicyId, variables: {}}], utils.boomErrorWrapper(next))
       })
 
       return
@@ -516,10 +516,7 @@ function buildOrganizationOps (db, config) {
       policies.slice(1).forEach((policy) => {
         sqlQuery.append(SQL`, (${policy.id}, ${id}, ${policy.variables})`)
       })
-      sqlQuery.append(SQL` ON CONFLICT ON CONSTRAINT org_policy_link
-        DO UPDATE SET variables = excluded.variables
-        WHERE organization_policies.policy_id = excluded.policy_id
-        AND organization_policies.org_id = excluded.org_id`)
+      sqlQuery.append(SQL` ON CONFLICT ON CONSTRAINT org_policy_link DO NOTHING`)
 
       client.query(sqlQuery, utils.boomErrorWrapper(cb))
     }

--- a/lib/core/lib/ops/policyOps.js
+++ b/lib/core/lib/ops/policyOps.js
@@ -320,22 +320,52 @@ function buildPolicyOps (db, config) {
           version,
           name,
           statements,
-          COALESCE(
-            policies_from_user.variables,
-            policies_from_teams.variables,
-            policies_from_organization.variables
-          ) AS variables
+          policies_from_user.variables AS variables
         FROM
           policies
-        LEFT JOIN
+        INNER JOIN
           policies_from_user
         ON
           policies.id = policies_from_user.policy_id
-        LEFT JOIN
+        WHERE (
+            org_id = ${organizationId}
+          OR (
+              EXISTS (SELECT FROM is_root_user)
+            AND
+              org_id = ${rootOrgId}
+          )
+        )
+        UNION
+        SELECT
+          id,
+          version,
+          name,
+          statements,
+          policies_from_teams.variables AS variables
+        FROM
+          policies
+        INNER JOIN
           policies_from_teams
         ON
           policies.id = policies_from_teams.policy_id
-        LEFT JOIN
+        WHERE (
+            org_id = ${organizationId}
+          OR (
+              EXISTS (SELECT FROM is_root_user)
+            AND
+              org_id = ${rootOrgId}
+          )
+        )
+        UNION
+        SELECT
+          id,
+          version,
+          name,
+          statements,
+          policies_from_organization.variables
+        FROM
+          policies
+        INNER JOIN
           policies_from_organization
         ON
           policies.id = policies_from_organization.policy_id
@@ -346,13 +376,6 @@ function buildPolicyOps (db, config) {
             AND
               org_id = ${rootOrgId}
           )
-        )
-        AND (
-            policies_from_user.policy_id IS NOT NULL
-          OR
-            policies_from_teams.policy_id IS NOT NULL
-          OR
-            policies_from_organization.policy_id IS NOT NULL
         )
       `
 

--- a/lib/core/lib/ops/policyOps.js
+++ b/lib/core/lib/ops/policyOps.js
@@ -288,7 +288,7 @@ function buildPolicyOps (db, config) {
         ),
         policies_from_teams AS (
           SELECT
-            policy_id
+            policy_id, variables
           FROM
             team_policies
           WHERE
@@ -296,7 +296,7 @@ function buildPolicyOps (db, config) {
         ),
         policies_from_user AS (
           SELECT
-            policy_id
+            policy_id, variables
           FROM
             user_policies
           WHERE
@@ -304,7 +304,7 @@ function buildPolicyOps (db, config) {
         ),
         policies_from_organization AS (
           SELECT
-            op.policy_id
+            op.policy_id, variables
           FROM
             organization_policies op
           LEFT JOIN
@@ -319,9 +319,26 @@ function buildPolicyOps (db, config) {
           id,
           version,
           name,
-          statements
+          statements,
+          COALESCE(
+            policies_from_user.variables,
+            policies_from_teams.variables,
+            policies_from_organization.variables
+          ) AS variables
         FROM
           policies
+        LEFT JOIN
+          policies_from_user
+        ON
+          policies.id = policies_from_user.policy_id
+        LEFT JOIN
+          policies_from_teams
+        ON
+          policies.id = policies_from_teams.policy_id
+        LEFT JOIN
+          policies_from_organization
+        ON
+          policies.id = policies_from_organization.policy_id
         WHERE (
             org_id = ${organizationId}
           OR (
@@ -331,11 +348,11 @@ function buildPolicyOps (db, config) {
           )
         )
         AND (
-            id IN (SELECT policy_id FROM policies_from_user)
+            policies_from_user.policy_id IS NOT NULL
           OR
-            id IN (SELECT policy_id FROM policies_from_teams)
+            policies_from_teams.policy_id IS NOT NULL
           OR
-            id IN (SELECT policy_id FROM policies_from_organization)
+            policies_from_organization.policy_id IS NOT NULL
         )
       `
 

--- a/lib/core/lib/ops/teamOps.js
+++ b/lib/core/lib/ops/teamOps.js
@@ -142,12 +142,16 @@ function buildTeamOps (db, config) {
 
     if (policies.length === 0) return next()
 
-    const sql = SQL`INSERT INTO team_policies (policy_id, team_id) VALUES `
-    sql.append(SQL`(${policies[0]},${teamId})`)
-    policies.slice(1).forEach((policyId) => {
-      sql.append(SQL`, (${policyId},${teamId})`)
+    const sql = SQL`INSERT INTO team_policies (policy_id, team_id, variables) VALUES `
+    sql.append(SQL`(${policies[0].id},${teamId},${policies[0].variables})`)
+    policies.slice(1).forEach((policy) => {
+      sql.append(SQL`, (${policy.id},${teamId}, ${policy.variables})`)
     })
-    sql.append(SQL` ON CONFLICT ON CONSTRAINT team_policy_link DO NOTHING`)
+    sql.append(SQL`
+      ON CONFLICT ON CONSTRAINT team_policy_link
+      DO UPDATE SET variables = excluded.variables
+      WHERE team_policies.policy_id = excluded.policy_id
+      AND team_policies.team_id = excluded.team_id`)
     job.client.query(sql, utils.boomErrorWrapper(next))
   }
 
@@ -268,7 +272,7 @@ function buildTeamOps (db, config) {
   function loadTeamPolicies (job, next) {
     const { id } = job
     const sql = SQL`
-      SELECT pol.id, pol.name, pol.version
+      SELECT pol.id, pol.name, pol.version, tpol.variables
       FROM team_policies tpol, policies pol
       WHERE tpol.team_id = ${id}
       AND tpol.policy_id = pol.id
@@ -547,10 +551,12 @@ function buildTeamOps (db, config) {
      * @param  {Function} cb
      */
     addTeamPolicies: function addTeamPolicies (params, cb) {
-      const { id, organizationId, policies } = params
+      const { id, organizationId } = params
 
-      Joi.validate({ id, organizationId, policies }, validationRules.addTeamPolicies, function (err) {
+      Joi.validate({ id, organizationId, policies: params.policies }, validationRules.addTeamPolicies, function (err) {
         if (err) return cb(Boom.badRequest(err))
+
+        const policies = utils.preparePolicies(params.policies)
 
         utils.checkPoliciesOrg(db, policies, organizationId, (err) => {
           if (err) return cb(err)
@@ -581,7 +587,7 @@ function buildTeamOps (db, config) {
         (job, next) => {
           job.teamId = id
           job.organizationId = organizationId
-          job.policies = policies
+          job.policies = utils.preparePolicies(policies)
           next()
         },
         (job, next) => {

--- a/lib/core/lib/ops/teamOps.js
+++ b/lib/core/lib/ops/teamOps.js
@@ -147,11 +147,7 @@ function buildTeamOps (db, config) {
     policies.slice(1).forEach((policy) => {
       sql.append(SQL`, (${policy.id},${teamId}, ${policy.variables})`)
     })
-    sql.append(SQL`
-      ON CONFLICT ON CONSTRAINT team_policy_link
-      DO UPDATE SET variables = excluded.variables
-      WHERE team_policies.policy_id = excluded.policy_id
-      AND team_policies.team_id = excluded.team_id`)
+    sql.append(SQL` ON CONFLICT ON CONSTRAINT team_policy_link DO NOTHING`)
     job.client.query(sql, utils.boomErrorWrapper(next))
   }
 

--- a/lib/core/lib/ops/userOps.js
+++ b/lib/core/lib/ops/userOps.js
@@ -49,7 +49,6 @@ function buildUserOps (db/*, config */) {
 
   function insertUserPolicies (job, next) {
     const { id: userId, policies } = job
-
     userOps.insertPolicies(job.client, userId, policies, utils.boomErrorWrapper(next))
   }
 
@@ -471,15 +470,12 @@ function buildUserOps (db/*, config */) {
           policy_id, user_id, variables
         ) VALUES
       `
+
       sqlQuery.append(SQL`(${policies[0].id}, ${id}, ${policies[0].variables})`)
       policies.slice(1).forEach((policy) => {
         sqlQuery.append(SQL`, (${policy.id}, ${id}, ${policy.variables})`)
       })
-      sqlQuery.append(SQL`
-        ON CONFLICT ON CONSTRAINT user_policy_link
-        DO UPDATE SET variables = excluded.variables
-        WHERE user_policies.policy_id = excluded.policy_id
-        AND user_policies.user_id = excluded.user_id`)
+      sqlQuery.append(SQL` ON CONFLICT ON CONSTRAINT user_policy_link DO NOTHING`)
 
       client.query(sqlQuery, utils.boomErrorWrapper(cb))
     },

--- a/lib/core/lib/ops/userOps.js
+++ b/lib/core/lib/ops/userOps.js
@@ -153,7 +153,7 @@ function buildUserOps (db/*, config */) {
 
       tasks.push((next) => {
         const sqlQuery = SQL`
-          SELECT pol.id, pol.name, pol.version
+          SELECT pol.id, pol.name, pol.version, user_pol.variables
           FROM user_policies user_pol, policies pol
           WHERE user_pol.user_id = ${id} AND user_pol.policy_id = pol.id
           ORDER BY UPPER(pol.name)
@@ -291,7 +291,7 @@ function buildUserOps (db/*, config */) {
         (job, next) => {
           job.id = id
           job.organizationId = organizationId
-          job.policies = policies
+          job.policies = utils.preparePolicies(policies)
 
           next()
         },
@@ -334,7 +334,7 @@ function buildUserOps (db/*, config */) {
         },
         (job, next) => {
           job.id = id
-          job.policies = policies
+          job.policies = utils.preparePolicies(policies)
           job.organizationId = organizationId
 
           next()
@@ -468,14 +468,18 @@ function buildUserOps (db/*, config */) {
     insertPolicies: function insertPolicies (client, id, policies, cb) {
       const sqlQuery = SQL`
         INSERT INTO user_policies (
-          policy_id, user_id
+          policy_id, user_id, variables
         ) VALUES
       `
-      sqlQuery.append(SQL`(${policies[0]}, ${id})`)
-      policies.slice(1).forEach((policyId) => {
-        sqlQuery.append(SQL`, (${policyId}, ${id})`)
+      sqlQuery.append(SQL`(${policies[0].id}, ${id}, ${policies[0].variables})`)
+      policies.slice(1).forEach((policy) => {
+        sqlQuery.append(SQL`, (${policy.id}, ${id}, ${policy.variables})`)
       })
-      sqlQuery.append(SQL` ON CONFLICT ON CONSTRAINT user_policy_link DO NOTHING`)
+      sqlQuery.append(SQL`
+        ON CONFLICT ON CONSTRAINT user_policy_link
+        DO UPDATE SET variables = excluded.variables
+        WHERE user_policies.policy_id = excluded.policy_id
+        AND user_policies.user_id = excluded.user_id`)
 
       client.query(sqlQuery, utils.boomErrorWrapper(cb))
     },

--- a/lib/core/lib/ops/utils.js
+++ b/lib/core/lib/ops/utils.js
@@ -92,6 +92,8 @@ function preparePolicy (policy) {
     }
   }
 
+  policy.variables = policy.variables || {}
+
   return policy
 }
 

--- a/lib/core/lib/ops/utils.js
+++ b/lib/core/lib/ops/utils.js
@@ -23,11 +23,13 @@ function isForeignKeyViolationError (err) {
 }
 
 function checkPoliciesOrg (db, policies, organizationId, cb) {
-  db.query(SQL`SELECT id FROM policies WHERE id = ANY (${policies}) AND org_id = ${organizationId}`, (err, result) => {
+  const policyIds = _.map(policies, 'id')
+
+  db.query(SQL`SELECT id FROM policies WHERE id = ANY (${policyIds}) AND org_id = ${organizationId}`, (err, result) => {
     if (err) return cb(Boom.badImplementation(err))
 
     if (result.rowCount !== policies.length) {
-      return cb(Boom.badRequest(`Some policies [${_.difference(policies, result.rows.map(r => r.id))}] were not found`))
+      return cb(Boom.badRequest(`Some policies [${_.difference(policyIds, result.rows.map(r => r.id))}] were not found`))
     }
 
     cb()
@@ -82,7 +84,23 @@ function checkOrg (db, organizationId, cb) {
   })
 }
 
+function preparePolicy (policy) {
+  if (_.isString(policy)) {
+    return {
+      id: policy,
+      variables: {}
+    }
+  }
+
+  return policy
+}
+
+function preparePolicies (policies) {
+  return _.map(policies, preparePolicy)
+}
+
 module.exports = {
+  preparePolicies,
   boomErrorWrapper,
   isUniqueViolationError,
   isForeignKeyViolationError,

--- a/lib/core/lib/ops/validation.js
+++ b/lib/core/lib/ops/validation.js
@@ -5,6 +5,14 @@ const Joi = require('joi')
 const requiredString = Joi.string().required()
 const requiredStringId = Joi.string().required().max(128)
 
+const requiredPolicy = Joi.alternatives().try([
+  requiredString,
+  Joi.object().description('Policy').keys({
+    id: requiredString.description('Policy Id'),
+    variables: Joi.object().description('A list of the veriables with their fixed values')
+  })
+])
+
 const validationRules = {
   name: requiredString.description('Name'),
   userName: requiredString.max(255).description('Name'),
@@ -28,7 +36,7 @@ const validationRules = {
   policyId: requiredStringId.description('Policy ID'),
 
   users: Joi.array().required().items(requiredString).description('User IDs'),
-  policies: Joi.array().required().items(requiredString).description('Policies IDs'),
+  policies: Joi.array().required().items(requiredPolicy).description('Policies IDs'),
   teams: Joi.array().required().items(requiredString).description('Teams IDs'),
   resources: Joi.array().max(10).items(requiredString.description('A single resource')).single().required().description('A list of Resources'),
 
@@ -231,7 +239,7 @@ const organizations = {
   },
   replaceOrganizationPolicies: {
     id: validationRules.organizationId,
-    policies: validationRules.policies
+    policies: validationRules.policies.min(1)
   },
   deleteOrganizationPolicies: {
     id: validationRules.organizationId

--- a/lib/plugin/swagger.js
+++ b/lib/plugin/swagger.js
@@ -22,7 +22,8 @@ const Policy = Joi.object({
 const PolicyRef = Joi.object({
   id: Joi.string().description('Policy ID'),
   version: Joi.string().description('Policy version'),
-  name: Joi.string().description('Policy name')
+  name: Joi.string().description('Policy name'),
+  variables: Joi.object().description('List of fixed values for variables')
 }).label('PolicyRef')
 
 const UserRef = Joi.object({

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "pg:init": "UDARU_SERVICE_local=true node database/init.js && npm run pg:migrate",
     "pg:init-test-db": "npm run pg:init && npm run pg:load-test-data",
     "pg:load-test-data": "UDARU_SERVICE_local=true node database/loadTestData.js",
-    "pg:migrate": "node database/migrate.js --version=3",
+    "pg:migrate": "node database/migrate.js --version=4",
     "start": "node lib/server/start.js",
     "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 95",
     "test:commit-check": "npm run doc:lint && npm run lint && npm run test",

--- a/test/factory.js
+++ b/test/factory.js
@@ -117,9 +117,13 @@ function Factory (lab, data, udaruCore) {
         policies: []
       }
 
-      _.each(team.policies, (policyKey) => {
+      _.each(team.policies, (policy) => {
+        const policyKey = policy.key || policy
         const policyId = records[policyKey].id
-        list[teamId].policies.push(policyId)
+        list[teamId].policies.push({
+          id: policyId,
+          variables: policy.variables || {}
+        })
       })
     })
 
@@ -175,9 +179,13 @@ function Factory (lab, data, udaruCore) {
         policies: []
       }
 
-      _.each(user.policies, (policyKey) => {
+      _.each(user.policies, (policy) => {
+        const policyKey = policy.key || policy
         const policyId = records[policyKey].id
-        list[userId].policies.push(policyId)
+        list[userId].policies.push({
+          id: policyId,
+          variables: policy.variables || {}
+        })
       })
     })
 

--- a/test/integration/authorizeOps.test.js
+++ b/test/integration/authorizeOps.test.js
@@ -301,7 +301,8 @@ lab.experiment('AuthorizeOps', () => {
       }, (err, result) => {
         expect(err).to.not.exist()
         expect(result).to.exist()
-        expect(result.actions).to.equal(['finance:ReadBalanceSheet', 'finance:EditBalanceSheet'])
+        expect(result.actions).to.have.length(2)
+        expect(result.actions).to.only.include(['finance:ReadBalanceSheet', 'finance:EditBalanceSheet'])
 
         cb(err, result)
       })

--- a/test/integration/endToEnd/organizations.test.js
+++ b/test/integration/endToEnd/organizations.test.js
@@ -425,6 +425,31 @@ lab.experiment('Organizations', () => {
     })
   })
 
+  lab.test('add policies with variables to an organization', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: `/authorization/organizations/${organizationId}/policies`,
+      payload: {
+        policies: [{
+          id: testPolicy.id,
+          variables: {var1: 'value1'}
+        }]
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.policies).to.exist()
+      expect(result.policies.length).to.equal(1)
+      expect(result.policies[0].id).to.equal(testPolicy.id)
+      expect(result.policies[0].variables).to.equal({var1: 'value1'})
+
+      done()
+    })
+  })
+
   lab.test('add policy with invalid ID to an organization', (done) => {
     const options = utils.requestOptions({
       method: 'PUT',

--- a/test/integration/endToEnd/organizations.test.js
+++ b/test/integration/endToEnd/organizations.test.js
@@ -442,9 +442,14 @@ lab.experiment('Organizations', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result.policies).to.exist()
-      expect(result.policies.length).to.equal(1)
-      expect(result.policies[0].id).to.equal(testPolicy.id)
-      expect(result.policies[0].variables).to.equal({var1: 'value1'})
+      // it's 2 because the previous tests insert one policy, this inserts the second
+      expect(result.policies.length).to.equal(2)
+      expect(result.policies).to.include({
+        id: testPolicy.id,
+        name: testPolicy.name,
+        version: testPolicy.version,
+        variables: {var1: 'value1'}
+      })
 
       done()
     })

--- a/test/integration/endToEnd/teams.test.js
+++ b/test/integration/endToEnd/teams.test.js
@@ -777,8 +777,33 @@ lab.experiment('Teams - manage policies', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result.policies).to.equal([
-        { id: 'policyId2', name: 'Accountant', version: '0.1' },
-        { id: 'policyId1', name: 'Director', version: '0.1' }
+        { id: 'policyId2', name: 'Accountant', version: '0.1', variables: {} },
+        { id: 'policyId1', name: 'Director', version: '0.1', variables: {} }
+      ])
+
+      udaru.teams.replacePolicies({ id: result.id, policies: ['policyId1'], organizationId: result.organizationId }, done)
+    })
+  })
+
+  lab.test('Add one policy with variables to a team', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/teams/1/policies',
+      payload: {
+        policies: [{
+          id: 'policyId2',
+          variables: {var1: 'value1'}
+        }]
+      }
+    })
+
+    server.inject(options, (response) => {
+      const { result } = response
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.policies).to.equal([
+        { id: 'policyId2', name: 'Accountant', version: '0.1', variables: {var1: 'value1'} },
+        { id: 'policyId1', name: 'Director', version: '0.1', variables: {} }
       ])
 
       udaru.teams.replacePolicies({ id: result.id, policies: ['policyId1'], organizationId: result.organizationId }, done)
@@ -829,10 +854,10 @@ lab.experiment('Teams - manage policies', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result.policies).to.equal([
-        { id: 'policyId5', name: 'DB Admin', version: '0.1' },
-        { id: 'policyId6', name: 'DB Only Read', version: '0.1' },
-        { id: 'policyId1', name: 'Director', version: '0.1' },
-        { id: 'policyId4', name: 'Finance Director', version: '0.1' }
+        { id: 'policyId5', name: 'DB Admin', version: '0.1', variables: {} },
+        { id: 'policyId6', name: 'DB Only Read', version: '0.1', variables: {} },
+        { id: 'policyId1', name: 'Director', version: '0.1', variables: {} },
+        { id: 'policyId4', name: 'Finance Director', version: '0.1', variables: {} }
       ])
 
       udaru.teams.replacePolicies({ id: result.id, policies: ['policyId1'], organizationId: result.organizationId }, done)
@@ -852,7 +877,12 @@ lab.experiment('Teams - manage policies', () => {
       const { result } = response
 
       expect(response.statusCode).to.equal(200)
-      expect(result.policies).to.equal([{ id: 'policyId6', name: 'DB Only Read', version: '0.1' }])
+      expect(result.policies).to.equal([{
+        id: 'policyId6',
+        name: 'DB Only Read',
+        version: '0.1',
+        variables: {}
+      }])
 
       udaru.teams.replacePolicies({ id: result.id, policies: ['policyId1'], organizationId: result.organizationId }, done)
     })

--- a/test/integration/endToEnd/users.test.js
+++ b/test/integration/endToEnd/users.test.js
@@ -390,6 +390,37 @@ lab.experiment('Users - manage policies', () => {
     })
   })
 
+  lab.test('add policies with variables to a user', (done) => {
+    udaru.policies.create(policyCreateData, (err, p) => {
+      expect(err).to.not.exist()
+
+      const options = utils.requestOptions({
+        method: 'PUT',
+        url: '/authorization/users/ModifyId/policies',
+        payload: {
+          policies: [{
+            id: p.id,
+            variables: {var1: 'value1'}
+          }]
+        }
+      })
+
+      server.inject(options, (response) => {
+        const result = response.result
+
+        expect(response.statusCode).to.equal(200)
+        expect(result.policies[0].id).to.equal(p.id)
+        expect(result.policies[0].variables).to.equal({var1: 'value1'})
+
+        udaru.users.deletePolicies({ id: 'ModifyId', organizationId: 'WONKA' }, (err, res) => {
+          expect(err).to.not.exist()
+
+          udaru.policies.delete({ id: p.id, organizationId: 'WONKA' }, done)
+        })
+      })
+    })
+  })
+
   lab.test('add policy with invalid ID to a user', (done) => {
     const options = utils.requestOptions({
       method: 'PUT',

--- a/test/integration/organizationOps.test.js
+++ b/test/integration/organizationOps.test.js
@@ -798,4 +798,252 @@ lab.experiment('OrganizationOps', () => {
 
     async.series(tasks, done)
   })
+
+  lab.experiment('add policies twice', () => {
+    lab.test('without variables do nothing', (done) => {
+      const tasks = []
+
+      tasks.push((next) => {
+        udaru.policies.list({organizationId}, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.length).to.equal(defaultPoliciesNames.length + 2)
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.read(organizationId, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.policies.length).to.equal(0)
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.addPolicies({id: organizationId, policies: [testPolicy.id]}, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.id).to.equal(organizationId)
+          expect(res.policies.length).to.equal(1)
+          expect(res.policies[0].id).to.equal(testPolicy.id)
+          expect(res.policies[0].name).to.equal(testPolicy.name)
+          expect(res.policies[0].version).to.equal(testPolicy.version)
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.read(organizationId, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.policies.length).to.equal(1)
+          expect(res.policies[0].id).to.equal(testPolicy.id)
+          expect(res.policies[0].name).to.equal(testPolicy.name)
+          expect(res.policies[0].version).to.equal(testPolicy.version)
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.addPolicies({id: organizationId, policies: [testPolicy.id]}, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.id).to.equal(organizationId)
+          expect(res.policies.length).to.equal(1)
+          expect(res.policies[0].id).to.equal(testPolicy.id)
+          expect(res.policies[0].name).to.equal(testPolicy.name)
+          expect(res.policies[0].version).to.equal(testPolicy.version)
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.read(organizationId, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.policies.length).to.equal(1)
+          expect(res.policies[0].id).to.equal(testPolicy.id)
+          expect(res.policies[0].name).to.equal(testPolicy.name)
+          expect(res.policies[0].version).to.equal(testPolicy.version)
+          next(err, res)
+        })
+      })
+
+      async.series(tasks, done)
+    })
+
+    lab.test('with different variables add twice', (done) => {
+      const tasks = []
+
+      tasks.push((next) => {
+        udaru.policies.list({organizationId}, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.length).to.equal(defaultPoliciesNames.length + 2)
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.read(organizationId, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.policies.length).to.equal(0)
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        const policies = [{
+          id: testPolicy.id,
+          variables: {var1: 'value1'}
+        }]
+        udaru.organizations.addPolicies({id: organizationId, policies}, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.id).to.equal(organizationId)
+          expect(res.policies.length).to.equal(1)
+          expect(res.policies[0].id).to.equal(testPolicy.id)
+          expect(res.policies[0].name).to.equal(testPolicy.name)
+          expect(res.policies[0].version).to.equal(testPolicy.version)
+          expect(res.policies[0].variables).to.equal({var1: 'value1'})
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.read(organizationId, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.policies.length).to.equal(1)
+          expect(res.policies[0].id).to.equal(testPolicy.id)
+          expect(res.policies[0].name).to.equal(testPolicy.name)
+          expect(res.policies[0].version).to.equal(testPolicy.version)
+          expect(res.policies[0].variables).to.equal({var1: 'value1'})
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        const policies = [{
+          id: testPolicy.id,
+          variables: {var1: 'value2'}
+        }]
+        udaru.organizations.addPolicies({id: organizationId, policies}, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.id).to.equal(organizationId)
+          expect(res.policies.length).to.equal(2)
+          expect(res.policies).to.include([{
+            id: testPolicy.id,
+            name: testPolicy.name,
+            version: testPolicy.version,
+            variables: {var1: 'value2'}
+          }])
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.read(organizationId, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.policies.length).to.equal(2)
+          expect(res.policies).to.include([{
+            id: testPolicy.id,
+            name: testPolicy.name,
+            version: testPolicy.version,
+            variables: {var1: 'value1'}
+          }, {
+            id: testPolicy.id,
+            name: testPolicy.name,
+            version: testPolicy.version,
+            variables: {var1: 'value2'}
+          }])
+
+          next(err, res)
+        })
+      })
+
+      async.series(tasks, done)
+    })
+
+    lab.test('with same variables do nothing', (done) => {
+      const tasks = []
+
+      tasks.push((next) => {
+        udaru.policies.list({organizationId}, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.length).to.equal(defaultPoliciesNames.length + 2)
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.read(organizationId, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.policies.length).to.equal(0)
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        const policies = [{
+          id: testPolicy.id,
+          variables: {var1: 'value1'}
+        }]
+        udaru.organizations.addPolicies({id: organizationId, policies}, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.id).to.equal(organizationId)
+          expect(res.policies.length).to.equal(1)
+          expect(res.policies[0].id).to.equal(testPolicy.id)
+          expect(res.policies[0].name).to.equal(testPolicy.name)
+          expect(res.policies[0].version).to.equal(testPolicy.version)
+          expect(res.policies[0].variables).to.equal({var1: 'value1'})
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.read(organizationId, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.policies.length).to.equal(1)
+          expect(res.policies[0].id).to.equal(testPolicy.id)
+          expect(res.policies[0].name).to.equal(testPolicy.name)
+          expect(res.policies[0].version).to.equal(testPolicy.version)
+          expect(res.policies[0].variables).to.equal({var1: 'value1'})
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        const policies = [{
+          id: testPolicy.id,
+          variables: {var1: 'value1'}
+        }]
+        udaru.organizations.addPolicies({id: organizationId, policies}, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.id).to.equal(organizationId)
+          expect(res.policies.length).to.equal(1)
+          expect(res.policies).to.include([{
+            id: testPolicy.id,
+            name: testPolicy.name,
+            version: testPolicy.version,
+            variables: {var1: 'value1'}
+          }])
+          next(err, res)
+        })
+      })
+      tasks.push((next) => {
+        udaru.organizations.read(organizationId, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.exist()
+          expect(res.policies.length).to.equal(1)
+          expect(res.policies).to.include([{
+            id: testPolicy.id,
+            name: testPolicy.name,
+            version: testPolicy.version,
+            variables: {var1: 'value1'}
+          }])
+
+          next(err, res)
+        })
+      })
+
+      async.series(tasks, done)
+    })
+  })
 })

--- a/test/integration/organizationOps.test.js
+++ b/test/integration/organizationOps.test.js
@@ -440,6 +440,58 @@ lab.experiment('OrganizationOps', () => {
     async.series(tasks, done)
   })
 
+  lab.test('add policies with variables to an organization', (done) => {
+    const tasks = []
+
+    tasks.push((next) => {
+      udaru.policies.list({organizationId}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.length).to.equal(defaultPoliciesNames.length + 2)
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      udaru.organizations.read(organizationId, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.policies.length).to.equal(0)
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      const policies = [{
+        id: testPolicy.id,
+        variables: {var1: 'value1'}
+      }]
+      udaru.organizations.addPolicies({id: organizationId, policies}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.id).to.equal(organizationId)
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal(testPolicy.id)
+        expect(res.policies[0].name).to.equal(testPolicy.name)
+        expect(res.policies[0].version).to.equal(testPolicy.version)
+        expect(res.policies[0].variables).to.equal({var1: 'value1'})
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      udaru.organizations.read(organizationId, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal(testPolicy.id)
+        expect(res.policies[0].name).to.equal(testPolicy.name)
+        expect(res.policies[0].version).to.equal(testPolicy.version)
+        expect(res.policies[0].variables).to.equal({var1: 'value1'})
+        next(err, res)
+      })
+    })
+
+    async.series(tasks, done)
+  })
+
   lab.test('add empty policy array to an organization that has default policies', (done) => {
     const tasks = []
 
@@ -518,6 +570,80 @@ lab.experiment('OrganizationOps', () => {
         expect(res.policies[0].id).to.equal(testPolicy2.id)
         expect(res.policies[0].name).to.equal(testPolicy2.name)
         expect(res.policies[0].version).to.equal(testPolicy2.version)
+        next(err, res)
+      })
+    })
+
+    async.series(tasks, done)
+  })
+
+  lab.test('replace organization policies with variables', (done) => {
+    const tasks = []
+
+    tasks.push((next) => {
+      udaru.policies.list({organizationId}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.length).to.equal(defaultPoliciesNames.length + 2)
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      const policies = [{
+        id: testPolicy.id,
+        variables: {var1: 'value1'}
+      }]
+
+      udaru.organizations.addPolicies({id: organizationId, policies}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.id).to.equal(organizationId)
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal(testPolicy.id)
+        expect(res.policies[0].name).to.equal(testPolicy.name)
+        expect(res.policies[0].version).to.equal(testPolicy.version)
+        expect(res.policies[0].variables).to.equal({var1: 'value1'})
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      udaru.organizations.read(organizationId, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal(testPolicy.id)
+        expect(res.policies[0].name).to.equal(testPolicy.name)
+        expect(res.policies[0].version).to.equal(testPolicy.version)
+        expect(res.policies[0].variables).to.equal({var1: 'value1'})
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      const policies = [{
+        id: testPolicy2.id,
+        variables: {var1: 'value2'}
+      }]
+      udaru.organizations.replacePolicies({id: organizationId, policies}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.id).to.equal(organizationId)
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal(testPolicy2.id)
+        expect(res.policies[0].name).to.equal(testPolicy2.name)
+        expect(res.policies[0].version).to.equal(testPolicy2.version)
+        expect(res.policies[0].variables).to.equal({var1: 'value2'})
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      udaru.organizations.read(organizationId, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal(testPolicy2.id)
+        expect(res.policies[0].name).to.equal(testPolicy2.name)
+        expect(res.policies[0].version).to.equal(testPolicy2.version)
+        expect(res.policies[0].variables).to.equal({var1: 'value2'})
         next(err, res)
       })
     })

--- a/test/integration/policyOps.test.js
+++ b/test/integration/policyOps.test.js
@@ -322,17 +322,26 @@ lab.experiment('PolicyOps', () => {
       })
     })
 
-    lab.test('should prefer variables in user policy over team policy for interpolation', (done) => {
+    lab.test('should support multiple instances of the same policy with different variables', (done) => {
       policyOps.listAllUserPolicies({ userId: records.called.id, organizationId: orgId }, (err, results) => {
         if (err) return done(err)
 
         expect(results.map(getName)).to.include(records.policyWithVariablesMulti.name)
 
-        const policy = _.find(results, {Name: records.policyWithVariablesMulti.name})
-        expect(policy.Statement).to.equal([{
+        const statements = _.chain(results)
+          .filter({Name: records.policyWithVariablesMulti.name})
+          .map('Statement')
+          .flatten()
+          .value()
+
+        expect(statements).to.include([{
           Effect: 'Allow',
           Action: ['dummy'],
           Resource: ['value2']
+        }, {
+          Effect: 'Allow',
+          Action: ['dummy'],
+          Resource: ['value3']
         }])
 
         done()

--- a/test/integration/security/sqlinjection.core.test.js
+++ b/test/integration/security/sqlinjection.core.test.js
@@ -75,15 +75,27 @@ lab.experiment('UserOps injection tests', () => {
     udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
-      expect(user.policies).to.equal([accountantPolicy])
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
 
       udaru.users.addPolicies({ id: 'VerucaId', policies: [directorPolicy.id], organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.not.exist()
         expect(user).to.exist()
-        expect(user.policies).to.equal([
-          accountantPolicy,
-          directorPolicy
-        ])
+        expect(user.policies).to.equal([{
+          id: accountantPolicy.id,
+          name: accountantPolicy.name,
+          version: accountantPolicy.version,
+          variables: {}
+        }, {
+          id: directorPolicy.id,
+          name: directorPolicy.name,
+          version: directorPolicy.version,
+          variables: {}
+        }])
 
         udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
           expect(err).to.not.exist()
@@ -100,7 +112,12 @@ lab.experiment('UserOps injection tests', () => {
     udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
-      expect(user.policies).to.equal([accountantPolicy])
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
 
       udaru.users.addPolicies({ id: '\'VerucaId\' AND 1=1', policies: [directorPolicy.id], organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.exist()
@@ -123,7 +140,12 @@ lab.experiment('UserOps injection tests', () => {
     udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
-      expect(user.policies).to.equal([accountantPolicy])
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
 
       udaru.users.addPolicies({ id: 'VerucaId', policies: ['1 OR 1=1'], organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.exist()

--- a/test/integration/teamOps.test.js
+++ b/test/integration/teamOps.test.js
@@ -540,10 +540,46 @@ lab.experiment('TeamOps', () => {
       expect(err).to.not.exist()
       expect(team).to.exist()
       expect(team.policies).to.have.length(2)
-      expect(team.policies).to.only.include([
-        _.pick(policies[0], 'id', 'name', 'version'),
-        _.pick(policies[1], 'id', 'name', 'version')
-      ])
+      expect(team.policies).to.only.include([{
+        id: policies[0].id,
+        name: policies[0].name,
+        version: policies[0].version,
+        variables: {}
+      }, {
+        id: policies[1].id,
+        name: policies[1].name,
+        version: policies[1].version,
+        variables: {}
+      }])
+
+      done()
+    })
+  })
+
+  lab.test('add policies with variables to team', (done) => {
+    const policiesParam = [{
+      id: policies[0].id,
+      variables: {var1: 'value1'}
+    }, {
+      id: policies[1].id,
+      variables: {var2: 'value2'}
+    }]
+
+    udaru.teams.addPolicies({ id: testTeam.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
+      expect(err).to.not.exist()
+      expect(team).to.exist()
+      expect(team.policies).to.have.length(2)
+      expect(team.policies).to.only.include([{
+        id: policies[0].id,
+        name: policies[0].name,
+        version: policies[0].version,
+        variables: {var1: 'value1'}
+      }, {
+        id: policies[1].id,
+        name: policies[1].name,
+        version: policies[1].version,
+        variables: {var2: 'value2'}
+      }])
 
       done()
     })
@@ -562,7 +598,44 @@ lab.experiment('TeamOps', () => {
         expect(err).to.not.exist()
         expect(team).to.exist()
         expect(team.policies).to.have.length(1)
-        expect(team.policies).to.only.include([_.pick(policies[1], 'id', 'name', 'version')])
+        expect(team.policies).to.only.include([{
+          id: policies[1].id,
+          name: policies[1].name,
+          version: policies[1].version,
+          variables: {}
+        }])
+        done()
+      })
+    })
+  })
+
+  lab.test('replace team policies with variables', (done) => {
+    udaru.teams.addPolicies({
+      id: testTeam.id,
+      organizationId: 'WONKA',
+      policies: [{
+        id: policies[0].id,
+        variables: {var1: 'value1'}
+      }]
+    }, (err, team) => {
+      expect(err).to.not.exist()
+      expect(team).to.exist()
+
+      const policiesParam = [{
+        id: policies[1].id,
+        variables: {var1: 'value2'}
+      }]
+
+      udaru.teams.replacePolicies({ id: team.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
+        expect(err).to.not.exist()
+        expect(team).to.exist()
+        expect(team.policies).to.have.length(1)
+        expect(team.policies).to.only.include([{
+          id: policies[1].id,
+          name: policies[1].name,
+          version: policies[1].version,
+          variables: {var1: 'value2'}
+        }])
         done()
       })
     })
@@ -573,19 +646,83 @@ lab.experiment('TeamOps', () => {
       expect(err).to.not.exist()
       expect(team).to.exist()
       expect(team.policies).to.have.length(2)
-      expect(team.policies).to.only.include([
-        _.pick(policies[0], 'id', 'name', 'version'),
-        _.pick(policies[1], 'id', 'name', 'version')
-      ])
+      expect(team.policies).to.only.include([{
+        id: policies[0].id,
+        name: policies[0].name,
+        version: policies[0].version,
+        variables: {}
+      }, {
+        id: policies[1].id,
+        name: policies[1].name,
+        version: policies[1].version,
+        variables: {}
+      }])
 
       udaru.teams.addPolicies({ id: team.id, policies: [policies[1].id], organizationId: 'WONKA' }, (err, team) => {
         expect(err).to.not.exist()
         expect(team).to.exist()
         expect(team.policies).to.have.length(2)
-        expect(team.policies).to.only.include([
-          _.pick(policies[0], 'id', 'name', 'version'),
-          _.pick(policies[1], 'id', 'name', 'version')
-        ])
+        expect(team.policies).to.only.include([{
+          id: policies[0].id,
+          name: policies[0].name,
+          version: policies[0].version,
+          variables: {}
+        }, {
+          id: policies[1].id,
+          name: policies[1].name,
+          version: policies[1].version,
+          variables: {}
+        }])
+        done()
+      })
+    })
+  })
+
+  lab.test('add the same policy with variables twice to a team (variables updated)', (done) => {
+    const policiesParam = [{
+      id: policies[0].id,
+      variables: {var1: 'value1'}
+    }, {
+      id: policies[1].id,
+      variables: {var2: 'value2'}
+    }]
+
+    udaru.teams.addPolicies({ id: testTeam.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
+      expect(err).to.not.exist()
+      expect(team).to.exist()
+      expect(team.policies).to.have.length(2)
+      expect(team.policies).to.only.include([{
+        id: policies[0].id,
+        name: policies[0].name,
+        version: policies[0].version,
+        variables: {var1: 'value1'}
+      }, {
+        id: policies[1].id,
+        name: policies[1].name,
+        version: policies[1].version,
+        variables: {var2: 'value2'}
+      }])
+
+      const policiesParam = [{
+        id: policies[1].id,
+        variables: {var2: 'value3'}
+      }]
+
+      udaru.teams.addPolicies({ id: team.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
+        expect(err).to.not.exist()
+        expect(team).to.exist()
+        expect(team.policies).to.have.length(2)
+        expect(team.policies).to.only.include([{
+          id: policies[0].id,
+          name: policies[0].name,
+          version: policies[0].version,
+          variables: {var1: 'value1'}
+        }, {
+          id: policies[1].id,
+          name: policies[1].name,
+          version: policies[1].version,
+          variables: {var2: 'value3'}
+        }])
         done()
       })
     })
@@ -615,7 +752,12 @@ lab.experiment('TeamOps', () => {
       udaru.teams.deletePolicy({ teamId: team.id, policyId: policies[0].id, organizationId: 'WONKA' }, (err, team) => {
         expect(err).to.not.exist()
         expect(team).to.exist()
-        expect(team.policies).to.equal([_.pick(policies[1], 'id', 'name', 'version')])
+        expect(team.policies).to.equal([{
+          id: policies[1].id,
+          name: policies[1].name,
+          version: policies[1].version,
+          variables: {}
+        }])
 
         done()
       })

--- a/test/integration/teamOps.test.js
+++ b/test/integration/teamOps.test.js
@@ -641,93 +641,6 @@ lab.experiment('TeamOps', () => {
     })
   })
 
-  lab.test('add the same policy twice to a team', (done) => {
-    udaru.teams.addPolicies({ id: testTeam.id, policies: [policies[0].id, policies[1].id], organizationId: 'WONKA' }, (err, team) => {
-      expect(err).to.not.exist()
-      expect(team).to.exist()
-      expect(team.policies).to.have.length(2)
-      expect(team.policies).to.only.include([{
-        id: policies[0].id,
-        name: policies[0].name,
-        version: policies[0].version,
-        variables: {}
-      }, {
-        id: policies[1].id,
-        name: policies[1].name,
-        version: policies[1].version,
-        variables: {}
-      }])
-
-      udaru.teams.addPolicies({ id: team.id, policies: [policies[1].id], organizationId: 'WONKA' }, (err, team) => {
-        expect(err).to.not.exist()
-        expect(team).to.exist()
-        expect(team.policies).to.have.length(2)
-        expect(team.policies).to.only.include([{
-          id: policies[0].id,
-          name: policies[0].name,
-          version: policies[0].version,
-          variables: {}
-        }, {
-          id: policies[1].id,
-          name: policies[1].name,
-          version: policies[1].version,
-          variables: {}
-        }])
-        done()
-      })
-    })
-  })
-
-  lab.test('add the same policy with variables twice to a team (variables updated)', (done) => {
-    const policiesParam = [{
-      id: policies[0].id,
-      variables: {var1: 'value1'}
-    }, {
-      id: policies[1].id,
-      variables: {var2: 'value2'}
-    }]
-
-    udaru.teams.addPolicies({ id: testTeam.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
-      expect(err).to.not.exist()
-      expect(team).to.exist()
-      expect(team.policies).to.have.length(2)
-      expect(team.policies).to.only.include([{
-        id: policies[0].id,
-        name: policies[0].name,
-        version: policies[0].version,
-        variables: {var1: 'value1'}
-      }, {
-        id: policies[1].id,
-        name: policies[1].name,
-        version: policies[1].version,
-        variables: {var2: 'value2'}
-      }])
-
-      const policiesParam = [{
-        id: policies[1].id,
-        variables: {var2: 'value3'}
-      }]
-
-      udaru.teams.addPolicies({ id: team.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
-        expect(err).to.not.exist()
-        expect(team).to.exist()
-        expect(team.policies).to.have.length(2)
-        expect(team.policies).to.only.include([{
-          id: policies[0].id,
-          name: policies[0].name,
-          version: policies[0].version,
-          variables: {var1: 'value1'}
-        }, {
-          id: policies[1].id,
-          name: policies[1].name,
-          version: policies[1].version,
-          variables: {var2: 'value3'}
-        }])
-        done()
-      })
-    })
-  })
-
   lab.test('delete team policies', (done) => {
     udaru.teams.addPolicies({ id: testTeam.id, policies: [policies[0].id, policies[1].id], organizationId: 'WONKA' }, (err, team) => {
       expect(err).to.not.exist()
@@ -882,6 +795,150 @@ lab.experiment('TeamOps', () => {
           expect(team.users).to.equal([{
             id: users[0].id,
             name: users[0].name
+          }])
+          done()
+        })
+      })
+    })
+  })
+
+  lab.experiment('add policies twice', () => {
+    lab.test('without variables do nothing', (done) => {
+      udaru.teams.addPolicies({ id: testTeam.id, policies: [policies[0].id, policies[1].id], organizationId: 'WONKA' }, (err, team) => {
+        expect(err).to.not.exist()
+        expect(team).to.exist()
+        expect(team.policies).to.have.length(2)
+        expect(team.policies).to.only.include([{
+          id: policies[0].id,
+          name: policies[0].name,
+          version: policies[0].version,
+          variables: {}
+        }, {
+          id: policies[1].id,
+          name: policies[1].name,
+          version: policies[1].version,
+          variables: {}
+        }])
+
+        udaru.teams.addPolicies({ id: team.id, policies: [policies[1].id], organizationId: 'WONKA' }, (err, team) => {
+          expect(err).to.not.exist()
+          expect(team).to.exist()
+          expect(team.policies).to.have.length(2)
+          expect(team.policies).to.only.include([{
+            id: policies[0].id,
+            name: policies[0].name,
+            version: policies[0].version,
+            variables: {}
+          }, {
+            id: policies[1].id,
+            name: policies[1].name,
+            version: policies[1].version,
+            variables: {}
+          }])
+          done()
+        })
+      })
+    })
+
+    lab.test('with different variables add twice', (done) => {
+      const policiesParam = [{
+        id: policies[0].id,
+        variables: {var1: 'value1'}
+      }, {
+        id: policies[1].id,
+        variables: {var2: 'value2'}
+      }]
+
+      udaru.teams.addPolicies({ id: testTeam.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
+        expect(err).to.not.exist()
+        expect(team).to.exist()
+        expect(team.policies).to.have.length(2)
+        expect(team.policies).to.only.include([{
+          id: policies[0].id,
+          name: policies[0].name,
+          version: policies[0].version,
+          variables: {var1: 'value1'}
+        }, {
+          id: policies[1].id,
+          name: policies[1].name,
+          version: policies[1].version,
+          variables: {var2: 'value2'}
+        }])
+
+        const policiesParam = [{
+          id: policies[1].id,
+          variables: {var2: 'value3'}
+        }]
+
+        udaru.teams.addPolicies({ id: team.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
+          expect(err).to.not.exist()
+          expect(team).to.exist()
+          expect(team.policies).to.have.length(3)
+          expect(team.policies).to.only.include([{
+            id: policies[0].id,
+            name: policies[0].name,
+            version: policies[0].version,
+            variables: {var1: 'value1'}
+          }, {
+            id: policies[1].id,
+            name: policies[1].name,
+            version: policies[1].version,
+            variables: {var2: 'value2'}
+          }, {
+            id: policies[1].id,
+            name: policies[1].name,
+            version: policies[1].version,
+            variables: {var2: 'value3'}
+          }])
+          done()
+        })
+      })
+    })
+
+    lab.test('with same variables do nothing', (done) => {
+      const policiesParam = [{
+        id: policies[0].id,
+        variables: {var1: 'value1'}
+      }, {
+        id: policies[1].id,
+        variables: {var2: 'value2'}
+      }]
+
+      udaru.teams.addPolicies({ id: testTeam.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
+        expect(err).to.not.exist()
+        expect(team).to.exist()
+        expect(team.policies).to.have.length(2)
+        expect(team.policies).to.only.include([{
+          id: policies[0].id,
+          name: policies[0].name,
+          version: policies[0].version,
+          variables: {var1: 'value1'}
+        }, {
+          id: policies[1].id,
+          name: policies[1].name,
+          version: policies[1].version,
+          variables: {var2: 'value2'}
+        }])
+
+        const policiesParam = [{
+          id: policies[1].id,
+          variables: {var2: 'value2'}
+        }]
+
+        udaru.teams.addPolicies({ id: team.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
+          expect(err).to.not.exist()
+          expect(team).to.exist()
+          expect(team.policies).to.have.length(2)
+          expect(team.policies).to.only.include([{
+            id: policies[0].id,
+            name: policies[0].name,
+            version: policies[0].version,
+            variables: {var1: 'value1'}
+          }, {
+            id: policies[1].id,
+            name: policies[1].name,
+            version: policies[1].version,
+            variables: {var2: 'value2'}
           }])
           done()
         })

--- a/test/integration/userOps.test.js
+++ b/test/integration/userOps.test.js
@@ -151,9 +151,12 @@ lab.experiment('UserOps', () => {
         authorsTeam,
         readersTeam
       ],
-      policies: [
-        accountantPolicy
-      ]
+      policies: [{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }]
     }
     udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, result) => {
       expect(err).to.not.exist()
@@ -193,7 +196,12 @@ lab.experiment('UserOps', () => {
     udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
-      expect(user.policies).to.equal([accountantPolicy])
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
 
       udaru.users.replacePolicies({
         id: 'VerucaId',
@@ -202,7 +210,64 @@ lab.experiment('UserOps', () => {
       }, (err, user) => {
         expect(err).to.not.exist()
         expect(user).to.exist()
-        expect(user.policies).to.equal([directorPolicy, sysadminPolicy])
+        expect(user.policies).to.equal([{
+          id: directorPolicy.id,
+          name: directorPolicy.name,
+          version: directorPolicy.version,
+          variables: {}
+        }, {
+          id: sysadminPolicy.id,
+          name: sysadminPolicy.name,
+          version: sysadminPolicy.version,
+          variables: {}
+        }])
+
+        udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+    })
+  })
+
+  lab.test('replace user\'s policies with variables', (done) => {
+    const accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
+    const directorPolicy = u.findPick(wonkaPolicies, {name: 'Director'}, ['id', 'name', 'version'])
+    const sysadminPolicy = u.findPick(wonkaPolicies, {name: 'Sys admin'}, ['id', 'name', 'version'])
+
+    udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
+      expect(err).to.not.exist()
+      expect(user).to.exist()
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
+
+      udaru.users.replacePolicies({
+        id: 'VerucaId',
+        policies: [{
+          id: directorPolicy.id
+        }, {
+          id: sysadminPolicy.id,
+          variables: {var1: 'value1'}
+        }],
+        organizationId: 'WONKA'
+      }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([{
+          id: directorPolicy.id,
+          name: directorPolicy.name,
+          version: directorPolicy.version,
+          variables: {}
+        }, {
+          id: sysadminPolicy.id,
+          name: sysadminPolicy.name,
+          version: sysadminPolicy.version,
+          variables: {var1: 'value1'}
+        }])
 
         udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
           expect(err).to.not.exist()
@@ -220,16 +285,83 @@ lab.experiment('UserOps', () => {
     udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
-      expect(user.policies).to.equal([accountantPolicy])
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
 
       udaru.users.addPolicies({ id: 'VerucaId', policies: [directorPolicy.id, sysadminPolicy.id], organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.not.exist()
         expect(user).to.exist()
-        expect(user.policies).to.equal([
-          accountantPolicy,
-          directorPolicy,
-          sysadminPolicy
-        ])
+        expect(user.policies).to.equal([{
+          id: accountantPolicy.id,
+          name: accountantPolicy.name,
+          version: accountantPolicy.version,
+          variables: {}
+        }, {
+          id: directorPolicy.id,
+          name: directorPolicy.name,
+          version: directorPolicy.version,
+          variables: {}
+        }, {
+          id: sysadminPolicy.id,
+          name: sysadminPolicy.name,
+          version: sysadminPolicy.version,
+          variables: {}
+        }])
+
+        udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+    })
+  })
+
+  lab.test('add policies with variables to user', (done) => {
+    let accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
+    let directorPolicy = u.findPick(wonkaPolicies, {name: 'Director'}, ['id', 'name', 'version'])
+    let sysadminPolicy = u.findPick(wonkaPolicies, {name: 'Sys admin'}, ['id', 'name', 'version'])
+
+    udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
+      expect(err).to.not.exist()
+      expect(user).to.exist()
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
+
+      const policies = [{
+        id: directorPolicy.id,
+        variables: {var1: 'value1'}
+      }, {
+        id: sysadminPolicy.id,
+        variables: {var2: 'value2'}
+      }]
+
+      udaru.users.addPolicies({ id: 'VerucaId', policies, organizationId: 'WONKA' }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([{
+          id: accountantPolicy.id,
+          name: accountantPolicy.name,
+          version: accountantPolicy.version,
+          variables: {}
+        }, {
+          id: directorPolicy.id,
+          name: directorPolicy.name,
+          version: directorPolicy.version,
+          variables: {var1: 'value1'}
+        }, {
+          id: sysadminPolicy.id,
+          name: sysadminPolicy.name,
+          version: sysadminPolicy.version,
+          variables: {var2: 'value2'}
+        }])
 
         udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
           expect(err).to.not.exist()
@@ -247,7 +379,12 @@ lab.experiment('UserOps', () => {
     udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
-      expect(user.policies).to.equal([accountantPolicy])
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
 
       udaru.users.addPolicies({
         id: 'VerucaId',
@@ -260,11 +397,71 @@ lab.experiment('UserOps', () => {
       }, (err, user) => {
         expect(err).to.not.exist()
         expect(user).to.exist()
-        expect(user.policies).to.equal([
-          accountantPolicy,
-          directorPolicy,
-          sysadminPolicy
-        ])
+        expect(user.policies).to.equal([{
+          id: accountantPolicy.id,
+          name: accountantPolicy.name,
+          version: accountantPolicy.version,
+          variables: {}
+        }, {
+          id: directorPolicy.id,
+          name: directorPolicy.name,
+          version: directorPolicy.version,
+          variables: {}
+        }, {
+          id: sysadminPolicy.id,
+          name: sysadminPolicy.name,
+          version: sysadminPolicy.version,
+          variables: {}
+        }])
+
+        udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+    })
+  })
+
+  lab.test('add twice the same policy with variables to a user (update variables)', (done) => {
+    const accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
+    const directorPolicy = u.findPick(wonkaPolicies, {name: 'Director'}, ['id', 'name', 'version'])
+
+    udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
+      expect(err).to.not.exist()
+      expect(user).to.exist()
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
+
+      const policies = [{
+        id: accountantPolicy.id,
+        variables: {var1: 'value1'}
+      }, {
+        id: directorPolicy.id,
+        variables: {var2: 'value2'}
+      }]
+
+      udaru.users.addPolicies({
+        id: 'VerucaId',
+        policies,
+        organizationId: 'WONKA'
+      }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([{
+          id: accountantPolicy.id,
+          name: accountantPolicy.name,
+          version: accountantPolicy.version,
+          variables: {var1: 'value1'}
+        }, {
+          id: directorPolicy.id,
+          name: directorPolicy.name,
+          version: directorPolicy.version,
+          variables: {var2: 'value2'}
+        }])
 
         udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
           expect(err).to.not.exist()
@@ -280,7 +477,12 @@ lab.experiment('UserOps', () => {
     udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
-      expect(user.policies).to.equal([accountantPolicy])
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
 
       udaru.users.deletePolicies({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.not.exist()
@@ -301,7 +503,12 @@ lab.experiment('UserOps', () => {
     udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
       expect(err).to.not.exist()
       expect(user).to.exist()
-      expect(user.policies).to.equal([accountantPolicy])
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
 
       udaru.users.deletePolicy({ userId: 'VerucaId', policyId: accountantPolicy.id, organizationId: 'WONKA' }, (err, user) => {
         expect(err).to.not.exist()

--- a/test/integration/userOps.test.js
+++ b/test/integration/userOps.test.js
@@ -371,106 +371,6 @@ lab.experiment('UserOps', () => {
     })
   })
 
-  lab.test('add twice the same policy to a user', (done) => {
-    let accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
-    let directorPolicy = u.findPick(wonkaPolicies, {name: 'Director'}, ['id', 'name', 'version'])
-    let sysadminPolicy = u.findPick(wonkaPolicies, {name: 'Sys admin'}, ['id', 'name', 'version'])
-
-    udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
-      expect(err).to.not.exist()
-      expect(user).to.exist()
-      expect(user.policies).to.equal([{
-        id: accountantPolicy.id,
-        name: accountantPolicy.name,
-        version: accountantPolicy.version,
-        variables: {}
-      }])
-
-      udaru.users.addPolicies({
-        id: 'VerucaId',
-        policies: [
-          accountantPolicy.id,
-          directorPolicy.id,
-          sysadminPolicy.id
-        ],
-        organizationId: 'WONKA'
-      }, (err, user) => {
-        expect(err).to.not.exist()
-        expect(user).to.exist()
-        expect(user.policies).to.equal([{
-          id: accountantPolicy.id,
-          name: accountantPolicy.name,
-          version: accountantPolicy.version,
-          variables: {}
-        }, {
-          id: directorPolicy.id,
-          name: directorPolicy.name,
-          version: directorPolicy.version,
-          variables: {}
-        }, {
-          id: sysadminPolicy.id,
-          name: sysadminPolicy.name,
-          version: sysadminPolicy.version,
-          variables: {}
-        }])
-
-        udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
-          expect(err).to.not.exist()
-          done()
-        })
-      })
-    })
-  })
-
-  lab.test('add twice the same policy with variables to a user (update variables)', (done) => {
-    const accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
-    const directorPolicy = u.findPick(wonkaPolicies, {name: 'Director'}, ['id', 'name', 'version'])
-
-    udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
-      expect(err).to.not.exist()
-      expect(user).to.exist()
-      expect(user.policies).to.equal([{
-        id: accountantPolicy.id,
-        name: accountantPolicy.name,
-        version: accountantPolicy.version,
-        variables: {}
-      }])
-
-      const policies = [{
-        id: accountantPolicy.id,
-        variables: {var1: 'value1'}
-      }, {
-        id: directorPolicy.id,
-        variables: {var2: 'value2'}
-      }]
-
-      udaru.users.addPolicies({
-        id: 'VerucaId',
-        policies,
-        organizationId: 'WONKA'
-      }, (err, user) => {
-        expect(err).to.not.exist()
-        expect(user).to.exist()
-        expect(user.policies).to.equal([{
-          id: accountantPolicy.id,
-          name: accountantPolicy.name,
-          version: accountantPolicy.version,
-          variables: {var1: 'value1'}
-        }, {
-          id: directorPolicy.id,
-          name: directorPolicy.name,
-          version: directorPolicy.version,
-          variables: {var2: 'value2'}
-        }])
-
-        udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
-          expect(err).to.not.exist()
-          done()
-        })
-      })
-    })
-  })
-
   lab.test('delete user\'s policies', (done) => {
     let accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
 
@@ -518,6 +418,178 @@ lab.experiment('UserOps', () => {
         udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
           expect(err).to.not.exist()
           done()
+        })
+      })
+    })
+  })
+
+  lab.experiment('add policies twice', () => {
+    lab.test('without variables should do nothing', (done) => {
+      let accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
+      let directorPolicy = u.findPick(wonkaPolicies, {name: 'Director'}, ['id', 'name', 'version'])
+      let sysadminPolicy = u.findPick(wonkaPolicies, {name: 'Sys admin'}, ['id', 'name', 'version'])
+
+      udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([{
+          id: accountantPolicy.id,
+          name: accountantPolicy.name,
+          version: accountantPolicy.version,
+          variables: {}
+        }])
+
+        udaru.users.addPolicies({
+          id: 'VerucaId',
+          policies: [
+            accountantPolicy.id,
+            directorPolicy.id,
+            sysadminPolicy.id
+          ],
+          organizationId: 'WONKA'
+        }, (err, user) => {
+          expect(err).to.not.exist()
+          expect(user).to.exist()
+          expect(user.policies).to.equal([{
+            id: accountantPolicy.id,
+            name: accountantPolicy.name,
+            version: accountantPolicy.version,
+            variables: {}
+          }, {
+            id: directorPolicy.id,
+            name: directorPolicy.name,
+            version: directorPolicy.version,
+            variables: {}
+          }, {
+            id: sysadminPolicy.id,
+            name: sysadminPolicy.name,
+            version: sysadminPolicy.version,
+            variables: {}
+          }])
+
+          udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+
+    lab.test('with different variables should add twice', (done) => {
+      const accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
+      const directorPolicy = u.findPick(wonkaPolicies, {name: 'Director'}, ['id', 'name', 'version'])
+
+      udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([{
+          id: accountantPolicy.id,
+          name: accountantPolicy.name,
+          version: accountantPolicy.version,
+          variables: {}
+        }])
+
+        const policies = [{
+          id: accountantPolicy.id,
+          variables: {var1: 'value1'}
+        }, {
+          id: directorPolicy.id,
+          variables: {var2: 'value2'}
+        }]
+
+        udaru.users.addPolicies({
+          id: 'VerucaId',
+          policies,
+          organizationId: 'WONKA'
+        }, (err, user) => {
+          expect(err).to.not.exist()
+          expect(user).to.exist()
+          expect(user.policies).to.equal([{
+            id: accountantPolicy.id,
+            name: accountantPolicy.name,
+            version: accountantPolicy.version,
+            variables: {}
+          }, {
+            id: accountantPolicy.id,
+            name: accountantPolicy.name,
+            version: accountantPolicy.version,
+            variables: {var1: 'value1'}
+          }, {
+            id: directorPolicy.id,
+            name: directorPolicy.name,
+            version: directorPolicy.version,
+            variables: {var2: 'value2'}
+          }])
+
+          udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+
+    lab.test('with same variables should do nothing', (done) => {
+      const accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
+
+      udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([{
+          id: accountantPolicy.id,
+          name: accountantPolicy.name,
+          version: accountantPolicy.version,
+          variables: {}
+        }])
+
+        const policies = [{
+          id: accountantPolicy.id,
+          variables: {var1: 'value1'}
+        }]
+
+        udaru.users.addPolicies({
+          id: 'VerucaId',
+          policies,
+          organizationId: 'WONKA'
+        }, (err, user) => {
+          expect(err).to.not.exist()
+          expect(user).to.exist()
+          expect(user.policies).to.equal([{
+            id: accountantPolicy.id,
+            name: accountantPolicy.name,
+            version: accountantPolicy.version,
+            variables: {}
+          }, {
+            id: accountantPolicy.id,
+            name: accountantPolicy.name,
+            version: accountantPolicy.version,
+            variables: {var1: 'value1'}
+          }])
+
+          udaru.users.addPolicies({
+            id: 'VerucaId',
+            policies,
+            organizationId: 'WONKA'
+          }, (err, user) => {
+            expect(err).to.not.exist()
+            expect(user).to.exist()
+            expect(user.policies).to.equal([{
+              id: accountantPolicy.id,
+              name: accountantPolicy.name,
+              version: accountantPolicy.version,
+              variables: {}
+            }, {
+              id: accountantPolicy.id,
+              name: accountantPolicy.name,
+              version: accountantPolicy.version,
+              variables: {var1: 'value1'}
+            }])
+
+            udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
+              expect(err).to.not.exist()
+              done()
+            })
+          })
         })
       })
     })


### PR DESCRIPTION
Policy templates are implemented as regular policy with variables similar to regular PBAC variables.
However, it is possible to fix the value of those variables when a policy is assigned to a user, team or organisation.

This PR makes 3 changes:
- endpoints that assign policies now support passing variables
- endpoints that return assigned policies now return variables as well
- policies retrieved for an authorization check are now parsed and variables are interpolated before being feeded into PBAC

This is the first step required to make policies shared across organisation and is meant to allow customisation of the policies.
Next step is to build a mechanism to actually share the policies and make them visible to all organisations.