### PR TITLE
fix: allow empty results when the user is in no teams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 
 ## 3.1.0 - February 5, 2018
--  Added get user teams [commit](https://github.com/nearform/udaru/pull/451)
+-   Added get user teams [commit](https://github.com/nearform/udaru/pull/451)
 
 ## 3.0.0 - January 22, 2018
 Features, enhancements:
@@ -16,7 +16,7 @@ Features, enhancements:
 -   Documentation udpates
 
 Fixes:
-- **Breaking change: solutions using 2.0 can't migrate DB to 3.0**: Fix migration issue [commit](https://github.com/nearform/udaru/pull/438)
+-   **Breaking change: solutions using 2.0 can't migrate DB to 3.0**: Fix migration issue [commit](https://github.com/nearform/udaru/pull/438)
 -   Fix not existing user got authorized [commit](https://github.com/nearform/udaru/pull/429)
 -   Fix db init script [commit](https://github.com/nearform/udaru/pull/432)
 

--- a/lib/core/lib/ops/userOps.js
+++ b/lib/core/lib/ops/userOps.js
@@ -562,28 +562,20 @@ function buildUserOps (db, config) {
       Joi.validate({ id, organizationId, page, limit }, validationRules.listUserTeams, function (err) {
         if (err) return cb(Boom.badRequest(err))
 
-        const pageLimit = limit || config.get('authorization.defaultPageSize')
-        const offset = (page - 1) * pageLimit
-
+        const offset = (page - 1) * limit
         const job = {
           id,
           organizationId,
           offset,
-          limit: pageLimit,
+          limit,
           user: {},
           client: db
         }
 
         readUserTeams(job, (err) => {
           if (err) return cb(err)
-          const pageSize = Math.min(pageLimit, job.user.teams ? job.user.teams.length : 0)
-          const result = {
-            page,
-            limit: pageSize,
-            total: job.totalTeamsCount,
-            data: job.user.teams
-          }
-          return cb(null, result)
+
+          return cb(null, job.user.teams, job.totalTeamsCount)
         })
       })
     },

--- a/lib/plugin/routes/public/users.js
+++ b/lib/plugin/routes/public/users.js
@@ -312,10 +312,11 @@ exports.register = function (server, options, next) {
     handler: function (request, reply) {
       const { id } = request.params
       const { organizationId } = request.udaru
-      const { limit, page } = request.query
+      const limit = request.query.limit || server.udaruConfig.get('authorization.defaultPageSize')
+      const page = request.query.page || 1
 
-      request.udaruCore.users.listUserTeams({ id, organizationId, limit, page }, (err, result) => {
-        reply(err, result)
+      request.udaruCore.users.listUserTeams({ id, organizationId, limit, page }, (err, data, total) => {
+        reply(err, { page, limit, total, data })
       })
     },
     config: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "udaru",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udaru",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A policy based authorization module",
   "license": "MIT",
   "author": "nearForm Ltd",

--- a/test/integration/userOps.test.js
+++ b/test/integration/userOps.test.js
@@ -698,71 +698,77 @@ lab.experiment('UserOps structure', () => {
   })
 
   lab.test('Test user exists in two teams, no pagination', (done) => {
-    udaru.users.listUserTeams({ id: 'VerucaId', organizationId: 'WONKA' }, (err, result) => {
+    udaru.users.listUserTeams({ id: 'VerucaId', organizationId: 'WONKA' }, (err, data, total) => {
       expect(err).to.not.exist()
-      expect(result).to.exist()
+      expect(data).to.exist()
       let expectedTeams = [
         'Readers',
         'Authors'
       ]
-      expect(_.map(result.data, 'name')).contains(expectedTeams)
-      expect(result.page).to.equal(1)
-      expect(result.limit).to.equal(2)
-      expect(result.total).to.equal(2)
-      expect(result.data.length).to.equal(2)
+      expect(_.map(data, 'name')).contains(expectedTeams)
+      expect(total).to.equal(2)
+      expect(data.length).to.equal(2)
 
       done()
     })
   })
 
   lab.test('Test incorrect pagination', (done) => {
-    udaru.users.listUserTeams({ id: 'VerucaId', organizationId: 'WONKA', page: 0 }, (err, result) => {
+    udaru.users.listUserTeams({ id: 'VerucaId', organizationId: 'WONKA', page: 0 }, (err, data, total) => {
       expect(err).to.exist()
       expect(err.message.indexOf('page')).to.be.at.least(0)
       expect(err.message.indexOf('limit')).to.be.below(0)
-      expect(result).to.not.exist()
+      expect(data).to.not.exist()
+      expect(total).to.not.exist()
 
       done()
     })
   })
 
   lab.test('Test incorrect limit', (done) => {
-    udaru.users.listUserTeams({ id: 'VerucaId', organizationId: 'WONKA', page: 1, limit: 0 }, (err, result) => {
+    udaru.users.listUserTeams({ id: 'VerucaId', organizationId: 'WONKA', page: 1, limit: 0 }, (err, data, total) => {
       expect(err).to.exist()
       expect(err.message.indexOf('page')).to.be.below(0)
       expect(err.message.indexOf('limit')).to.be.at.least(0)
-      expect(result).to.not.exist()
+      expect(data).to.not.exist()
+      expect(total).to.not.exist()
 
       done()
     })
   })
 
   lab.test('Test user exists in two teams, pagination', (done) => {
-    udaru.users.listUserTeams({ id: 'VerucaId', organizationId: 'WONKA', page: 2, limit: 1 }, (err, result) => {
+    udaru.users.listUserTeams({ id: 'VerucaId', organizationId: 'WONKA', page: 2, limit: 1 }, (err, data, total) => {
       expect(err).to.not.exist()
-      expect(result).to.exist()
+      expect(data).to.exist()
       let expectedTeams = [
         'Readers'
       ]
-      expect(_.map(result.data, 'name')).contains(expectedTeams)
-      expect(result.page).to.equal(2)
-      expect(result.limit).to.equal(1)
-      expect(result.total).to.equal(2)
-      expect(result.data.length).to.equal(1)
+      expect(_.map(data, 'name')).contains(expectedTeams)
+      expect(total).to.equal(2)
+      expect(data.length).to.equal(1)
 
       done()
     })
   })
 
   lab.test('Test user exists in two teams, pagination', (done) => {
-    udaru.users.listUserTeams({ id: 'VerucaId', organizationId: 'WONKA', page: 2, limit: 10 }, (err, result) => {
+    udaru.users.listUserTeams({ id: 'VerucaId', organizationId: 'WONKA', page: 2, limit: 10 }, (err, data, total) => {
       expect(err).to.not.exist()
-      expect(result).to.exist()
+      expect(data).to.exist()
+      expect(total).to.equal(2)
+      expect(data.length).to.equal(0)
 
-      expect(result.page).to.equal(2)
-      expect(result.limit).to.equal(0)
-      expect(result.total).to.equal(2)
-      expect(result.data.length).to.equal(0)
+      done()
+    })
+  })
+
+  lab.test('Test no teams', (done) => {
+    udaru.users.listUserTeams({ id: 'InvalidId', organizationId: 'WONKA' }, (err, data, total) => {
+      expect(err).to.not.exist()
+      expect(total).to.exist()
+      expect(total).to.equal(0)
+      expect(data.length).to.equal(0)
 
       done()
     })


### PR DESCRIPTION
Addresses https://github.com/nearform/udaru/issues/453

This unifies the implementation with the ones made at similar endpoints, like get users:
- the page is what the user sends or 1 by default
- the limit is what the user sends or 100 by default (100 is set in config)
- the answer is an object containing: page used for query, limit used for query, the total records found (not only the returned ones), the data result of the current query

There seems to be some implementation on `Get team users` that is not consistent with the other endpoints, will open an issue to investigate it.