### PR TITLE
removing public schema from migration scripts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## 4.0.1 - February 15, 2018
+Fixes:
+-   Migration scripts 006 & 007 (removed public schema)
+
 ## 4.0.0 - February 15, 2018
 Features, enhancements:
 -   Added /database/loadVolumeData.js to populate test database with large volume of data [commit](https://github.com/nearform/udaru/pull/456)
@@ -9,7 +13,7 @@ Features, enhancements:
 -   Updated chalk dependency (dev) for volume test output
 -   Updated PBAC to version 0.2.0 (lodash vulnerability update)
 -   Updated iam.js (StringLike param order reversed)
--   Updated unique constraint violation to return code 409 conflict for users, policies, orgs and teams
+-   Breaking Change: Updated unique constraint violation to return code 409 conflict for users, policies, orgs and teams
 -   Enhanced swagger documentation (better definition of models and other tidy ups)
 
 Fixes:

--- a/database/migrations/006.do.sql
+++ b/database/migrations/006.do.sql
@@ -1,6 +1,6 @@
 CREATE INDEX "team_members#user_id"
-    ON public.team_members USING btree
+    ON team_members USING btree
     (user_id COLLATE pg_catalog."default" varchar_ops)
     TABLESPACE pg_default;
-ALTER TABLE public.team_members
+ALTER TABLE team_members
     CLUSTER ON "team_members#user_id";

--- a/database/migrations/006.undo.sql
+++ b/database/migrations/006.undo.sql
@@ -1,3 +1,3 @@
-ALTER TABLE public.team_members
+ALTER TABLE team_members
 	SET WITHOUT CLUSTER;
 DROP INDEX IF EXISTS "team_members#user_id";

--- a/database/migrations/007.do.sql
+++ b/database/migrations/007.do.sql
@@ -1,7 +1,7 @@
-ALTER TABLE public.organizations
+ALTER TABLE organizations
     ADD COLUMN metadata jsonb;
-ALTER TABLE public.teams
+ALTER TABLE teams
     ADD COLUMN metadata jsonb;
-ALTER TABLE public.users
+ALTER TABLE users
     ADD COLUMN metadata jsonb;
     

--- a/database/migrations/007.undo.sql
+++ b/database/migrations/007.undo.sql
@@ -1,6 +1,6 @@
-ALTER TABLE public.organizations
+ALTER TABLE organizations
     DROP COLUMN metadata;
-ALTER TABLE public.teams
+ALTER TABLE teams
     DROP COLUMN metadata;
-ALTER TABLE public.users
+ALTER TABLE users
     DROP COLUMN metadata;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "udaru",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udaru",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A policy based authorization module",
   "license": "MIT",
   "author": "nearForm Ltd",


### PR DESCRIPTION
public schema removed from migration scripts... this will cause a bad credentials error if migration to 7 does not work