### PR TITLE
check if team or users exist

### DIFF
--- a/lib/plugin/routes/public/teams.js
+++ b/lib/plugin/routes/public/teams.js
@@ -406,7 +406,11 @@ exports.register = function (server, options, next) {
       const limit = request.query.limit || server.udaruConfig.get('authorization.defaultPageSize')
       const page = request.query.page || 1
 
-      request.udaruCore.teams.listUsers({ id, page, limit, organizationId }, reply)
+      request.udaruCore.teams.read({ id, organizationId }, (err) => {
+        if (err) return reply(err)
+
+        request.udaruCore.teams.listUsers({ id, page, limit, organizationId }, reply)
+      })
     },
     config: {
       validate: {

--- a/lib/plugin/routes/public/users.js
+++ b/lib/plugin/routes/public/users.js
@@ -317,8 +317,12 @@ exports.register = function (server, options, next) {
       const limit = request.query.limit || server.udaruConfig.get('authorization.defaultPageSize')
       const page = request.query.page || 1
 
-      request.udaruCore.users.listUserTeams({ id, organizationId, limit, page }, (err, data, total) => {
-        reply(err, { page, limit, total, data })
+      request.udaruCore.users.read({ id, organizationId }, (err) => {
+        if (err) return reply(err)
+
+        request.udaruCore.users.listUserTeams({ id, organizationId, limit, page }, (err, data, total) => {
+          reply(err, { page, limit, total, data })
+        })
       })
     },
     config: {

--- a/test/integration/endToEnd/teams.test.js
+++ b/test/integration/endToEnd/teams.test.js
@@ -310,6 +310,27 @@ lab.experiment('Teams - get/list', () => {
       })
     })
   })
+
+  lab.test('return 404 if team does not exist when requesting users', (done) => {
+    const teamId = 'idontexist'
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: `/authorization/teams/$${teamId}/users`
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(result.statusCode).to.equal(404)
+      expect(result.data).to.not.exist()
+      expect(result.total).to.not.exist()
+      expect(result.error).to.exist()
+      expect(result.message).to.exist()
+      expect(result.message.toLowerCase()).to.include(teamId).include('not').include('found')
+
+      done()
+    })
+  })
 })
 
 lab.experiment('Teams - create', () => {

--- a/test/integration/endToEnd/teams.test.js
+++ b/test/integration/endToEnd/teams.test.js
@@ -315,7 +315,7 @@ lab.experiment('Teams - get/list', () => {
     const teamId = 'idontexist'
     const options = utils.requestOptions({
       method: 'GET',
-      url: `/authorization/teams/$${teamId}/users`
+      url: `/authorization/teams/${teamId}/users`
     })
 
     server.inject(options, (response) => {

--- a/test/integration/endToEnd/users.test.js
+++ b/test/integration/endToEnd/users.test.js
@@ -741,7 +741,7 @@ lab.experiment('Users - manage teams', () => {
   })
 
   lab.test('get user teams, invalid userId', (done) => {
-    const userId = 'InvalidId'
+    const userId = 'invalidid'
     const options = utils.requestOptions({
       method: 'GET',
       url: `/authorization/users/${userId}/teams`
@@ -750,11 +750,12 @@ lab.experiment('Users - manage teams', () => {
     server.inject(options, (response) => {
       const result = response.result
 
-      expect(response.statusCode).to.equal(200)
-      expect(result.total).to.equal(0)
-      expect(result.page).to.equal(1)
-      expect(result.limit).to.equal(defaultPageSize)
-      expect(result.data.length).to.equal(0)
+      expect(result.statusCode).to.equal(404)
+      expect(result.data).to.not.exist()
+      expect(result.total).to.not.exist()
+      expect(result.error).to.exist()
+      expect(result.message).to.exist()
+      expect(result.message.toLowerCase()).to.include(userId).include('not').include('found')
 
       done()
     })


### PR DESCRIPTION
Resolves #488 

Identified two routes that meet this criteria:

`/authorization/teams/{id}/users`
`/authorization/users/{id}/teams`