### PR TITLE
Fix multi variable policies

### DIFF
--- a/lib/core/lib/ops/utils.js
+++ b/lib/core/lib/ops/utils.js
@@ -23,12 +23,12 @@ function isForeignKeyViolationError (err) {
 }
 
 function checkPoliciesOrg (db, policies, organizationId, cb) {
-  const policyIds = _.map(policies, 'id')
+  const policyIds = _.uniq(_.map(policies, 'id'))
 
   db.query(SQL`SELECT id FROM policies WHERE id = ANY (${policyIds}) AND (org_id = ${organizationId} OR org_id IS NULL)`, (err, result) => {
     if (err) return cb(Boom.badImplementation(err))
 
-    if (result.rowCount !== policies.length) {
+    if (result.rowCount !== policyIds.length) {
       return cb(Boom.badRequest(`Some policies [${_.difference(policyIds, result.rows.map(r => r.id))}] were not found`))
     }
 

--- a/lib/plugin/index.js
+++ b/lib/plugin/index.js
@@ -11,7 +11,7 @@ const defaultConfigCore = require('../config/default.core')
 
 function register (server, options, next) {
   const config = buildConfig(defaultConfigCore, defaultConfig, options.config || {})
-  const { decorateUdaruCore = true } = config
+  const decorateUdaruCore = config.get('decorateUdaruCore', {}, true)
   if (decorateUdaruCore) {
     const udaru = buildUdaru(options.dbPool, config)
     server.decorate('request', 'udaruCore', udaru)

--- a/package-lock.json
+++ b/package-lock.json
@@ -5714,14 +5714,6 @@
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5744,6 +5736,14 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringify-entities": {

--- a/test/integration/policyOps.test.js
+++ b/test/integration/policyOps.test.js
@@ -201,19 +201,28 @@ lab.experiment('PolicyOps', () => {
           name: 'called',
           description: 'called',
           organizationId: orgId,
-          policies: [{
-            key: 'userPolicy'
-          }, {
-            key: 'policyWithoutVariables'
-          }, {
-            key: 'policyWithVariables',
-            variables: {var1: 'value1'}
-          }, {
-            key: 'policyWithVariablesMulti',
-            variables: {var2: 'value2'}
-          }, {
-            key: 'sharedPolicy'
-          }]
+          policies: [
+            {
+              key: 'userPolicy'
+            },
+            {
+              key: 'policyWithoutVariables'
+            },
+            {
+              key: 'policyWithVariables',
+              variables: { var1: 'value1' }
+            },
+            {
+              key: 'policyWithVariablesMulti',
+              variables: { var2: 'value2' }
+            },
+            {
+              key: 'policyWithVariablesMulti',
+              variables: { var2: 'value4' }
+            },
+            {
+              key: 'sharedPolicy'
+            }]
         }
       },
       policies: {
@@ -270,7 +279,7 @@ lab.experiment('PolicyOps', () => {
       policyOps.listAllUserPolicies({ userId: records.called.id, organizationId: orgId }, (err, results) => {
         if (err) return done(err)
 
-        expect(results).to.have.length(9)
+        expect(results).to.have.length(10)
         done()
       })
     })
@@ -362,11 +371,18 @@ lab.experiment('PolicyOps', () => {
           Effect: 'Allow',
           Action: ['dummy'],
           Resource: ['value2']
-        }, {
+        },
+        {
           Effect: 'Allow',
           Action: ['dummy'],
           Resource: ['value3']
-        }])
+        },
+        {
+          Effect: 'Allow',
+          Action: ['dummy'],
+          Resource: ['value4']
+        }
+        ])
 
         done()
       })

--- a/test/integration/policyOps.test.js
+++ b/test/integration/policyOps.test.js
@@ -185,7 +185,7 @@ lab.experiment('PolicyOps', () => {
             key: 'teamPolicy'
           }, {
             key: 'policyWithVariablesMulti',
-            variables: {var2: 'value3'}
+            variables: { var21: 'value21', var22: 'value22' }
           }],
           parent: 'parentTeam'
         },
@@ -213,12 +213,12 @@ lab.experiment('PolicyOps', () => {
               variables: { var1: 'value1' }
             },
             {
-              key: 'policyWithVariablesMulti',
-              variables: { var2: 'value2' }
+              key: 'policyWithVariables',
+              variables: { var1: 'value11' }
             },
             {
               key: 'policyWithVariablesMulti',
-              variables: { var2: 'value4' }
+              variables: { var21: 'value21', var22: 'value22' }
             },
             {
               key: 'sharedPolicy'
@@ -249,7 +249,7 @@ lab.experiment('PolicyOps', () => {
             Statement: [{
               Effect: 'Allow',
               Action: ['dummy'],
-              Resource: ['${var2}']
+              Resource: ['${var21}', '${var22}']
             }]
           }
         },
@@ -278,8 +278,7 @@ lab.experiment('PolicyOps', () => {
     lab.test('loads correct number of policies', (done) => {
       policyOps.listAllUserPolicies({ userId: records.called.id, organizationId: orgId }, (err, results) => {
         if (err) return done(err)
-
-        expect(results).to.have.length(10)
+        expect(results).to.have.length(9)
         done()
       })
     })
@@ -338,24 +337,35 @@ lab.experiment('PolicyOps', () => {
       })
     })
 
-    lab.test('should interpolate variables provided on policy assignment', (done) => {
+    lab.test('should support multiple instances of the same policy with different variables', (done) => {
       policyOps.listAllUserPolicies({ userId: records.called.id, organizationId: orgId }, (err, results) => {
         if (err) return done(err)
 
         expect(results.map(getName)).to.include(records.policyWithVariables.name)
 
-        const policy = _.find(results, {Name: records.policyWithVariables.name})
-        expect(policy.Statement).to.equal([{
+        const statements = _.chain(results)
+          .filter({Name: records.policyWithVariables.name})
+          .map('Statement')
+          .flatten()
+          .value()
+
+        expect(statements).to.include([{
           Effect: 'Allow',
           Action: ['dummy'],
           Resource: ['value1']
-        }])
+        },
+        {
+          Effect: 'Allow',
+          Action: ['dummy'],
+          Resource: ['value11']
+        }
+        ])
 
         done()
       })
     })
 
-    lab.test('should support multiple instances of the same policy with different variables', (done) => {
+    lab.test('should support multiple variables on the same policy instance', (done) => {
       policyOps.listAllUserPolicies({ userId: records.called.id, organizationId: orgId }, (err, results) => {
         if (err) return done(err)
 
@@ -370,17 +380,7 @@ lab.experiment('PolicyOps', () => {
         expect(statements).to.include([{
           Effect: 'Allow',
           Action: ['dummy'],
-          Resource: ['value2']
-        },
-        {
-          Effect: 'Allow',
-          Action: ['dummy'],
-          Resource: ['value3']
-        },
-        {
-          Effect: 'Allow',
-          Action: ['dummy'],
-          Resource: ['value4']
+          Resource: ['value21', 'value22']
         }
         ])
 


### PR DESCRIPTION
In case of policies with variables you could assign the same policy to the same user but having different variables. The checkPoliciesOrg was failing because in this case where you have duplicate policy IDs the query returns less results that the policy array as the query does not return duplicate entries.

Added also a fix on the `decoreateUdaruCore` retrieval, `config` was of type Reconfig and confg properties are accessed using `.get(property)`