### PR TITLE
Search teams

### DIFF
--- a/lib/config/auth.js
+++ b/lib/config/auth.js
@@ -32,6 +32,7 @@ const Actions = {
   ReadTeam: 'authorization:teams:read',
   DeleteTeam: 'authorization:teams:delete',
   ListTeams: 'authorization:teams:list',
+  SearchTeams: 'authorization:teams:search',
   ManageTeams: 'authorization:teams:manage',
   AddTeamPolicy: 'authorization:teams:policy:add',
   ReplaceTeamPolicy: 'authorization:teams:policy:replace',

--- a/lib/core/index.js
+++ b/lib/core/index.js
@@ -69,7 +69,8 @@ function buildUdaruCore (dbPool, config) {
       addUsers: teamOps.addUsersToTeam,
       replaceUsers: teamOps.replaceUsersInTeam,
       deleteMembers: teamOps.deleteTeamMembers,
-      deleteMember: teamOps.deleteTeamMember
+      deleteMember: teamOps.deleteTeamMember,
+      search: teamOps.search
     },
 
     users: {

--- a/lib/core/lib/ops/teamOps.js
+++ b/lib/core/lib/ops/teamOps.js
@@ -536,7 +536,7 @@ function buildTeamOps (db, config) {
         moveTeamDescendants
       ], (err) => {
         if (err) return cb(err)
-        teamOps.readTeam({id, organizationId}, cb)
+        teamOps.readTeam({ id, organizationId }, cb)
       })
     },
 
@@ -807,9 +807,34 @@ function buildTeamOps (db, config) {
         if (err) return cb(err)
         cb()
       })
+    },
+
+    /**
+     * Search for team
+     *
+     * @param {Object} params { organizationId, query }
+     * @param {Function} cb
+     */
+    search: function search (params, cb) {
+      const { organizationId, query } = params
+      Joi.validate({ organizationId, query }, validationRules.searchTeam, function (err) {
+        if (err) return cb(Boom.badRequest(err))
+
+        const sqlQuery = SQL`
+          SELECT *
+          FROM teams
+          WHERE org_id=${organizationId} AND to_tsvector(name) @@ to_tsquery(${query});
+        `
+
+        db.query(sqlQuery, (err, result) => {
+          if (err) return cb(Boom.badImplementation(err))
+          return cb(null, result.rows.map(mapping.user), result.rows.length)
+        })
+      })
     }
   }
 
+  teamOps.search.validate = validationRules.searchTeam
   teamOps.deleteTeamMembers.validate = validationRules.deleteTeamMembers
   teamOps.deleteTeamMember.validate = validationRules.deleteTeamMember
   teamOps.replaceTeamPolicies.validate = validationRules.replaceTeamPolicies

--- a/lib/core/lib/ops/teamOps.js
+++ b/lib/core/lib/ops/teamOps.js
@@ -823,12 +823,17 @@ function buildTeamOps (db, config) {
         const sqlQuery = SQL`
           SELECT *
           FROM teams
-          WHERE org_id=${organizationId} AND to_tsvector(name) @@ to_tsquery(${query});
+          WHERE org_id=${organizationId}
+          AND (
+            to_tsvector(name) || to_tsvector(description) @@ to_tsquery(${query.split(' ').join(' & ') + ':*'})
+            OR name LIKE(${'%' + query + '%'})
+          )
+          ORDER BY id;
         `
 
         db.query(sqlQuery, (err, result) => {
           if (err) return cb(Boom.badImplementation(err))
-          return cb(null, result.rows.map(mapping.user), result.rows.length)
+          return cb(null, result.rows.map(mapping.team), result.rows.length)
         })
       })
     }

--- a/lib/core/lib/ops/validation.js
+++ b/lib/core/lib/ops/validation.js
@@ -209,6 +209,10 @@ const teams = {
     id: validationRules.teamId,
     userId: validationRules.userId,
     organizationId: validationRules.organizationId
+  },
+  searchTeam: {
+    organizationId: validationRules.organizationId,
+    query: Joi.string()
   }
 }
 

--- a/lib/core/lib/ops/validation.js
+++ b/lib/core/lib/ops/validation.js
@@ -212,7 +212,7 @@ const teams = {
   },
   searchTeam: {
     organizationId: validationRules.organizationId,
-    query: Joi.string()
+    query: requiredString
   }
 }
 

--- a/lib/plugin/routes/public/teams.js
+++ b/lib/plugin/routes/public/teams.js
@@ -561,6 +561,42 @@ exports.register = function (server, options, next) {
     }
   })
 
+  server.route({
+    method: 'GET',
+    path: '/authorization/teams/search',
+    handler: function (request, reply) {
+      const { organizationId } = request.udaru
+      const query = request.query.query
+
+      request.udaruCore.teams.search({
+        organizationId,
+        query
+      }, (err, data, total) => {
+        reply(
+          err,
+          err ? null : {
+            data: data
+          }
+        )
+      })
+    },
+    config: {
+      description: 'Search for teams from the current user organization',
+      notes: 'The GET /authorization/teams/search endpoint returns a filtered list of teams from the current organization.\n\n',
+      tags: ['api', 'teams'],
+      plugins: {
+        auth: {
+          action: Action.SearchTeams
+        }
+      },
+      validate: {
+        headers,
+        query: _.pick(validation.searchTeam, ['query'])
+      },
+      response: { schema: swagger.List(swagger.Team).label('FilteredTeams') }
+    }
+  })
+
   next()
 }
 

--- a/lib/plugin/routes/public/teams.js
+++ b/lib/plugin/routes/public/teams.js
@@ -594,7 +594,7 @@ exports.register = function (server, options, next) {
         headers,
         query: _.pick(validation.searchTeam, ['query'])
       },
-      response: { schema: swagger.List(swagger.Team).label('FilteredTeams') }
+      response: { schema: swagger.Search(swagger.ShortTeam).label('FilteredTeams') }
     }
   })
 

--- a/lib/plugin/routes/public/teams.js
+++ b/lib/plugin/routes/public/teams.js
@@ -575,7 +575,8 @@ exports.register = function (server, options, next) {
         reply(
           err,
           err ? null : {
-            data: data
+            data,
+            total
           }
         )
       })

--- a/lib/plugin/swagger.js
+++ b/lib/plugin/swagger.js
@@ -42,6 +42,14 @@ const TeamRef = Joi.object({
 }).label('TeamRef')
 const TeamRefs = Joi.array().items(TeamRef).description('Team refs').label('TeamRefs')
 
+const ShortTeam = Joi.object({
+  id: Joi.string().description('Team ID'),
+  name: Joi.string().description('Team name'),
+  description: Joi.string().description('Team description'),
+  path: Joi.string(),
+  organizationId: Joi.string().description('Organization ID to which the team belongs to')
+}).label('Short Team')
+
 const Team = Joi.object({
   id: Joi.string().description('Team ID'),
   name: Joi.string().description('Team name'),
@@ -95,6 +103,13 @@ const PagedTeamRefs = List(TeamRefs).label('PagedTeamRefs')
 const PagedUsers = List(Users).label('PagedUsers')
 const PagedOrganizations = List(Organizations).label('PagedOrganizations')
 
+const Search = (data) => {
+  return Joi.object({
+    total: Joi.number().integer().description('Total number of entries matched by the query'),
+    data: Joi.array().items(data).label('Data')
+  }).label('SearchList')
+}
+
 const Access = Joi.object({
   access: Joi.boolean()
 }).label('Access')
@@ -127,5 +142,7 @@ module.exports = {
   Organization,
   OrganizationAndUser,
   PolicyStatements,
-  Access
+  Access,
+  Search,
+  ShortTeam
 }

--- a/test/integration/teamOps.test.js
+++ b/test/integration/teamOps.test.js
@@ -1026,26 +1026,67 @@ lab.experiment('TeamOps', () => {
     udaru.teams.search({ query: 'Authors', organizationId: 'WONKA' }, (err, data, total) => {
       expect(err).to.not.exist()
       expect(total).to.exist()
-      expect(total).to.equal(1)
-      expect(data.length).to.equal(1)
+      expect(total).to.equal(3)
+      expect(data.length).to.equal(3)
 
       done()
     })
   })
 
   lab.test('Wildcard search for Authors', (done) => {
-    udaru.teams.search({ query: 'Auth:*', organizationId: 'WONKA' }, (err, data, total) => {
+    udaru.teams.search({ query: 'Auth', organizationId: 'WONKA' }, (err, data, total) => {
+      expect(err).to.not.exist()
+      expect(total).to.exist()
+      expect(total).to.equal(3)
+      expect(data.length).to.equal(3)
+
+      done()
+    })
+  })
+
+  lab.test('Search for common words phrase', (done) => {
+    udaru.teams.search({ query: 'Managers', organizationId: 'WONKA' }, (err, data, total) => {
+      expect(err).to.not.exist()
+      expect(total).to.exist()
+      expect(total).to.equal(2)
+      expect(data.length).to.equal(2)
+    })
+
+    done()
+  })
+
+  lab.test('Search for multiple words phrase', (done) => {
+    udaru.teams.search({ query: 'Personnel Managers', organizationId: 'WONKA' }, (err, data, total) => {
       expect(err).to.not.exist()
       expect(total).to.exist()
       expect(total).to.equal(1)
       expect(data.length).to.equal(1)
+    })
+
+    done()
+  })
+
+  lab.test('Search with empty query', (done) => {
+    udaru.teams.search({ query: '', organizationId: 'WONKA' }, (err, data, total) => {
+      expect(err).to.exist()
+
+      done()
+    })
+  })
+
+  lab.test('Search with no match', (done) => {
+    udaru.teams.search({ query: 'idontexist', organizationId: 'WONKA' }, (err, data, total) => {
+      expect(err).to.not.exist()
+      expect(total).to.exist()
+      expect(total).to.equal(0)
+      expect(data.length).to.equal(0)
 
       done()
     })
   })
 
   lab.test('Search with bad org id', (done) => {
-    udaru.teams.search({ query: 'Auth:*', organizationId: 'IDONTEXIST' }, (err, data, total) => {
+    udaru.teams.search({ query: 'Auth', organizationId: 'IDONTEXIST' }, (err, data, total) => {
       expect(err).to.not.exist()
       expect(total).to.exist()
       expect(total).to.equal(0)

--- a/test/integration/teamOps.test.js
+++ b/test/integration/teamOps.test.js
@@ -21,7 +21,7 @@ lab.experiment('TeamOps', () => {
   let users
   let policies = []
   lab.before(done => {
-    udaru.users.list({organizationId: 'WONKA'}, (err, fetchedUsers) => {
+    udaru.users.list({ organizationId: 'WONKA' }, (err, fetchedUsers) => {
       expect(err).to.not.exist()
       expect(fetchedUsers).to.exist()
       expect(fetchedUsers.length).to.be.at.least(2)
@@ -82,7 +82,7 @@ lab.experiment('TeamOps', () => {
   lab.afterEach(done => {
     // always cleanup test data
     if (testTeam && testTeam.id) {
-      udaru.teams.delete({id: testTeam.id, organizationId: 'WONKA'}, done)
+      udaru.teams.delete({ id: testTeam.id, organizationId: 'WONKA' }, done)
       testTeam = null
     } else {
       done()
@@ -90,7 +90,7 @@ lab.experiment('TeamOps', () => {
   })
 
   lab.test('list of org teams', (done) => {
-    udaru.teams.list({organizationId: 'WONKA'}, (err, result) => {
+    udaru.teams.list({ organizationId: 'WONKA' }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
 
@@ -109,12 +109,12 @@ lab.experiment('TeamOps', () => {
 
   lab.test('Add twice the same user to a team', (done) => {
     let userIds = [users[0].id]
-    udaru.teams.addUsers({id: testTeam.id, organizationId: 'WONKA', users: userIds}, (err, result) => {
+    udaru.teams.addUsers({ id: testTeam.id, organizationId: 'WONKA', users: userIds }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
 
       userIds = [users[0].id, users[1].id]
-      udaru.teams.addUsers({id: testTeam.id, organizationId: 'WONKA', users: userIds}, (err, result) => {
+      udaru.teams.addUsers({ id: testTeam.id, organizationId: 'WONKA', users: userIds }, (err, result) => {
         expect(err).to.not.exist()
         expect(result).to.exist()
         expect(result.users.length).to.equal(2)
@@ -246,7 +246,7 @@ lab.experiment('TeamOps', () => {
   })
 
   lab.test('creating a team should create a default admin policy', (done) => {
-    udaru.policies.list({organizationId: 'WONKA'}, (err, policies) => {
+    udaru.policies.list({ organizationId: 'WONKA' }, (err, policies) => {
       expect(err).to.not.exist()
 
       const defaultPolicy = policies.find((p) => { return p.name === 'Default Team Admin for ' + testTeam.id })
@@ -266,13 +266,13 @@ lab.experiment('TeamOps', () => {
       organizationId: 'WONKA'
     }
 
-    udaru.teams.create(testTeam, {createOnly: true}, (err, result) => {
+    udaru.teams.create(testTeam, { createOnly: true }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
       expect(result.id).to.exist()
       testTeam.id = result.id // afterEach will cleanup based on the ID
 
-      udaru.policies.list({organizationId: 'WONKA'}, (err, policies) => {
+      udaru.policies.list({ organizationId: 'WONKA' }, (err, policies) => {
         udaru.teams.delete(testTeam, (err) => { if (err) throw err })
         expect(err).to.not.exist()
 
@@ -293,11 +293,11 @@ lab.experiment('TeamOps', () => {
       organizationId: 'WONKA'
     }
 
-    udaru.teams.create(testTeam, {createOnly: true}, (err, result) => {
+    udaru.teams.create(testTeam, { createOnly: true }, (err, result) => {
       expect(err).to.not.exist()
       expect(result).to.exist()
 
-      udaru.teams.create(testTeam, {createOnly: true}, (err, result) => {
+      udaru.teams.create(testTeam, { createOnly: true }, (err, result) => {
         expect(err).to.exist()
         expect(err.output.statusCode).to.equal(409)
         expect(err.message).to.equal('Key (id)=(nearForm) already exists.')
@@ -339,7 +339,7 @@ lab.experiment('TeamOps', () => {
     }
     setTimeout(() => {
       // TODO: delete team
-      udaru.teams.delete(testTeam, () => {})
+      udaru.teams.delete(testTeam, () => { })
     }, 5000)
 
     udaru.teams.create(testTeam, function (err, team) {
@@ -377,7 +377,7 @@ lab.experiment('TeamOps', () => {
     }
     setTimeout(() => {
       // TODO: delete team
-      udaru.teams.delete(testTeam, () => {})
+      udaru.teams.delete(testTeam, () => { })
     }, 5000)
 
     udaru.teams.create(testTeam, function (err, team) {
@@ -525,12 +525,12 @@ lab.experiment('TeamOps', () => {
           expect(result).to.exist()
           expect(result.path).to.equal(testTeam2.id + '.' + childTeam.id)
 
-          udaru.teams.read({id: childTeam.id, organizationId: 'WONKA'}, (err, result) => {
+          udaru.teams.read({ id: childTeam.id, organizationId: 'WONKA' }, (err, result) => {
             expect(err).to.not.exist()
             expect(result).to.exist()
             expect(result.path).to.equal(testTeam2.id + '.' + childTeam.id)
 
-            udaru.teams.delete({id: testTeam2.id, organizationId: 'WONKA'}, done)
+            udaru.teams.delete({ id: testTeam2.id, organizationId: 'WONKA' }, done)
           })
         })
       })
@@ -557,7 +557,7 @@ lab.experiment('TeamOps', () => {
         expect(result).to.exist()
         expect(result.path).to.equal(teamId.toString())
 
-        udaru.teams.delete({id: teamId, organizationId: 'WONKA'}, done)
+        udaru.teams.delete({ id: teamId, organizationId: 'WONKA' }, done)
       })
     })
   })
@@ -595,10 +595,10 @@ lab.experiment('TeamOps', () => {
   lab.test('add policies with variables to team', (done) => {
     const policiesParam = [{
       id: policies[0].id,
-      variables: {var1: 'value1'}
+      variables: { var1: 'value1' }
     }, {
       id: policies[1].id,
-      variables: {var2: 'value2'}
+      variables: { var2: 'value2' }
     }]
 
     udaru.teams.addPolicies({ id: testTeam.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
@@ -609,12 +609,12 @@ lab.experiment('TeamOps', () => {
         id: policies[0].id,
         name: policies[0].name,
         version: policies[0].version,
-        variables: {var1: 'value1'}
+        variables: { var1: 'value1' }
       }, {
         id: policies[1].id,
         name: policies[1].name,
         version: policies[1].version,
-        variables: {var2: 'value2'}
+        variables: { var2: 'value2' }
       }])
 
       done()
@@ -667,7 +667,7 @@ lab.experiment('TeamOps', () => {
       organizationId: 'WONKA',
       policies: [{
         id: policies[0].id,
-        variables: {var1: 'value1'}
+        variables: { var1: 'value1' }
       }]
     }, (err, team) => {
       expect(err).to.not.exist()
@@ -675,7 +675,7 @@ lab.experiment('TeamOps', () => {
 
       const policiesParam = [{
         id: policies[1].id,
-        variables: {var1: 'value2'}
+        variables: { var1: 'value2' }
       }]
 
       udaru.teams.replacePolicies({ id: team.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
@@ -686,7 +686,7 @@ lab.experiment('TeamOps', () => {
           id: policies[1].id,
           name: policies[1].name,
           version: policies[1].version,
-          variables: {var1: 'value2'}
+          variables: { var1: 'value2' }
         }])
         done()
       })
@@ -919,10 +919,10 @@ lab.experiment('TeamOps', () => {
     lab.test('with different variables add twice', (done) => {
       const policiesParam = [{
         id: policies[0].id,
-        variables: {var1: 'value1'}
+        variables: { var1: 'value1' }
       }, {
         id: policies[1].id,
-        variables: {var2: 'value2'}
+        variables: { var2: 'value2' }
       }]
 
       udaru.teams.addPolicies({ id: testTeam.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
@@ -933,17 +933,17 @@ lab.experiment('TeamOps', () => {
           id: policies[0].id,
           name: policies[0].name,
           version: policies[0].version,
-          variables: {var1: 'value1'}
+          variables: { var1: 'value1' }
         }, {
           id: policies[1].id,
           name: policies[1].name,
           version: policies[1].version,
-          variables: {var2: 'value2'}
+          variables: { var2: 'value2' }
         }])
 
         const policiesParam = [{
           id: policies[1].id,
-          variables: {var2: 'value3'}
+          variables: { var2: 'value3' }
         }]
 
         udaru.teams.addPolicies({ id: team.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
@@ -954,17 +954,17 @@ lab.experiment('TeamOps', () => {
             id: policies[0].id,
             name: policies[0].name,
             version: policies[0].version,
-            variables: {var1: 'value1'}
+            variables: { var1: 'value1' }
           }, {
             id: policies[1].id,
             name: policies[1].name,
             version: policies[1].version,
-            variables: {var2: 'value2'}
+            variables: { var2: 'value2' }
           }, {
             id: policies[1].id,
             name: policies[1].name,
             version: policies[1].version,
-            variables: {var2: 'value3'}
+            variables: { var2: 'value3' }
           }])
           done()
         })
@@ -974,10 +974,10 @@ lab.experiment('TeamOps', () => {
     lab.test('with same variables do nothing', (done) => {
       const policiesParam = [{
         id: policies[0].id,
-        variables: {var1: 'value1'}
+        variables: { var1: 'value1' }
       }, {
         id: policies[1].id,
-        variables: {var2: 'value2'}
+        variables: { var2: 'value2' }
       }]
 
       udaru.teams.addPolicies({ id: testTeam.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
@@ -988,17 +988,17 @@ lab.experiment('TeamOps', () => {
           id: policies[0].id,
           name: policies[0].name,
           version: policies[0].version,
-          variables: {var1: 'value1'}
+          variables: { var1: 'value1' }
         }, {
           id: policies[1].id,
           name: policies[1].name,
           version: policies[1].version,
-          variables: {var2: 'value2'}
+          variables: { var2: 'value2' }
         }])
 
         const policiesParam = [{
           id: policies[1].id,
-          variables: {var2: 'value2'}
+          variables: { var2: 'value2' }
         }]
 
         udaru.teams.addPolicies({ id: team.id, policies: policiesParam, organizationId: 'WONKA' }, (err, team) => {
@@ -1009,16 +1009,75 @@ lab.experiment('TeamOps', () => {
             id: policies[0].id,
             name: policies[0].name,
             version: policies[0].version,
-            variables: {var1: 'value1'}
+            variables: { var1: 'value1' }
           }, {
             id: policies[1].id,
             name: policies[1].name,
             version: policies[1].version,
-            variables: {var2: 'value2'}
+            variables: { var2: 'value2' }
           }])
           done()
         })
       })
+    })
+  })
+
+  lab.test('Search for Authors', (done) => {
+    udaru.teams.search({ query: 'Authors', organizationId: 'WONKA' }, (err, data, total) => {
+      expect(err).to.not.exist()
+      expect(total).to.exist()
+      expect(total).to.equal(1)
+      expect(data.length).to.equal(1)
+
+      done()
+    })
+  })
+
+  lab.test('Wildcard search for Authors', (done) => {
+    udaru.teams.search({ query: 'Auth:*', organizationId: 'WONKA' }, (err, data, total) => {
+      expect(err).to.not.exist()
+      expect(total).to.exist()
+      expect(total).to.equal(1)
+      expect(data.length).to.equal(1)
+
+      done()
+    })
+  })
+
+  lab.test('Search with bad org id', (done) => {
+    udaru.teams.search({ query: 'Auth:*', organizationId: 'IDONTEXIST' }, (err, data, total) => {
+      expect(err).to.not.exist()
+      expect(total).to.exist()
+      expect(total).to.equal(0)
+      expect(data.length).to.equal(0)
+
+      done()
+    })
+  })
+
+  lab.test('Search expect error with bad params', (done) => {
+    udaru.teams.search({ querty: 'Bad query param', orId: 'Bad organizationId param' }, (err, data, total) => {
+      expect(err).to.exist()
+
+      done()
+    })
+  })
+
+  lab.test('Search sql injection org_id sanity check', (done) => {
+    udaru.teams.search({ query: 'Authors', organizationId: 'WONKA||org_id<>-1' }, (err, data, total) => {
+      expect(err).to.not.exist()
+      expect(total).to.equal(0)
+      expect(data.length).to.equal(0)
+
+      done()
+    })
+  })
+
+  lab.test('Search sql injection query sanity check', (done) => {
+    udaru.teams.search({ query: 'Authors\'); drop database authorization;', organizationId: 'WONKA' }, (err, data, total) => {
+      expect(err).to.exist()
+
+      done()
     })
   })
 })


### PR DESCRIPTION
Add support for searching teams by name or description. 

Endpoint: `/authorization/teams/search` that takes parameters:
_headers_: `authorization`, `org` 
_query_:  `query`

Completes the team search support (based on PR #463)

@dberesford @mihaidma