### PR TITLE
Add request id for the resource builder

### DIFF
--- a/lib/plugin/routes/public/users.js
+++ b/lib/plugin/routes/public/users.js
@@ -332,7 +332,8 @@ exports.register = function (server, options, next) {
       tags: ['api', 'users'],
       plugins: {
         auth: {
-          action: Action.ListUserTeams
+          action: Action.ListUserTeams,
+          getParams: (request) => ({ userId: request.params.id })
         }
       },
       response: { schema: swagger.PagedTeamRefs }


### PR DESCRIPTION
The endpoint should expose a get params functions that when called by the resource builder should provide the user id. In this case the resource was `.../WONKA/*/*` instead of `.../WONKA/*/userId`