### PR TITLE
Introduce shared policies

### DIFF
--- a/database/migrations/005.do.sql
+++ b/database/migrations/005.do.sql
@@ -1,0 +1,2 @@
+
+ALTER TABLE policies ALTER COLUMN org_id DROP NOT NULL;

--- a/database/migrations/005.undo.sql
+++ b/database/migrations/005.undo.sql
@@ -1,0 +1,2 @@
+
+ALTER TABLE policies ALTER COLUMN org_id SET NOT NULL;

--- a/database/testdata/fixtures.sql
+++ b/database/testdata/fixtures.sql
@@ -193,6 +193,12 @@ VALUES
           "Resource": ["/myapp/documents/no_access"]
         }]}'::JSONB);
 
+INSERT INTO policies (id, version, name, statements)
+VALUES ('sharedPolicyId1', 0.1, 'Shared policy from fixtures', '{ "Statement": [{
+          "Effect": "Allow",
+          "Action": ["Read"],
+          "Resource": ["/myapp/documents/*"]
+        }]}'::JSONB);
 
 INSERT INTO user_policies (user_id, policy_id)
   SELECT 'ROOTid', id FROM policies WHERE name = 'SuperAdmin'

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -204,7 +204,7 @@ Currently we support variables in the Resource part of the policy statement (sim
 
 ## Shared Policies
 
-Everything in Udaru is scoped by policies and there can't be any interaction between two entities that belongs to different organizations.
+Everything in Udaru is scoped by policies and there can't be any interaction between two entities that belong to different organizations.
 
 However, if you are offering the same structure to all organizations in your deployment and need to reduce complexity and duplication, Udaru offers the concept of "Shared Policies".
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -202,6 +202,18 @@ When a policy is assigned to a user (or a team) an additional object can be prov
 
 Currently we support variables in the Resource part of the policy statement (similar o what PBAC already does)
 
+## Shared Policies
+
+Everything in Udaru is scoped by policies and can't be any interaction between two entities that belongs to different organizations.
+
+However, in the case you are offering the same structure to all organizations in your deployment and need to reduce complexity and duplication, Udaru offers the concept of "Shared Policies".
+
+Shared Policy are equal in concept to regular policy, but are visibile to every organization. A shared policy can be assigned to a user or a team of any organization - but can't be used to give visibility of other organizations entities.
+
+They can also be template policies. In fact, they are designed to work together so that the shared policies can be customized for the need of a specific organization.
+
+Shared Policies work exactly as regular policies, they just can be created (or updated, deleted) once for every organizations.
+
 ## Super User
 
 In Udaru all operations are performed in the organization context: for each user request Udaru finds the organization to which the user belongs to and from there all middleware checks and element queries are made in the organization context. One user can't perform operations outside the organization to which it belongs to. The user identifier is passed in the Http headers as the `authorization` field.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -204,11 +204,11 @@ Currently we support variables in the Resource part of the policy statement (sim
 
 ## Shared Policies
 
-Everything in Udaru is scoped by policies and can't be any interaction between two entities that belongs to different organizations.
+Everything in Udaru is scoped by policies and there can't be any interaction between two entities that belongs to different organizations.
 
-However, in the case you are offering the same structure to all organizations in your deployment and need to reduce complexity and duplication, Udaru offers the concept of "Shared Policies".
+However, if you are offering the same structure to all organizations in your deployment and need to reduce complexity and duplication, Udaru offers the concept of "Shared Policies".
 
-Shared Policy are equal in concept to regular policy, but are visibile to every organization. A shared policy can be assigned to a user or a team of any organization - but can't be used to give visibility of other organizations entities.
+A Shared Policy is equal in concept to a regular policy, but is visibile to every organization. A shared policy can be assigned to a user or a team of any organization - but can't be used to give visibility of other organizations entities.
 
 They can also be template policies. In fact, they are designed to work together so that the shared policies can be customized for the need of a specific organization.
 

--- a/lib/config/auth.js
+++ b/lib/config/auth.js
@@ -6,7 +6,8 @@ const resourcesConfig = new Reconfig({
     organizations: '/{{ namespace }}/organization/[organizationId]',
     teams: '/{{ namespace }}/team/[organizationId]/[teamId]',
     users: '/{{ namespace }}/user/[organizationId]/[teamId]/[userId]',
-    policies: '/{{ namespace }}/policy/[organizationId]/[policyId]'
+    policies: '/{{ namespace }}/policy/[organizationId]/[policyId]',
+    'shared-policies': '/{{ namespace }}/shared-policy/[policyId]'
   }
 }, {
   paramsInterpolation: ['[', ']'],
@@ -86,6 +87,7 @@ module.exports = {
     organizations: getResource.bind(null, 'organizations'),
     teams: getResource.bind(null, 'teams'),
     users: getResource.bind(null, 'users'),
-    policies: getResource.bind(null, 'policies')
+    policies: getResource.bind(null, 'policies'),
+    'shared-policies': getResource.bind(null, 'shared-policies')
   }
 }

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -46,7 +46,12 @@ function buildUdaruCore (dbPool, config) {
       read: policyOps.readPolicy,
       create: policyOps.createPolicy,
       update: policyOps.updatePolicy,
-      delete: policyOps.deletePolicy
+      delete: policyOps.deletePolicy,
+      listShared: policyOps.listSharedPolicies,
+      createShared: policyOps.createSharedPolicy,
+      updateShared: policyOps.updateSharedPolicy,
+      deleteShared: policyOps.deleteSharedPolicy,
+      readShared: policyOps.readSharedPolicy
     },
 
     teams: {

--- a/lib/core/lib/ops/policyOps.js
+++ b/lib/core/lib/ops/policyOps.js
@@ -40,6 +40,19 @@ function buildPolicyOps (db, config) {
     client.query(sql, utils.boomErrorWrapper(cb))
   }
 
+  function insertSharedPolicies (client, policies, cb) {
+    policies = toArrayWithId(policies)
+
+    const sql = SQL`INSERT INTO policies (id, version, name, statements) VALUES `
+    sql.append(SQL`(${policies[0].id}, ${policies[0].version}, ${policies[0].name}, ${policies[0].statements})`)
+    policies.slice(1).forEach((policy) => {
+      sql.append(SQL`, (${policy.id}, ${policy.version}, ${policy.name}, ${policy.statements})`)
+    })
+    sql.append(SQL` RETURNING id`)
+
+    client.query(sql, utils.boomErrorWrapper(cb))
+  }
+
   function deletePolicies (client, ids, orgId, cb) {
     client.query(SQL`DELETE FROM policies WHERE id = ANY (${ids}) AND org_id=${orgId}`, utils.boomErrorWrapper(cb))
   }
@@ -99,6 +112,22 @@ function buildPolicyOps (db, config) {
       DELETE FROM policies
       WHERE id = ${id}
       AND org_id = ${organizationId}
+    `
+    job.client.query(sqlQuery, (err, res) => {
+      if (err) return next(Boom.badImplementation(err))
+      if (res.rowCount === 0) return next(Boom.notFound(`Policy ${id} not found`))
+
+      next()
+    })
+  }
+
+  function removeSharedPolicy (job, next) {
+    const id = job.id
+
+    const sqlQuery = SQL`
+      DELETE FROM policies
+      WHERE id = ${id}
+      AND org_id IS NULL
     `
     job.client.query(sqlQuery, (err, res) => {
       if (err) return next(Boom.badImplementation(err))
@@ -334,6 +363,7 @@ function buildPolicyOps (db, config) {
             AND
               org_id = ${rootOrgId}
           )
+          OR org_id IS NULL
         )
         UNION
         SELECT
@@ -355,6 +385,7 @@ function buildPolicyOps (db, config) {
             AND
               org_id = ${rootOrgId}
           )
+          OR org_id IS NULL
         )
         UNION
         SELECT
@@ -376,6 +407,7 @@ function buildPolicyOps (db, config) {
             AND
               org_id = ${rootOrgId}
           )
+          OR org_id IS NULL
         )
       `
 
@@ -424,6 +456,165 @@ function buildPolicyOps (db, config) {
       const defaultPolicies = config.get('authorization.teams.defaultPolicies', {organizationId, teamId})
       const names = getNames(defaultPolicies)
       client.query(SQL`SELECT id FROM policies WHERE name = ANY(${names}) AND org_id = ${organizationId}`, utils.boomErrorWrapper(cb))
+    },
+
+    /**
+     * List all the policies referencing a specific organization (not necessarily attached to it)
+     *
+     * @param  {Object}   params { limit, page }
+     * @param  {Function} cb
+     */
+    listSharedPolicies: function listSharedPolicies (params, cb) {
+      const { limit, page } = params
+
+      Joi.validate({ page, limit }, validationRules.listSharedPolicies, function (err) {
+        if (err) return cb(Boom.badRequest(err))
+
+        const sqlQuery = SQL`
+          WITH total AS (
+            SELECT COUNT(*) AS cnt FROM policies
+            WHERE org_id IS NULL
+          )
+          SELECT
+            p.id,
+            p.version,
+            p.name,
+            p.statements,
+            t.cnt::INTEGER AS total
+          FROM policies AS p
+          INNER JOIN total AS t ON 1=1
+          WHERE p.org_id IS NULL
+          ORDER BY UPPER(p.name)
+        `
+        if (limit) {
+          sqlQuery.append(SQL` LIMIT ${limit}`)
+        }
+        if (limit && page) {
+          const offset = (page - 1) * limit
+          sqlQuery.append(SQL` OFFSET ${offset}`)
+        }
+        db.query(sqlQuery, function (err, result) {
+          if (err) return cb(Boom.badImplementation(err))
+          let total = result.rows.length > 0 ? result.rows[0].total : 0
+          return cb(null, result.rows.map(mapping.policy), total)
+        })
+      })
+    },
+
+    /**
+     * fetch specific shared policy
+     *
+     * @param  {Object}   params { id }
+     * @param  {Function} cb
+     */
+    readSharedPolicy: function readSharedPolicy ({ id }, cb) {
+      Joi.validate({ id }, validationRules.readSharedPolicy, function (err) {
+        if (err) return cb(Boom.badRequest(err))
+
+        const sqlQuery = SQL`
+          SELECT  *
+          FROM policies
+          WHERE id = ${id}
+          AND org_id IS NULL
+        `
+        db.query(sqlQuery, function (err, result) {
+          if (err) return cb(Boom.badImplementation(err))
+          if (result.rowCount === 0) return cb(Boom.notFound())
+
+          return cb(null, mapping.policy(result.rows[0]))
+        })
+      })
+    },
+
+    /**
+     * Creates a new shared policy
+     *
+     * @param  {Object}   params { id, version, name, statements }
+     * @param  {Function} cb
+     */
+    createSharedPolicy: function createSharedPolicy (params, cb) {
+      Joi.validate(params, validationRules.createSharedPolicy, function (err) {
+        if (err) return cb(Boom.badRequest(err))
+
+        const { id, version, name, statements } = params
+
+        insertSharedPolicies(db, [{
+          id: id,
+          version: version,
+          name: name,
+          statements: statements
+        }], (err, result) => {
+          if (utils.isUniqueViolationError(err)) {
+            return cb(Boom.badRequest(`Policy with id ${id} already present`))
+          }
+          if (err) return cb(err)
+
+          policyOps.readSharedPolicy({ id: result.rows[0].id }, cb)
+        })
+      })
+    },
+
+    /**
+     * Update shared policy values
+     *
+     * @param  {Object}   params { id, organizationId, version, name, statements }
+     * @param  {Function} cb
+     */
+    updateSharedPolicy: function updateSharedPolicy (params, cb) {
+      const { id, version, name, statements } = params
+
+      Joi.validate({ id, version, name, statements }, validationRules.updateSharedPolicy, function (err) {
+        if (err) return cb(Boom.badRequest(err))
+
+        const sqlQuery = SQL`
+          UPDATE policies
+          SET
+            version = ${version},
+            name = ${name},
+            statements = ${statements}
+          WHERE
+            id = ${id}
+            AND org_id IS NULL
+        `
+        db.query(sqlQuery, function (err, result) {
+          if (err) return cb(Boom.badImplementation(err))
+          if (result.rowCount === 0) return cb(Boom.notFound())
+
+          policyOps.readSharedPolicy({ id }, cb)
+        })
+      })
+    },
+
+    /**
+     * Delete a specific shared policy
+     *
+     * @param  {Object}   params { id }
+     * @param  {Function} cb
+     */
+    deleteSharedPolicy: function deleteSharedPolicy (params, cb) {
+      const id = params.id
+      const tasks = [
+        (job, next) => {
+          Joi.validate({ id }, validationRules.deleteSharedPolicy, (err) => {
+            if (err) return next(Boom.badRequest(err))
+
+            next()
+          })
+        },
+        (job, next) => {
+          job.id = id
+          next()
+        },
+        removePolicyFromUsers,
+        removePolicyFromTeams,
+        removePolicyFromOrganizations,
+        removeSharedPolicy
+      ]
+
+      db.withTransaction(tasks, (err, res) => {
+        if (err) return cb(err)
+        cb()
+      })
     }
   }
 
@@ -432,6 +623,12 @@ function buildPolicyOps (db, config) {
   policyOps.createPolicy.validate = validationRules.createPolicy
   policyOps.updatePolicy.validate = validationRules.updatePolicy
   policyOps.deletePolicy.validate = validationRules.deletePolicy
+
+  policyOps.listSharedPolicies.validate = validationRules.listSharedPolicies
+  policyOps.readSharedPolicy.validate = validationRules.readSharedPolicy
+  policyOps.createSharedPolicy.validate = validationRules.createSharedPolicy
+  policyOps.updateSharedPolicy.validate = validationRules.updateSharedPolicy
+  policyOps.deleteSharedPolicy.validate = validationRules.deleteSharedPolicy
 
   return policyOps
 }

--- a/lib/core/lib/ops/utils.js
+++ b/lib/core/lib/ops/utils.js
@@ -25,7 +25,7 @@ function isForeignKeyViolationError (err) {
 function checkPoliciesOrg (db, policies, organizationId, cb) {
   const policyIds = _.map(policies, 'id')
 
-  db.query(SQL`SELECT id FROM policies WHERE id = ANY (${policyIds}) AND org_id = ${organizationId}`, (err, result) => {
+  db.query(SQL`SELECT id FROM policies WHERE id = ANY (${policyIds}) AND (org_id = ${organizationId} OR org_id IS NULL)`, (err, result) => {
     if (err) return cb(Boom.badImplementation(err))
 
     if (result.rowCount !== policies.length) {

--- a/lib/core/lib/ops/validation.js
+++ b/lib/core/lib/ops/validation.js
@@ -212,6 +212,28 @@ const policies = {
   deletePolicy: {
     id: validationRules.policyId,
     organizationId: validationRules.organizationId
+  },
+  listSharedPolicies: {
+    page: validationRules.page,
+    limit: validationRules.limit
+  },
+  readSharedPolicy: {
+    id: validationRules.policyId
+  },
+  createSharedPolicy: {
+    id: validationRules.policyId.allow('').optional(),
+    version: validationRules.version,
+    name: validationRules.policyName,
+    statements: validationRules.statements
+  },
+  deleteSharedPolicy: {
+    id: validationRules.policyId
+  },
+  updateSharedPolicy: {
+    id: validationRules.policyId,
+    version: validationRules.version,
+    name: validationRules.policyName,
+    statements: validationRules.statements
   }
 }
 

--- a/lib/plugin/routes/private/policies.js
+++ b/lib/plugin/routes/private/policies.js
@@ -136,6 +136,123 @@ exports.register = function (server, options, next) {
     }
   })
 
+  server.route({
+    method: 'POST',
+    path: '/authorization/shared-policies',
+    handler: function (request, reply) {
+      if (!serviceKey.hasValidServiceKey(request)) return reply(Boom.forbidden())
+
+      const params = _.pick(request.payload, [
+        'id',
+        'version',
+        'name',
+        'statements'
+      ])
+
+      request.udaruCore.policies.createShared(params, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply(res).code(201)
+      })
+    },
+    config: {
+      validate: {
+        payload: _.pick(validation.createSharedPolicy, ['id', 'name', 'version', 'statements']),
+        query: {
+          sig: Joi.string().required()
+        },
+        headers
+      },
+      description: 'Create a policy shared across organizations',
+      notes: 'The POST /authorization/shared-policies endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
+      tags: ['api', 'policies', 'private'],
+      plugins: {
+        auth: {
+          action: Action.CreatePolicy
+        }
+      },
+      response: { schema: swagger.Policy }
+    }
+  })
+
+  server.route({
+    method: 'PUT',
+    path: '/authorization/shared-policies/{id}',
+    handler: function (request, reply) {
+      if (!serviceKey.hasValidServiceKey(request)) return reply(Boom.forbidden())
+
+      const { id } = request.params
+      const { version, name, statements } = request.payload
+
+      const params = {
+        id,
+        version,
+        name,
+        statements
+      }
+
+      request.udaruCore.policies.updateShared(params, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.updateSharedPolicy, ['id']),
+        payload: _.pick(validation.updateSharedPolicy, ['version', 'name', 'statements']),
+        query: {
+          sig: Joi.string().required()
+        },
+        headers
+      },
+      description: 'Update a shared policy',
+      notes: 'The PUT /authorization/shared-policies/{id} endpoint is a private endpoint. It can be accessed only using a service key.\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
+      tags: ['api', 'policies', 'private'],
+      plugins: {
+        auth: {
+          action: Action.UpdatePolicy,
+          getParams: (request) => ({ policyId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Policy }
+    }
+  })
+
+  server.route({
+    method: 'DELETE',
+    path: '/authorization/shared-policies/{id}',
+    handler: function (request, reply) {
+      if (!serviceKey.hasValidServiceKey(request)) return reply(Boom.forbidden())
+
+      const { id } = request.params
+
+      request.udaruCore.policies.deleteShared({ id }, function (err, res) {
+        if (err) {
+          return reply(err)
+        }
+
+        return reply(res).code(204)
+      })
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.deleteSharedPolicy, ['id']),
+        query: {
+          sig: Joi.string().required()
+        },
+        headers
+      },
+      description: 'Delete a shared policy',
+      notes: 'The DELETE /authorization/shared-policies/{id} endpoint is a private endpoint. It can be accessed only using a service key.\n\nThis service key needs to be passed as a query string in the form "sig=<key>"\n',
+      tags: ['api', 'policies', 'private'],
+      plugins: {
+        auth: {
+          action: Action.DeletePolicy,
+          getParams: (request) => ({ policyId: request.params.id })
+        }
+      }
+    }
+  })
+
   next()
 }
 

--- a/lib/plugin/routes/public/policies.js
+++ b/lib/plugin/routes/public/policies.js
@@ -75,6 +75,70 @@ exports.register = function (server, options, next) {
     }
   })
 
+  server.route({
+    method: 'GET',
+    path: '/authorization/shared-policies',
+    handler: function (request, reply) {
+      const limit = request.query.limit || server.udaruConfig.get('authorization.defaultPageSize')
+      const page = request.query.page || 1
+      request.udaruCore.policies.listShared({
+        limit: limit,
+        page: page
+      }, (err, data, total) => {
+        reply(
+          err,
+          !data ? null : {
+            page: page,
+            limit: limit,
+            total: total,
+            data: data
+          }
+        )
+      })
+    },
+    config: {
+      description: 'Fetch all the defined shared policies',
+      notes: 'The GET /authorization/shared-policies endpoint returns a list of all the defined policies\nthe policies will contain only the ID, version and name. No statements.\n\nThe results are paginated. Page numbering and page limit start from 1.\n',
+      tags: ['api', 'policies'],
+      plugins: {
+        auth: {
+          action: Action.ListPolicies
+        }
+      },
+      validate: {
+        headers,
+        query: _.pick(validation.listSharedPolicies, ['page', 'limit'])
+      },
+      response: { schema: swagger.List(swagger.Policy).label('PagedPolicies') }
+    }
+  })
+
+  server.route({
+    method: 'GET',
+    path: '/authorization/shared-policies/{id}',
+    handler: function (request, reply) {
+      const { id } = request.params
+
+      request.udaruCore.policies.readShared({ id }, reply)
+    },
+    config: {
+      validate: {
+        params: _.pick(validation.readSharedPolicy, ['id']),
+        headers
+      },
+      description: 'Fetch a single shared policy',
+      notes: 'The GET /authorization/shared-policies/{id} endpoint returns a policy based on its ID.\n',
+      tags: ['api', 'policies'],
+      plugins: {
+        auth: {
+          action: Action.ReadPolicy,
+          getParams: (request) => ({ policyId: request.params.id })
+        }
+      },
+      response: { schema: swagger.Policy }
+    }
+  })
+
   next()
 }
 

--- a/lib/plugin/security/authorization.js
+++ b/lib/plugin/security/authorization.js
@@ -89,8 +89,8 @@ function buildAuthorization (config) {
 
   function authorize (server, settings, request, reply) {
     const req = request.raw.req
-
     const authorization = req.headers.authorization
+
     if (!authorization) {
       return reply(Boom.unauthorized('Missing authorization', 'udaru'))
     }

--- a/lib/plugin/security/hapi-auth-validation.js
+++ b/lib/plugin/security/hapi-auth-validation.js
@@ -91,7 +91,7 @@ function buildAuthValidation (authorization) {
 
   function authorize (job, next) {
     buildResources(job.options, job.udaru, job.authParams, job.request, job.organizationId, (err, resources) => {
-      if (err) return Boom.unauthorized('Bad credentials')
+      if (err) return next(Boom.unauthorized('Bad credentials'))
 
       const action = job.authParams.action
       const userId = job.currentUser.id

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "pg:init": "UDARU_SERVICE_local=true node database/init.js && npm run pg:migrate",
     "pg:init-test-db": "npm run pg:init && npm run pg:load-test-data",
     "pg:load-test-data": "UDARU_SERVICE_local=true node database/loadTestData.js",
-    "pg:migrate": "node database/migrate.js --version=4",
+    "pg:migrate": "node database/migrate.js --version=5",
     "start": "node lib/server/start.js",
     "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 95",
     "test:commit-check": "npm run doc:lint && npm run lint && npm run test",

--- a/test/factory.js
+++ b/test/factory.js
@@ -68,10 +68,11 @@ function Factory (lab, data, udaruCore) {
     if (!data.sharedPolicies) return done()
 
     async.mapValues(data.sharedPolicies, (policy, key, next) => {
-      udaru.policies.createShared(Object.assign({}, DEFAULT_SHARED_POLICY, _.pick(policy, 'id', 'name', 'version', 'statements')), (err, res) => {
-        if (err) return next(err)
-        next(null, res)
-      })
+      udaru.policies.createShared(Object.assign(
+        {},
+        DEFAULT_SHARED_POLICY,
+        _.pick(policy, 'id', 'name', 'version', 'statements')
+      ), next)
     }, (err, policies) => {
       if (err) return done(err)
 

--- a/test/factory.js
+++ b/test/factory.js
@@ -18,6 +18,18 @@ const DEFAULT_POLICY = {
   organizationId: 'WONKA'
 }
 
+const DEFAULT_SHARED_POLICY = {
+  version: '2016-07-01',
+  name: 'Shared Policy',
+  statements: {
+    Statement: [{
+      Effect: 'Allow',
+      Action: ['dummy'],
+      Resource: ['dummy']
+    }]
+  }
+}
+
 function Factory (lab, data, udaruCore) {
   const udaru = udaruCore || utils.udaru
   const records = {}
@@ -42,6 +54,22 @@ function Factory (lab, data, udaruCore) {
       udaru.policies.create(Object.assign({}, DEFAULT_POLICY, _.pick(policy, 'id', 'name', 'version', 'statements', 'organizationId')), (err, res) => {
         if (err) return next(err)
         res.organizationId = policy.organizationId || DEFAULT_POLICY.organizationId
+        next(null, res)
+      })
+    }, (err, policies) => {
+      if (err) return done(err)
+
+      Object.assign(records, policies)
+      done()
+    })
+  }
+
+  function createSharedPolicies (done) {
+    if (!data.sharedPolicies) return done()
+
+    async.mapValues(data.sharedPolicies, (policy, key, next) => {
+      udaru.policies.createShared(Object.assign({}, DEFAULT_SHARED_POLICY, _.pick(policy, 'id', 'name', 'version', 'statements')), (err, res) => {
+        if (err) return next(err)
         next(null, res)
       })
     }, (err, policies) => {
@@ -200,6 +228,7 @@ function Factory (lab, data, udaruCore) {
       createOrganizations,
       createUsers,
       createPolicies,
+      createSharedPolicies,
       createTeams
     ], (err) => {
       if (err) return done(err)
@@ -256,6 +285,19 @@ function Factory (lab, data, udaruCore) {
     }, done)
   }
 
+  function deleteSharedPolicies (done) {
+    if (!data.sharedPolicies) return done()
+
+    async.eachOf(data.sharedPolicies, (policy, key, next) => {
+      udaru.policies.deleteShared({
+        id: records[key].id
+      }, (err) => {
+        if (err && err.output.payload.error !== 'Not Found') return next(err)
+        next()
+      })
+    }, done)
+  }
+
   function deleteOrganizations (done) {
     if (!data.organizations) return done()
 
@@ -272,6 +314,7 @@ function Factory (lab, data, udaruCore) {
       deleteUsers,
       deleteTeams,
       deletePolicies,
+      deleteSharedPolicies,
       deleteOrganizations
     ], done)
   }

--- a/test/integration/authorization/policies.test.js
+++ b/test/integration/authorization/policies.test.js
@@ -26,6 +26,20 @@ function Policy (Statement) {
   }
 }
 
+function SharedPolicy (Statement) {
+  return {
+    version: '2016-07-01',
+    name: 'Shared Test Policy',
+    statements: JSON.stringify({
+      Statement: Statement || [{
+        Effect: 'Allow',
+        Action: ['dummy'],
+        Resource: ['dummy']
+      }]
+    })
+  }
+}
+
 lab.experiment('Routes Authorizations', () => {
   lab.experiment('policies', () => {
     lab.experiment('GET /authorization/policies', () => {
@@ -292,6 +306,282 @@ lab.experiment('Routes Authorizations', () => {
           Effect: 'Allow',
           Action: ['authorization:policies:delete'],
           Resource: ['/authorization/policy/WONKA/dummy']
+        }])
+        .shouldRespond(403)
+    })
+  })
+
+  lab.experiment('shared policies', () => {
+    lab.experiment('GET /authorization/shared-policies', () => {
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'GET',
+          url: '/authorization/shared-policies',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with correct policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:list'],
+          Resource: ['/authorization/shared-policy/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:dummy'],
+          Resource: ['/authorization/shared-policy']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:list'],
+          Resource: ['/authorization/shared-policy/dummy']
+        }])
+        .shouldRespond(403)
+    })
+
+    lab.experiment('GET /authorization/shared-policies/{id}', () => {
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy()
+        },
+        sharedPolicies: {
+          calledPolicy: SharedPolicy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'GET',
+          url: '/authorization/shared-policies/{{calledPolicy.id}}',
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all policies')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:read'],
+          Resource: ['/authorization/shared-policy/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for specific policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:read'],
+          Resource: ['/authorization/shared-policy/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:dummy'],
+          Resource: ['/authorization/shared-policy/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:read'],
+          Resource: ['/authorization/shared-policy/dummy']
+        }])
+        .shouldRespond(403)
+    })
+
+    lab.experiment('POST /authorization/shared-policies', () => {
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'POST',
+          url: `/authorization/shared-policies?sig=${config.get('security.api.servicekeys.private')}`,
+          payload: {
+            id: 'added-policy',
+            version: 'anything',
+            name: 'Added Policy',
+            statements: { Statement: [{
+              Effect: 'Allow',
+              Action: ['dummy'],
+              Resource: ['dummy']
+            }] }
+          },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      lab.afterEach((done) => {
+        udaru.policies.delete({ id: 'added-policy', organizationId: 'WONKA' }, () => {
+          // ignore error
+          done()
+        })
+      })
+
+      endpoint.test('should authorize user with correct policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:create'],
+          Resource: ['/authorization/shared-policy/*']
+        }])
+        .shouldRespond(201)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:dummy'],
+          Resource: ['/authorization/shared-policy/*']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:create'],
+          Resource: ['/authorization/shared-policy/dummy']
+        }])
+        .shouldRespond(403)
+    })
+
+    lab.experiment('PUT /authorization/shared-policies/{{id}}', () => {
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy()
+        },
+        sharedPolicies: {
+          calledPolicy: SharedPolicy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'PUT',
+          url: `/authorization/shared-policies/{{calledPolicy.id}}?sig=${config.get('security.api.servicekeys.private')}`,
+          payload: {
+            version: 'anything',
+            name: 'Updated Policy',
+            statements: { Statement: [{
+              Effect: 'Allow',
+              Action: ['dummy'],
+              Resource: ['dummy']
+            }] }
+          },
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all policies')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:update'],
+          Resource: ['/authorization/shared-policy/*']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should authorize user with policy for a specific policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:update'],
+          Resource: ['/authorization/shared-policy/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(200)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:dummy'],
+          Resource: ['/authorization/shared-policy/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:update'],
+          Resource: ['/authorization/shared-policy/dummy']
+        }])
+        .shouldRespond(403)
+    })
+
+    lab.experiment('DELETE /authorization/shared-policies/{{id}}', () => {
+      const records = Factory(lab, {
+        users: {
+          caller: { name: 'caller', organizationId, policies: ['testedPolicy'] }
+        },
+        policies: {
+          testedPolicy: Policy()
+        },
+        sharedPolicies: {
+          calledPolicy: SharedPolicy()
+        }
+      })
+
+      const endpoint = BuildFor(lab, records)
+        .server(server)
+        .endpoint({
+          method: 'DELETE',
+          url: `/authorization/shared-policies/{{calledPolicy.id}}?sig=${config.get('security.api.servicekeys.private')}`,
+          headers: { authorization: '{{caller.id}}' }
+        })
+
+      endpoint.test('should authorize user with policy for all policies')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:delete'],
+          Resource: ['/authorization/shared-policy/*']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should authorize user with policy for a specific policy')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:delete'],
+          Resource: ['/authorization/shared-policy/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(204)
+
+      endpoint.test('should not authorize user with incorrect policy (action)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:dummy'],
+          Resource: ['/authorization/shared-policy/{{calledPolicy.id}}']
+        }])
+        .shouldRespond(403)
+
+      endpoint.test('should not authorize user with incorrect policy (resource)')
+        .withPolicy([{
+          Effect: 'Allow',
+          Action: ['authorization:policies:delete'],
+          Resource: ['/authorization/shared-policy/dummy']
         }])
         .shouldRespond(403)
     })

--- a/test/integration/authorization/testBuilder.js
+++ b/test/integration/authorization/testBuilder.js
@@ -116,7 +116,7 @@ class CustomTest {
 
       const policyData = Policy(interpolate(statement, records))
       policyData.id = testedPolicy.id
-      policyData.organizationId = testedPolicy.organizationId
+      policyData.organizationId = testedPolicy.organizationId || 'WONKA'
 
       udaru.policies.update(policyData, (err, policy) => {
         if (err) return done(err)

--- a/test/integration/endToEnd/policies.test.js
+++ b/test/integration/endToEnd/policies.test.js
@@ -346,3 +346,330 @@ lab.experiment('Policies - create/update/delete (need service key)', () => {
     })
   })
 })
+
+lab.experiment('Shared Policies - create/update/delete (need service key)', () => {
+  const sharedPolicyCreateData = {
+    version: '2016-07-01',
+    name: 'Documents Admin',
+    statements
+  }
+
+  lab.test('create new shared policy without a service key should return 403 Forbidden', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/shared-policies?sig=1234',
+      payload: {
+        version: '2016-07-01',
+        name: 'Documents Admin',
+        statements
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(403)
+
+      done()
+    })
+  })
+
+  lab.test('create new shared policy without valid data should return 400 Bad Request', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/shared-policies?sig=123456789',
+      payload: {
+        version: '2016-07-01',
+        name: 'Documents Admin'
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+
+      done()
+    })
+  })
+
+  lab.test('create new shared policy with already present id should return 400 Bad Request', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/shared-policies?sig=123456789',
+      payload: {
+        id: 'policyId1',
+        version: '2016-07-01',
+        name: 'Documents Admin',
+        statements
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+      expect(response.result.message).to.equal('Policy with id policyId1 already present')
+
+      done()
+    })
+  })
+
+  lab.test('create new shared policy should return 201 and the created policy data', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/shared-policies?sig=123456789',
+      payload: {
+        version: '2016-07-01',
+        name: 'Documents Admin',
+        statements
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(201)
+      expect(result.name).to.equal('Documents Admin')
+      expect(result.statements).to.equal(statements)
+
+      udaru.policies.deleteShared({ id: result.id }, done)
+    })
+  })
+
+  lab.test('create new shared policy should allow empty string as id', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/shared-policies?sig=123456789',
+      payload: {
+        id: '',
+        version: '2016-07-01',
+        name: 'Documents Admin',
+        statements
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(201)
+      expect(result.id).to.not.equal('')
+      expect(result.name).to.equal('Documents Admin')
+
+      udaru.policies.deleteShared({ id: result.id }, done)
+    })
+  })
+
+  lab.test('create new shared policy specifying an id should return 201 and the created policy data', (done) => {
+    const options = utils.requestOptions({
+      method: 'POST',
+      url: '/authorization/shared-policies?sig=123456789',
+      payload: {
+        id: 'mySpecialPolicyId',
+        version: '2016-07-01',
+        name: 'Documents Admin',
+        statements
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(201)
+      expect(result.id).to.equal('mySpecialPolicyId')
+      expect(result.name).to.equal('Documents Admin')
+
+      udaru.policies.deleteShared({ id: result.id }, done)
+    })
+  })
+
+  lab.test('update shared policy without a service key should return 403 Forbidden', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/shared-policies/whatever?sig=123',
+      payload: {
+        version: '2016-07-01',
+        name: 'Documents Admin',
+        statements
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(403)
+
+      done()
+    })
+  })
+
+  lab.test('update shared policy without valid data should return 400 Bad Request', (done) => {
+    const options = utils.requestOptions({
+      method: 'PUT',
+      url: '/authorization/shared-policies/whatever?sig=123456789',
+      payload: {
+        version: '2016-07-01',
+        name: 'Documents Admin'
+      }
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(400)
+
+      done()
+    })
+  })
+
+  lab.test('update shared policy should return the updated policy data', (done) => {
+    udaru.policies.createShared(sharedPolicyCreateData, (err, p) => {
+      expect(err).to.not.exist()
+
+      const options = utils.requestOptions({
+        method: 'PUT',
+        url: `/authorization/shared-policies/${p.id}?sig=123456789`,
+        payload: {
+          version: '1234',
+          name: 'new policy name',
+          statements: {
+            Statement: [
+              {
+                Effect: 'Deny',
+                Action: ['documents:Read'],
+                Resource: ['wonka:documents:/public/*']
+              }
+            ]
+          }
+        }
+      })
+
+      server.inject(options, (response) => {
+        const result = response.result
+
+        expect(response.statusCode).to.equal(200)
+        expect(result.name).to.equal('new policy name')
+        expect(result.version).to.equal('1234')
+        expect(result.statements).to.equal({ Statement: [{ Action: ['documents:Read'], Effect: 'Deny', Resource: ['wonka:documents:/public/*'] }] })
+
+        udaru.policies.deleteShared({ id: p.id }, done)
+      })
+    })
+  })
+
+  lab.test('delete shared policy without a service key should return 403 Forbidden', (done) => {
+    const options = utils.requestOptions({
+      method: 'DELETE',
+      url: '/authorization/shared-policies/policyId1?sig=1234'
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(403)
+
+      done()
+    })
+  })
+
+  lab.test('delete shared policy should return 204', (done) => {
+    udaru.policies.createShared(sharedPolicyCreateData, (err, p) => {
+      expect(err).to.not.exist()
+
+      const options = utils.requestOptions({
+        method: 'DELETE',
+        url: `/authorization/shared-policies/${p.id}?sig=123456789`
+      })
+
+      server.inject(options, (response) => {
+        expect(response.statusCode).to.equal(204)
+
+        done()
+      })
+    })
+  })
+})
+
+lab.experiment('Shared policies - get/list', () => {
+  const sharedPolicyCreateData = {
+    id: 'sharedPolicyTestX',
+    version: '2016-07-01',
+    name: 'Documents Admin',
+    statements
+  }
+
+  lab.before(done => {
+    udaru.policies.createShared(sharedPolicyCreateData, done)
+  })
+
+  lab.after(done => {
+    udaru.policies.deleteShared({id: sharedPolicyCreateData.id}, done)
+  })
+
+  lab.test('get policy list has default pagination params', (done) => {
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/shared-policies'
+    })
+
+    server.inject(options, (response) => {
+      expect(response.statusCode).to.equal(200)
+      expect(response.result.page).to.equal(1)
+      expect(response.result.limit).greaterThan(1)
+      done()
+    })
+  })
+
+  lab.test('get policy list: limit', (done) => {
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/shared-policies?limit=1&page=1'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.total).greaterThan(1)
+      expect(result.page).to.equal(1)
+      expect(result.limit).to.equal(1)
+      expect(result.data.length).to.equal(1)
+
+      done()
+    })
+  })
+
+  lab.test('get policy list', (done) => {
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/shared-policies?limit=500&page=1'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.total).lessThan(result.limit) // Will fail if we need to increase limit
+      let accountantPolicy = _.find(result.data, {id: 'sharedPolicyId1'})
+      expect(accountantPolicy).to.equal({
+        id: 'sharedPolicyId1',
+        version: '0.1',
+        name: 'Shared policy from fixtures',
+        statements: {
+          Statement: [{
+            Effect: 'Allow',
+            Action: ['Read'],
+            Resource: ['/myapp/documents/*']
+          }]
+        }
+      })
+
+      done()
+    })
+  })
+
+  lab.test('get single policy', (done) => {
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: '/authorization/shared-policies/sharedPolicyTestX'
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result).to.equal(sharedPolicyCreateData)
+
+      done()
+    })
+  })
+})
+

--- a/test/integration/organizationOps.test.js
+++ b/test/integration/organizationOps.test.js
@@ -516,6 +516,44 @@ lab.experiment('OrganizationOps', () => {
     async.series(tasks, done)
   })
 
+  lab.test('add shared policies to an organization', (done) => {
+    const tasks = []
+
+    tasks.push((next) => {
+      udaru.organizations.read(organizationId, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.policies.length).to.equal(0)
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      udaru.organizations.addPolicies({id: organizationId, policies: ['sharedPolicyId1']}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.id).to.equal(organizationId)
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal('sharedPolicyId1')
+        expect(res.policies[0].name).to.equal('Shared policy from fixtures')
+        expect(res.policies[0].version).to.equal('0.1')
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      udaru.organizations.read(organizationId, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal('sharedPolicyId1')
+        expect(res.policies[0].name).to.equal('Shared policy from fixtures')
+        expect(res.policies[0].version).to.equal('0.1')
+        next(err, res)
+      })
+    })
+
+    async.series(tasks, done)
+  })
+
   lab.test('replace organization policies', (done) => {
     const tasks = []
 
@@ -666,6 +704,67 @@ lab.experiment('OrganizationOps', () => {
       expect(err).to.exist()
       done()
     })
+  })
+
+  lab.test('replace organization policies with shared policies', (done) => {
+    const tasks = []
+
+    tasks.push((next) => {
+      udaru.policies.list({organizationId}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.length).to.equal(defaultPoliciesNames.length + 2)
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      udaru.organizations.addPolicies({id: organizationId, policies: [testPolicy.id]}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.id).to.equal(organizationId)
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal(testPolicy.id)
+        expect(res.policies[0].name).to.equal(testPolicy.name)
+        expect(res.policies[0].version).to.equal(testPolicy.version)
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      udaru.organizations.read(organizationId, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal(testPolicy.id)
+        expect(res.policies[0].name).to.equal(testPolicy.name)
+        expect(res.policies[0].version).to.equal(testPolicy.version)
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      udaru.organizations.replacePolicies({id: organizationId, policies: ['sharedPolicyId1']}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.id).to.equal(organizationId)
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal('sharedPolicyId1')
+        expect(res.policies[0].name).to.equal('Shared policy from fixtures')
+        expect(res.policies[0].version).to.equal('0.1')
+        next(err, res)
+      })
+    })
+    tasks.push((next) => {
+      udaru.organizations.read(organizationId, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res.policies.length).to.equal(1)
+        expect(res.policies[0].id).to.equal('sharedPolicyId1')
+        expect(res.policies[0].name).to.equal('Shared policy from fixtures')
+        expect(res.policies[0].version).to.equal('0.1')
+        next(err, res)
+      })
+    })
+
+    async.series(tasks, done)
   })
 
   lab.test('replace organization policies with invalid policy ID', (done) => {

--- a/test/integration/teamOps.test.js
+++ b/test/integration/teamOps.test.js
@@ -585,6 +585,22 @@ lab.experiment('TeamOps', () => {
     })
   })
 
+  lab.test('add shared policies to team', (done) => {
+    udaru.teams.addPolicies({ id: testTeam.id, policies: ['sharedPolicyId1'], organizationId: 'WONKA' }, (err, team) => {
+      expect(err).to.not.exist()
+      expect(team).to.exist()
+      expect(team.policies).to.have.length(1)
+      expect(team.policies).to.only.include([{
+        id: 'sharedPolicyId1',
+        name: 'Shared policy from fixtures',
+        version: '0.1',
+        variables: {}
+      }])
+
+      done()
+    })
+  })
+
   lab.test('replace team policies', (done) => {
     udaru.teams.addPolicies({
       id: testTeam.id,
@@ -635,6 +651,30 @@ lab.experiment('TeamOps', () => {
           name: policies[1].name,
           version: policies[1].version,
           variables: {var1: 'value2'}
+        }])
+        done()
+      })
+    })
+  })
+
+  lab.test('replace with shared policies', (done) => {
+    udaru.teams.addPolicies({
+      id: testTeam.id,
+      organizationId: 'WONKA',
+      policies: [policies[0].id]
+    }, (err, team) => {
+      expect(err).to.not.exist()
+      expect(team).to.exist()
+
+      udaru.teams.replacePolicies({ id: team.id, policies: ['sharedPolicyId1'], organizationId: 'WONKA' }, (err, team) => {
+        expect(err).to.not.exist()
+        expect(team).to.exist()
+        expect(team.policies).to.have.length(1)
+        expect(team.policies).to.only.include([{
+          id: 'sharedPolicyId1',
+          name: 'Shared policy from fixtures',
+          version: '0.1',
+          variables: {}
         }])
         done()
       })

--- a/test/integration/userOps.test.js
+++ b/test/integration/userOps.test.js
@@ -277,6 +277,41 @@ lab.experiment('UserOps', () => {
     })
   })
 
+  lab.test('replace with shared policies', (done) => {
+    const accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
+
+    udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
+      expect(err).to.not.exist()
+      expect(user).to.exist()
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
+
+      udaru.users.replacePolicies({
+        id: 'VerucaId',
+        policies: ['sharedPolicyId1'],
+        organizationId: 'WONKA'
+      }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([{
+          id: 'sharedPolicyId1',
+          name: 'Shared policy from fixtures',
+          version: '0.1',
+          variables: {}
+        }])
+
+        udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+    })
+  })
+
   lab.test('add policies to user', (done) => {
     let accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
     let directorPolicy = u.findPick(wonkaPolicies, {name: 'Director'}, ['id', 'name', 'version'])
@@ -361,6 +396,42 @@ lab.experiment('UserOps', () => {
           name: sysadminPolicy.name,
           version: sysadminPolicy.version,
           variables: {var2: 'value2'}
+        }])
+
+        udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+    })
+  })
+
+  lab.test('add shared policies to user', (done) => {
+    const accountantPolicy = u.findPick(wonkaPolicies, {name: 'Accountant'}, ['id', 'name', 'version'])
+
+    udaru.users.read({ id: 'VerucaId', organizationId: 'WONKA' }, (err, user) => {
+      expect(err).to.not.exist()
+      expect(user).to.exist()
+      expect(user.policies).to.equal([{
+        id: accountantPolicy.id,
+        name: accountantPolicy.name,
+        version: accountantPolicy.version,
+        variables: {}
+      }])
+
+      udaru.users.addPolicies({ id: 'VerucaId', policies: ['sharedPolicyId1'], organizationId: 'WONKA' }, (err, user) => {
+        expect(err).to.not.exist()
+        expect(user).to.exist()
+        expect(user.policies).to.equal([{
+          id: accountantPolicy.id,
+          name: accountantPolicy.name,
+          version: accountantPolicy.version,
+          variables: {}
+        }, {
+          id: 'sharedPolicyId1',
+          name: 'Shared policy from fixtures',
+          version: '0.1',
+          variables: {}
         }])
 
         udaru.users.replacePolicies({ id: 'VerucaId', policies: [accountantPolicy.id], organizationId: 'WONKA' }, (err, user) => {


### PR DESCRIPTION
Shared policies aren't bounded by a single organization, but available to all the organizations on the same database.

They can be assigned to any user or team of any organization