### PR TITLE
Do not create Udaru instance when no need to decorate

### DIFF
--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -12,8 +12,8 @@ const defaultConfigCore = require('../config/default.core')
 function register (server, options, next) {
   const config = buildConfig(defaultConfigCore, defaultConfig, options.config || {})
   const { decorateUdaruCore = true } = config
-  const udaru = buildUdaru(options.dbPool, config)
   if (decorateUdaruCore) {
+    const udaru = buildUdaru(options.dbPool, config)
     server.decorate('request', 'udaruCore', udaru)
   }
   server.decorate('server', 'udaruConfig', config)


### PR DESCRIPTION
When the decorateUdaruCore flag is set on false no need to create an Udaru Core instance. This removes the need to pass a db config when the flag is on false.

The flag is set on false when the Udaru Core instanced is decorated from outside.