### PR TITLE
Fixes

### DIFF
--- a/database/migrations/001.do.sql
+++ b/database/migrations/001.do.sql
@@ -1,5 +1,5 @@
 
-CREATE EXTENSION ltree;
+CREATE EXTENSION IF NOT EXISTS ltree;
 
 /* TODO: consider using unique non-sequential ids, for security
   (less predictabiity)

--- a/scripts/factory.js
+++ b/scripts/factory.js
@@ -2,8 +2,7 @@
 
 const async = require('async')
 const _ = require('lodash')
-
-const utils = require('./utils')
+const defaultUdaru = require('./../lib/core')()
 
 const DEFAULT_POLICY = {
   version: '2016-07-01',
@@ -31,7 +30,7 @@ const DEFAULT_SHARED_POLICY = {
 }
 
 function Factory (lab, data, udaruCore) {
-  const udaru = udaruCore || utils.udaru
+  const udaru = udaruCore || defaultUdaru
   const records = {}
 
   function createUsers (done) {

--- a/test/integration/authorization/authorization.test.js
+++ b/test/integration/authorization/authorization.test.js
@@ -2,7 +2,7 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 
 const server = require('./../../../lib/server')
-const Factory = require('../../factory')
+const Factory = require('../../../scripts/factory')
 const BuildFor = require('./testBuilder')
 
 const organizationId = 'WONKA'

--- a/test/integration/authorization/organizations.test.js
+++ b/test/integration/authorization/organizations.test.js
@@ -2,7 +2,7 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 
 const server = require('./../../../lib/server')
-const Factory = require('../../factory')
+const Factory = require('../../../scripts/factory')
 const BuildFor = require('./testBuilder')
 const utils = require('../../utils')
 const { udaru } = utils

--- a/test/integration/authorization/policies.test.js
+++ b/test/integration/authorization/policies.test.js
@@ -4,7 +4,7 @@ const lab = exports.lab = Lab.script()
 const server = require('../../../lib/server')
 const config = require('../../../lib/config/build-all')()
 
-const Factory = require('../../factory')
+const Factory = require('../../../scripts/factory')
 const BuildFor = require('./testBuilder')
 
 const utils = require('../../utils')

--- a/test/integration/authorization/teams.test.js
+++ b/test/integration/authorization/teams.test.js
@@ -6,7 +6,7 @@ const server = require('../../../lib/server')
 const utils = require('../../utils')
 const { udaru } = utils
 
-const Factory = require('../../factory')
+const Factory = require('../../../scripts/factory')
 const BuildFor = require('./testBuilder')
 
 const organizationId = 'WONKA'

--- a/test/integration/authorization/users.test.js
+++ b/test/integration/authorization/users.test.js
@@ -3,7 +3,7 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 
 const server = require('./../../../lib/server')
-const Factory = require('../../factory')
+const Factory = require('../../../scripts/factory')
 const BuildFor = require('./testBuilder')
 
 const utils = require('../../utils')

--- a/test/integration/authorizeOps.test.js
+++ b/test/integration/authorizeOps.test.js
@@ -9,7 +9,7 @@ const _ = require('lodash')
 const testUtils = require('../utils')
 const { udaru } = testUtils
 const authorize = udaru.authorize
-const Factory = require('../factory')
+const Factory = require('../../scripts/factory')
 
 const fs = require('fs')
 const path = require('path')

--- a/test/integration/endToEnd/authorization.test.js
+++ b/test/integration/endToEnd/authorization.test.js
@@ -5,7 +5,7 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const utils = require('../../utils')
 const server = require('../../../lib/server')
-const Factory = require('../../factory')
+const Factory = require('../../../scripts/factory')
 
 lab.experiment('Authorization', () => {
   lab.test('check authorization should return access true for allowed', (done) => {

--- a/test/integration/endToEnd/fullOrgStructure.test.js
+++ b/test/integration/endToEnd/fullOrgStructure.test.js
@@ -6,7 +6,7 @@ const lab = exports.lab = Lab.script()
 
 const config = require('../../../lib/config/build-all')()
 const server = require('../../../lib/server')
-const Factory = require('../../factory')
+const Factory = require('../../../scripts/factory')
 const utils = require('../../utils')
 const Action = config.get('AuthConfig.Action')
 

--- a/test/integration/policyOps.test.js
+++ b/test/integration/policyOps.test.js
@@ -9,7 +9,7 @@ const lab = exports.lab = Lab.script()
 const _ = require('lodash')
 const async = require('async')
 const uuid = require('uuid/v4')
-const Factory = require('../factory')
+const Factory = require('../../scripts/factory')
 const testUtils = require('../utils')
 const { udaru } = testUtils
 


### PR DESCRIPTION
- Hit a migration issue with the `create extension` command. It it crashing when applied on two tenants/schemas on the same database. This change adds a bad **breaking change**, solutions using 2.0 migrations will not be able to use migrations to move to 3.0.

- Moved the Factory functionality into the scripts because it is really handy for generating policies and could be enhanced further to be exposed to clients. Having it in the tests folder might not be the best place if you want to use it from outside. Factory could be a great tool for implementing import and export or generating test data from JSON.