### PR TITLE
Context policy variable evaluation

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -144,7 +144,7 @@ The main elements of a Statement are:
 -   The Action to be performed. Example: `'authorization:teams:create'` or `'authorization:organizations:*'`
 -   The Resource on which the action is performed. A Resource name is effectively a URI for your resources. Example: `'FOO:orga:CLOUDCUCKOO:scenario:*:entity:north-america-id'`
 -   The Effect - has the value 'Allow' or 'Deny'.
--   The Conditions, which contain extra logic to determine whether access is granted to the resources
+-   The Conditions, an optional element, which contain extra logic to determine whether statement is applied or not
 
 Note that wildcards can be used in Action and Resource names, as can certain variables, see [IAM Policy Variables Overview](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html) for more details.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -127,6 +127,9 @@ A policy looks like:
     Effect: 'Allow',
     Action: ['Documents:Read'],
     Resource: ['wonka:documents:/public/*']
+    Conditions: { 
+      StringEquals: { udaru:userId: 'CharlieId' }
+    }
   }] }
 }
 ```
@@ -141,10 +144,41 @@ The main elements of a Statement are:
 -   The Action to be performed. Example: `'authorization:teams:create'` or `'authorization:organizations:*'`
 -   The Resource on which the action is performed. A Resource name is effectively a URI for your resources. Example: `'FOO:orga:CLOUDCUCKOO:scenario:*:entity:north-america-id'`
 -   The Effect - has the value 'Allow' or 'Deny'.
+-   The Conditions, which contain extra logic to determine whether access is granted to the resources
 
 Note that wildcards can be used in Action and Resource names, as can certain variables, see [IAM Policy Variables Overview](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html) for more details.
 
 For a detailed description of Policies, see the [AWS Policy Elements Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements.html).
+
+## Policy Context Variables & Conditions
+
+IAM facilitates the use of context variables in resources and conditions.
+
+For a detailed description of IAM policy variable usage see the [AWS Policy Variables Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html)
+
+Udaru has several system context variables that can be used in resources and conditions i.e.
+
+-  Udaru user context variables:
+  -  udaru:userId
+  -  udaru:organizationId
+
+- Request context variables
+  -  request:source (can be either 'api' or 'server')
+  -  request:sourceIp
+  -  request:sourcePort
+  -  request:currentTime
+
+A good example of condition usage would be to grant access to a resource using a policy that expires. To achieve this the DateTime condition, 'DateLessThan', can be used to grant access to a resource if the system context variable request:currentTime is evaluated as being less than the date specified in the condition.
+
+e.g. the following condition would mean the policy is effective until the date time specified is reached.  
+
+```javascript
+Condition: {DateLessThan: {udaru:currentTime: '2018-03-17T23:59:59Z'}}
+```
+
+For a detailed description of the condition operators see the [AWS Policy Condition Operators Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html) 
+
+**Note:** it is envisaged that more useful context variables will be added in future releases
 
 ## Template Policies
 

--- a/packages/udaru-core/database/loadVolumeData.js
+++ b/packages/udaru-core/database/loadVolumeData.js
@@ -94,8 +94,8 @@ function getPolicyTemplate () {
   statement[0].Action = ['Read']
   statement[0].Resource = ['x']
   statement[1] = {}
-  statement[1].Effect = 'Deny'
-  statement[1].Action = ['Write']
+  statement[1].Effect = 'Allow'
+  statement[1].Action = ['Read']
   statement[1].Resource = ['y']
   policyTemplate.Statement = statement
   return policyTemplate
@@ -108,19 +108,19 @@ function loadPolicies (startId, orgId, teamId, callback) {
   var policyTemplate = getPolicyTemplate()
 
   let policiesSql = 'INSERT INTO policies (id, version, name, org_id, statements)\nVALUES\n'
-  let teamPoliciesSql = 'INSERT INTO team_policies(team_id, policy_id)\nVALUES\n'
+  let teamPoliciesSql = 'INSERT INTO team_policies(team_id, policy_id, variables)\nVALUES\n'
 
   // 10 policies per team
   var count = 1
   for (var id = startId; id < startId + NUM_POLICIES_PER_TEAM; id++) {
     // modify policy here...
-    policyTemplate.Statement[0].Resource[0] = 'db:team_' + teamId + ':x_' + count
-    policyTemplate.Statement[1].Resource[0] = 'db:team_' + teamId + ':y_' + count
+    policyTemplate.Statement[0].Resource[0] = 'resource_' + count + ':team/$' + '{udaru:teamId}'
+    policyTemplate.Statement[1].Resource[0] = 'resource_' + count + ':user/$' + '{udaru:userId}'
 
-    policiesSql += "('" + id + "', 0.1, 'POLICY_" + id + "', '" + orgId + "', '" +
+    policiesSql += "('" + id + "', '2012-10-17', 'POLICY_" + id + "', '" + orgId + "', '" +
       JSON.stringify(policyTemplate) + "'::JSONB)"
 
-    teamPoliciesSql += "('" + teamId + "','" + id + "')"
+    teamPoliciesSql += "('" + teamId + "','" + id + "','" + JSON.stringify({var: count}) + "'::JSONB)"
 
     if (id === (startId + NUM_POLICIES_PER_TEAM - 1)) {
       policiesSql += ';'

--- a/packages/udaru-core/lib/ops/authorizeOps.js
+++ b/packages/udaru-core/lib/ops/authorizeOps.js
@@ -105,7 +105,7 @@ function buildAuthorizeOps (db, config) {
           policyOps.listAllUserPolicies({ userId, organizationId }, badImplementationWrap(next))
         },
         function listAuthorizationsOnResources (policies, next) {
-          let context = buildContext({userId, organizationId}, sourceIpAddress, sourcePort)
+          let context = buildContext({userId, organizationId, sourceIpAddress, sourcePort})
           iam(policies).actionsOnResources({ resources, context }, badImplementationWrap(next))
         }
       ], cb)

--- a/packages/udaru-core/lib/ops/authorizeOps.js
+++ b/packages/udaru-core/lib/ops/authorizeOps.js
@@ -19,6 +19,18 @@ function badImplementationWrap (next) {
   }
 }
 
+function getContext (userId, organizationId) {
+  return {
+    udaru: {
+      userId: userId,
+      organizationId: organizationId
+    },
+    request: {
+      currentTime: new Date().toISOString()
+    }
+  }
+}
+
 function buildAuthorizeOps (db, config) {
   const policyOps = buildPolicyOps(db, config)
   const authorize = {
@@ -37,7 +49,8 @@ function buildAuthorizeOps (db, config) {
           policyOps.listAllUserPolicies({ userId, organizationId }, badImplementationWrap(next))
         },
         function check (policies, next) {
-          next(null, iam(policies).isAuthorized({ resource, action }))
+          let context = getContext(userId, organizationId)
+          next(null, iam(policies).isAuthorized({resource, action, context}))
         }
       ], function (err, access) {
         cb(err, { access })
@@ -59,7 +72,8 @@ function buildAuthorizeOps (db, config) {
           policyOps.listAllUserPolicies({ userId, organizationId }, badImplementationWrap(next))
         },
         function check (policies, next) {
-          iam(policies).actions({ resource }, badImplementationWrap(next))
+          let context = getContext(userId, organizationId)
+          iam(policies).actions({resource, context}, badImplementationWrap(next))
         }
       ], function (err, actions) {
         cb(err, { actions })
@@ -81,7 +95,8 @@ function buildAuthorizeOps (db, config) {
           policyOps.listAllUserPolicies({ userId, organizationId }, badImplementationWrap(next))
         },
         function listAuthorizationsOnResources (policies, next) {
-          iam(policies).actionsOnResources({ resources }, badImplementationWrap(next))
+          let context = getContext(userId, organizationId)
+          iam(policies).actionsOnResources({ resources, context }, badImplementationWrap(next))
         }
       ], cb)
     }

--- a/packages/udaru-core/lib/ops/iam.js
+++ b/packages/udaru-core/lib/ops/iam.js
@@ -10,7 +10,7 @@ module.exports = function (policies) {
     return pbac.evaluate(params)
   }
 
-  function actions ({ resource }, done) {
+  function actions ({ resource, context }, done) {
     try {
       const result = _(policies)
         .map('Statement')
@@ -21,7 +21,7 @@ module.exports = function (policies) {
           statement.Resource.forEach((r) => {
             if (pbac.conditions.StringLike(resource, r)) {
               statement.Action.forEach((action) => {
-                if (isAuthorized({resource, action})) {
+                if (isAuthorized({resource, action, context})) {
                   actions.push(action)
                 }
               })
@@ -41,7 +41,7 @@ module.exports = function (policies) {
     }
   }
 
-  function actionsOnResources ({ resources }, done) {
+  function actionsOnResources ({ resources, context }, done) {
     try {
       const resultMap = {}
 
@@ -56,7 +56,7 @@ module.exports = function (policies) {
             statement.Resource.forEach((r) => {
               if (pbac.conditions.StringLike(resource, r)) {
                 statement.Action.forEach((action) => {
-                  if (isAuthorized({resource, action})) {
+                  if (isAuthorized({resource, action, context})) {
                     resultMap[resource].push(action)
                   }
                 })

--- a/packages/udaru-core/lib/ops/validation.js
+++ b/packages/udaru-core/lib/ops/validation.js
@@ -10,7 +10,7 @@ const PolicyIdString = requiredStringId.description('Policy Id String').label('P
 
 const PolicyIdObject = Joi.object({
   id: PolicyIdString,
-  variables: Joi.object().description('A list of the variables with their fixed values').label('variables')
+  variables: Joi.object().pattern(/^(?!(udaru)|(request)).*$/, requiredString).description('A list of the variables with their fixed values').label('variables')
 }).required().description('Policy Id Object').label('PolicyIdObject')
 
 // it would be ideal to put the policyid object first, however it causes a swagger doc error

--- a/packages/udaru-core/package.json
+++ b/packages/udaru-core/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "depcheck": "0.6.9",
-    "chalk": "2.3.2",
     "minimist": "1.2.0",
     "@nearform/udaru-test": "^5.0.0",
     "code": "^4.0.0",

--- a/packages/udaru-core/package.json
+++ b/packages/udaru-core/package.json
@@ -35,8 +35,7 @@
   "bin": {
     "udaru-migrate": "./database/migrate.js",
     "udaru-loadTestData": "./database/loadTestData.js",
-    "udaru-init": "./database/init.js",
-    "udaru-loadVolumeData": "./database/loadVolumeData.js"
+    "udaru-init": "./database/init.js"
   },
   "scripts": {
     "coverage": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 92 -r html -o coverage/coverage.html",
@@ -44,7 +43,6 @@
     "depcheck": "npx depcheck",
     "pg:init": "node ./database/init.js && npm run pg:migrate",
     "pg:init-test-db": "npm run pg:init && npm run pg:load-test-data",
-    "pg:init-volume-db": "npm run pg:init && node ./database/loadVolumeData.js",
     "pg:load-test-data": "node ./database/loadTestData.js",
     "pg:migrate": "node ./database/migrate.js --version=max",
     "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 92"

--- a/packages/udaru-core/test/integration/authorizeOps.test.js
+++ b/packages/udaru-core/test/integration/authorizeOps.test.js
@@ -182,7 +182,7 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - using udaru:userId context variable applied to a user attached policy', (done) => {
-    let testPolicy = {
+    const testPolicy = {
       id: 'userContextPolicy',
       name: 'User Context Policy',
       version: '2012-10-17',
@@ -213,7 +213,7 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - udaru:organizationId context variable applied to a user attached policy', (done) => {
-    let testPolicy = {
+    const testPolicy = {
       id: 'userContextPolicy',
       name: 'User Context Policy',
       version: '2012-10-17',
@@ -244,7 +244,7 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - using udaru:userId context variable applied to a user attached policy', (done) => {
-    let testPolicy = {
+    const testPolicy = {
       id: 'userContextPolicy',
       name: 'User Context Policy',
       version: '2012-10-17',
@@ -275,7 +275,7 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - using udaru:userId context variable applied to a TEAM attached policy', (done) => {
-    let testPolicy = {
+    const testPolicy = {
       id: 'teamContextPolicy',
       name: 'Team Context Policy',
       version: '2012-10-17',
@@ -306,7 +306,7 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - using udaru:userId context variable applied to an ORG attached policy', (done) => {
-    let testPolicy = {
+    const testPolicy = {
       id: 'orgContextPolicy',
       name: 'Org Context Policy',
       version: '2012-10-17',
@@ -337,7 +337,7 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - incorrect variable applied to a user attached policy', (done) => {
-    let testPolicy = {
+    const testPolicy = {
       id: 'userContextPolicy',
       name: 'User Context Policy',
       version: '2012-10-17',
@@ -368,9 +368,9 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - test with udaru:organizationId variable for condition', (done) => {
-    let Condition = { StringEquals: { 'udaru:organizationId': organizationId } }
+    const Condition = { StringEquals: { 'udaru:organizationId': organizationId } }
 
-    let testPolicy = {
+    const testPolicy = {
       id: 'userContextPolicy',
       name: 'User Context Policy',
       version: '2012-10-17',
@@ -401,9 +401,9 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - test with invalid variable for condition', (done) => {
-    let Condition = { StringEquals: { 'udaru:organizationId': 'invalidOrg' } }
+    const Condition = { StringEquals: { 'udaru:organizationId': 'invalidOrg' } }
 
-    let testPolicy = {
+    const testPolicy = {
       id: 'userContextPolicy',
       name: 'User Context Policy',
       version: '2012-10-17',
@@ -434,9 +434,9 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - test with udaru:organizationId variable for condition', (done) => {
-    let Condition = { StringEquals: { 'udaru:organizationId': organizationId } }
+    const Condition = { StringEquals: { 'udaru:organizationId': organizationId } }
 
-    let testPolicy = {
+    const testPolicy = {
       id: 'userContextPolicy',
       name: 'User Context Policy',
       version: '2012-10-17',
@@ -467,9 +467,9 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - allow with udaru:source condition = api', (done) => {
-    let Condition = { StringEquals: { 'request:source': 'api' } }
+    const Condition = { StringEquals: { 'request:source': 'api' } }
 
-    let testPolicy = {
+    const testPolicy = {
       id: 'userConditionPolicy',
       name: 'User Condition Policy',
       version: '2012-10-17',
@@ -500,9 +500,9 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - deny test with udaru:source condition = server', (done) => {
-    let Condition = { StringEquals: { 'request:source': 'server' } }
+    const Condition = { StringEquals: { 'request:source': 'server' } }
 
-    let testPolicy = {
+    const testPolicy = {
       id: 'userConditionPolicy',
       name: 'User Condition Policy',
       version: '2012-10-17',
@@ -533,9 +533,9 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - test with date greater than condition', (done) => {
-    let Condition = { DateGreaterThan: { 'request:currentTime': '2018-03-20T00:00:00Z' } }
+    const Condition = { DateGreaterThan: { 'request:currentTime': '2018-03-20T00:00:00Z' } }
 
-    let testPolicy = {
+    const testPolicy = {
       id: 'userContextPolicy',
       name: 'User Context Policy',
       version: '2012-10-17',
@@ -566,9 +566,9 @@ lab.experiment('AuthorizeOps', () => {
   })
 
   lab.test('authorize isUserAuthorized - test with date less than condition', (done) => {
-    let Condition = { DateLessThan: { 'request:currentTime': '2018-03-20T00:00:00Z' } }
+    const Condition = { DateLessThan: { 'request:currentTime': '2018-03-20T00:00:00Z' } }
 
-    let testPolicy = {
+    const testPolicy = {
       id: 'userContextPolicy',
       name: 'User Context Policy',
       version: '2012-10-17',

--- a/packages/udaru-core/test/integration/authorizeOps.test.js
+++ b/packages/udaru-core/test/integration/authorizeOps.test.js
@@ -12,7 +12,7 @@ const SQL = require('@nearform/sql')
 const udaru = require('../..')()
 const authorize = udaru.authorize
 const Factory = require('@nearform/udaru-test/factory')
-
+const testUtils = require('@nearform/udaru-test/utils')
 const fs = require('fs')
 const path = require('path')
 
@@ -177,6 +177,357 @@ lab.experiment('AuthorizeOps', () => {
         expect(result.access).to.be.false()
 
         done()
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - using udaru:userId context variable applied to a user attached policy', (done) => {
+    let testPolicy = {
+      id: 'userContextPolicy',
+      name: 'User Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.AllowStatement(['read'], ['org:documents/${udaru:userId}'])
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userContextPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.true()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - udaru:organizationId context variable applied to a user attached policy', (done) => {
+    let testPolicy = {
+      id: 'userContextPolicy',
+      name: 'User Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.AllowStatement(['read'], ['org:documents/${udaru:organizationId}'])
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userContextPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + organizationId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.true()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - using udaru:userId context variable applied to a user attached policy', (done) => {
+    let testPolicy = {
+      id: 'userContextPolicy',
+      name: 'User Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.AllowStatement(['read'], ['org:documents/${udaru:userId}'])
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userContextPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.true()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - using udaru:userId context variable applied to a TEAM attached policy', (done) => {
+    let testPolicy = {
+      id: 'teamContextPolicy',
+      name: 'Team Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.AllowStatement(['read'], ['org:documents/${udaru:userId}'])
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.teams.replacePolicies({ id: managersTeamId, policies: ['teamContextPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.true()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - using udaru:userId context variable applied to an ORG attached policy', (done) => {
+    let testPolicy = {
+      id: 'orgContextPolicy',
+      name: 'Org Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.AllowStatement(['read'], ['org:documents/${udaru:userId}'])
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.organizations.replacePolicies({ id: organizationId, policies: ['orgContextPolicy'] }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.true()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - incorrect variable applied to a user attached policy', (done) => {
+    let testPolicy = {
+      id: 'userContextPolicy',
+      name: 'User Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.AllowStatement(['read'], ['org:documents/$' + '{udaru:orgId}'])
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userContextPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + organizationId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.false()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - test with udaru:organizationId variable for condition', (done) => {
+    let Condition = { StringEquals: { 'udaru:organizationId': organizationId } }
+
+    let testPolicy = {
+      id: 'userContextPolicy',
+      name: 'User Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.StatementWithCondition('Allow', ['read'], ['org:documents/$' + '{udaru:userId}'], Condition)
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userContextPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.true()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - test with invalid variable for condition', (done) => {
+    let Condition = { StringEquals: { 'udaru:organizationId': 'invalidOrg' } }
+
+    let testPolicy = {
+      id: 'userContextPolicy',
+      name: 'User Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.StatementWithCondition('Allow', ['read'], ['org:documents/$' + '{udaru:userId}'], Condition)
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userContextPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.false()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - test with udaru:organizationId variable for condition', (done) => {
+    let Condition = { StringEquals: { 'udaru:organizationId': organizationId } }
+
+    let testPolicy = {
+      id: 'userContextPolicy',
+      name: 'User Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.StatementWithCondition('Allow', ['read'], ['org:documents/$' + '{udaru:userId}'], Condition)
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userContextPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.true()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - test with date greater than condition', (done) => {
+    let Condition = { DateGreaterThan: { 'request:currentTime': '2018-03-20T00:00:00Z' } }
+
+    let testPolicy = {
+      id: 'userContextPolicy',
+      name: 'User Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.StatementWithCondition('Allow', ['read'], ['org:documents/$' + '{udaru:userId}'], Condition)
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userContextPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.true()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - test with date less than condition', (done) => {
+    let Condition = { DateLessThan: { 'request:currentTime': '2018-03-20T00:00:00Z' } }
+
+    let testPolicy = {
+      id: 'userContextPolicy',
+      name: 'User Context Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.StatementWithCondition('Allow', ['read'], ['org:documents/$' + '{udaru:userId}'], Condition)
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userContextPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'read', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.false()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
       })
     })
   })

--- a/packages/udaru-core/test/integration/authorizeOps.test.js
+++ b/packages/udaru-core/test/integration/authorizeOps.test.js
@@ -187,7 +187,7 @@ lab.experiment('AuthorizeOps', () => {
       name: 'User Context Policy',
       version: '2012-10-17',
       organizationId: organizationId,
-      statements: testUtils.AllowStatement(['read'], ['org:documents/${udaru:userId}'])
+      statements: testUtils.AllowStatement(['read'], ['org:documents/$' + '{udaru:userId}'])
     }
 
     udaru.policies.create(testPolicy, (err, result) => {
@@ -218,7 +218,7 @@ lab.experiment('AuthorizeOps', () => {
       name: 'User Context Policy',
       version: '2012-10-17',
       organizationId: organizationId,
-      statements: testUtils.AllowStatement(['read'], ['org:documents/${udaru:organizationId}'])
+      statements: testUtils.AllowStatement(['read'], ['org:documents/$' + '{udaru:organizationId}'])
     }
 
     udaru.policies.create(testPolicy, (err, result) => {
@@ -249,7 +249,7 @@ lab.experiment('AuthorizeOps', () => {
       name: 'User Context Policy',
       version: '2012-10-17',
       organizationId: organizationId,
-      statements: testUtils.AllowStatement(['read'], ['org:documents/${udaru:userId}'])
+      statements: testUtils.AllowStatement(['read'], ['org:documents/$' + '{udaru:userId}'])
     }
 
     udaru.policies.create(testPolicy, (err, result) => {
@@ -280,7 +280,7 @@ lab.experiment('AuthorizeOps', () => {
       name: 'Team Context Policy',
       version: '2012-10-17',
       organizationId: organizationId,
-      statements: testUtils.AllowStatement(['read'], ['org:documents/${udaru:userId}'])
+      statements: testUtils.AllowStatement(['read'], ['org:documents/$' + '{udaru:userId}'])
     }
 
     udaru.policies.create(testPolicy, (err, result) => {
@@ -311,7 +311,7 @@ lab.experiment('AuthorizeOps', () => {
       name: 'Org Context Policy',
       version: '2012-10-17',
       organizationId: organizationId,
-      statements: testUtils.AllowStatement(['read'], ['org:documents/${udaru:userId}'])
+      statements: testUtils.AllowStatement(['read'], ['org:documents/$' + '{udaru:userId}'])
     }
 
     udaru.policies.create(testPolicy, (err, result) => {

--- a/packages/udaru-core/test/integration/authorizeOps.test.js
+++ b/packages/udaru-core/test/integration/authorizeOps.test.js
@@ -466,6 +466,72 @@ lab.experiment('AuthorizeOps', () => {
     })
   })
 
+  lab.test('authorize isUserAuthorized - allow with udaru:source condition = api', (done) => {
+    let Condition = { StringEquals: { 'request:source': 'api' } }
+
+    let testPolicy = {
+      id: 'userConditionPolicy',
+      name: 'User Condition Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.StatementWithCondition('Allow', ['write'], ['org:documents/$' + '{udaru:userId}'], Condition)
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userConditionPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'write', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.true()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  lab.test('authorize isUserAuthorized - deny test with udaru:source condition = server', (done) => {
+    let Condition = { StringEquals: { 'request:source': 'server' } }
+
+    let testPolicy = {
+      id: 'userConditionPolicy',
+      name: 'User Condition Policy',
+      version: '2012-10-17',
+      organizationId: organizationId,
+      statements: testUtils.StatementWithCondition('Allow', ['write'], ['org:documents/$' + '{udaru:userId}'], Condition)
+    }
+
+    udaru.policies.create(testPolicy, (err, result) => {
+      if (err) return done(err)
+
+      udaru.users.replacePolicies({ id: testUserId, policies: ['userConditionPolicy'], organizationId }, (err, result) => {
+        if (err) return done(err)
+
+        authorize.isUserAuthorized({ userId: testUserId, resource: 'org:documents/' + testUserId, action: 'write', organizationId }, (err, result) => {
+          if (err) return done(err)
+
+          expect(err).to.not.exist()
+          expect(result).to.exist()
+          expect(result.access).to.be.false()
+
+          udaru.policies.delete({id: testPolicy.id, organizationId}, (err, result) => {
+            expect(err).to.not.exist()
+            done()
+          })
+        })
+      })
+    })
+  })
+
   lab.test('authorize isUserAuthorized - test with date greater than condition', (done) => {
     let Condition = { DateGreaterThan: { 'request:currentTime': '2018-03-20T00:00:00Z' } }
 

--- a/packages/udaru-hapi-plugin/routes/public/authorization.js
+++ b/packages/udaru-hapi-plugin/routes/public/authorization.js
@@ -53,7 +53,9 @@ exports.register = function (server, options, next) {
       const params = {
         userId,
         resource,
-        organizationId
+        organizationId,
+        sourceIpAddress: request.info.remoteAddress,
+        sourcePort: request.info.remotePort
       }
 
       request.udaruCore.authorize.listActions(params, reply)
@@ -86,7 +88,9 @@ exports.register = function (server, options, next) {
       const params = {
         userId,
         resources,
-        organizationId
+        organizationId,
+        sourceIpAddress: request.info.remoteAddress,
+        sourcePort: request.info.remotePort
       }
 
       request.udaruCore.authorize.listAuthorizationsOnResources(params, reply)

--- a/packages/udaru-hapi-plugin/routes/public/authorization.js
+++ b/packages/udaru-hapi-plugin/routes/public/authorization.js
@@ -19,7 +19,9 @@ exports.register = function (server, options, next) {
         userId,
         action,
         resource,
-        organizationId
+        organizationId,
+        sourceIpAddress: request.info.remoteAddress,
+        sourcePort: request.info.remotePort
       }
 
       request.udaruCore.authorize.isUserAuthorized(params, reply)

--- a/packages/udaru-hapi-plugin/test/endToEnd/authorization.test.js
+++ b/packages/udaru-hapi-plugin/test/endToEnd/authorization.test.js
@@ -121,7 +121,7 @@ lab.experiment('Authorization inherited org policies', () => {
         id: orgId1,
         name: 'Test Organization',
         description: 'Test Organization',
-        policies: ['testPolicy1', 'checkAccessPolicy1'],
+        policies: ['testPolicy1', 'checkAccessPolicy1', 'contextTestPolicy'],
         users: ['TestUser1']
       },
       org2: {
@@ -181,6 +181,19 @@ lab.experiment('Authorization inherited org policies', () => {
               Effect: 'Allow',
               Action: ['authorization:authn:access'],
               Resource: ['authorization/access']
+            }
+          ]
+        }
+      },
+      contextTestPolicy: {
+        name: 'contextTestPolicy',
+        organizationId: orgId1,
+        statements: {
+          Statement: [
+            {
+              Effect: 'Allow',
+              Action: ['read'],
+              Resource: ['org:docs:$' + '{udaru:userId}']
             }
           ]
         }
@@ -264,6 +277,47 @@ lab.experiment('Authorization inherited org policies', () => {
 
       expect(response.statusCode).to.equal(200)
       expect(result.access).to.equal(true)
+
+      done()
+    })
+  })
+
+  lab.test('User is granted access to resource based on udaru:userId context variable', (done) => {
+    const userId = testUserId1
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: `/authorization/access/${userId}/read/org:docs:${userId}`,
+      headers: {
+        authorization: 'ROOTid',
+        org: orgId1
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.access).to.equal(true)
+
+      done()
+    })
+  })
+
+  lab.test('User is NOT granted access to other users resource based on udaru:userId context variable', (done) => {
+    const options = utils.requestOptions({
+      method: 'GET',
+      url: `/authorization/access/${testUserId1}/read/org:docs:${testUserId2}`,
+      headers: {
+        authorization: 'ROOTid',
+        org: orgId1
+      }
+    })
+
+    server.inject(options, (response) => {
+      const result = response.result
+
+      expect(response.statusCode).to.equal(200)
+      expect(result.access).to.equal(false)
 
       done()
     })

--- a/packages/udaru-hapi-server/README.md
+++ b/packages/udaru-hapi-server/README.md
@@ -78,6 +78,31 @@ npm run pg:load-test-data
 
 -   **Note:** Running a test or coverage command will auto run these commands
 
+#### Volume data set installation and bench tests
+The Authorization database can be further initialized with a larger volume of data, which can be tested using autocannon bench tests in order to demonstrate the potential throughput of the authorization API.
+
+To populate the database with volume data, execute the following command:
+
+```
+npm run pg:init-volume-db
+```
+
+-   **Note:** Running this command will auto run the standard database population commands also
+
+All volume data sits under the organization 'CONCH' and has the following default setup:
+-  500 teams
+-  100 users per team (the first of every 100 being the parent of subsequent 99)
+-  10 policies per team
+
+After loading the data, the autocannon bench tests can be run by executing:
+
+```
+npm run bench-volume
+```
+
+This will run 15 second autocannon tests, which fire multiple concurrent requests at 2 frequently used endpoints. This results in the database being queried randomly across the entire set of data giving a good indication of average end-to-end latency and potential requests per second for a database containing 50K users.
+
+
 ### pgAdmin database access
 As the Postgresql docker container has its 5432 port forwarded on the local machine the database can be accessed with pgAdmin.
 

--- a/packages/udaru-hapi-server/README.md
+++ b/packages/udaru-hapi-server/README.md
@@ -299,8 +299,22 @@ npm run pg:init-volume-db
 To run bench test against populated volume data (2 endpoints)
 
 ```
-npm run bench-volume
+npm run bench:volume
 ```
+
+For convenience, you can load the volume db and run the bench tests with the single command. 
+
+```
+npm run bench:load-volume
+```
+
+This command will:
+-  initialise the db & migrate to latest db schema
+-  load the standard test fixtures
+-  load the volume fixtures 
+-  spawn an instance of udaru server
+-  run the autocannon tests & display results
+-  shut down
 
 ## Security
 

--- a/packages/udaru-hapi-server/bench/util/loadVolumeData.js
+++ b/packages/udaru-hapi-server/bench/util/loadVolumeData.js
@@ -12,9 +12,7 @@ const NUM_USERS_PER_TEAM = 100 // put this many users in each team
 const NUM_POLICIES_PER_TEAM = 10 // :-|
 const ADD_METADATA = true
 
-const path = require('path')
 const pg = require('pg')
-const fs = require('fs')
 const chalk = require('chalk')
 const minimist = require('minimist')
 const argv = minimist(process.argv.slice(2))
@@ -36,20 +34,8 @@ function loadVolumeDataBegin (callback) {
   startTime = Date.now()
   console.log('loadVolume data started at ' + startTime)
 
-  // load original test data also..., should not interfere
-  console.log('loading existing fixtures from: ' + path.join(__dirname, '/testdata/fixtures.sql'))
-  let fixturesSQL = fs.readFileSync(path.join(__dirname, '/testdata/fixtures.sql'), 'utf8')
-
   client.connect(() => { // connect first, then set off daisy chain of queries on success
-    client.query(fixturesSQL, (err) => {
-      if (err) {
-        callback(err)
-      } else {
-        endTime = Date.now()
-        console.log(chalk.green('successfully loaded original fixtures'))
-        loadTeams('CONCH', callback) // loads load everything into WONKA org
-      }
-    })
+    loadTeams('CONCH', callback) // loads load everything into WONKA org
   })
 }
 

--- a/packages/udaru-hapi-server/package-lock.json
+++ b/packages/udaru-hapi-server/package-lock.json
@@ -501,6 +501,11 @@
 				}
 			}
 		},
+		"buffer-writer": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-1.0.1.tgz",
+			"integrity": "sha1-Iqk2kB4wKa/NdUfrRIfOtpejvwg="
+		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -2817,6 +2822,11 @@
 					}
 				}
 			}
+		},
+		"js-string-escape": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+			"integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
 		},
 		"js-tokens": {
 			"version": "3.0.2",
@@ -7004,6 +7014,11 @@
 			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
 			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
 		},
+		"packet-reader": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-0.3.1.tgz",
+			"integrity": "sha1-zWLmCvjX/qinBexP+ZCHHEaHHyc="
+		},
 		"pako": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
@@ -7108,6 +7123,57 @@
 				}
 			}
 		},
+		"pg": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/pg/-/pg-7.4.1.tgz",
+			"integrity": "sha512-Pi5qYuXro5PAD9xXx8h7bFtmHgAQEG6/SCNyi7gS3rvb/ZQYDmxKchfB0zYtiSJNWq9iXTsYsHjrM+21eBcN1A==",
+			"requires": {
+				"buffer-writer": "1.0.1",
+				"js-string-escape": "1.0.1",
+				"packet-reader": "0.3.1",
+				"pg-connection-string": "0.1.3",
+				"pg-pool": "2.0.3",
+				"pg-types": "1.12.1",
+				"pgpass": "1.0.2",
+				"semver": "4.3.2"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz",
+					"integrity": "sha1-x6BxWKgL7dBSNVt3DYLWZA+AO+c="
+				}
+			}
+		},
+		"pg-connection-string": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz",
+			"integrity": "sha1-2hhHsglA5C7hSSvq9l1J2RskXfc="
+		},
+		"pg-pool": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-2.0.3.tgz",
+			"integrity": "sha1-wCIDLIlJ8xKk+R+2QJzgQHa+Mlc="
+		},
+		"pg-types": {
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.12.1.tgz",
+			"integrity": "sha1-1kCH45A7WP+q0nnnWVxSIIoUw9I=",
+			"requires": {
+				"postgres-array": "1.0.2",
+				"postgres-bytea": "1.0.0",
+				"postgres-date": "1.0.3",
+				"postgres-interval": "1.1.1"
+			}
+		},
+		"pgpass": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.2.tgz",
+			"integrity": "sha1-Knu0G2BltnkH6R2hsHwYR8h3swY=",
+			"requires": {
+				"split": "1.0.1"
+			}
+		},
 		"pify": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -7177,6 +7243,29 @@
 						"topo": "2.0.2"
 					}
 				}
+			}
+		},
+		"postgres-array": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-1.0.2.tgz",
+			"integrity": "sha1-jgsy6wO/d6XAp4UeBEHBaaJWojg="
+		},
+		"postgres-bytea": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+			"integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU="
+		},
+		"postgres-date": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz",
+			"integrity": "sha1-4tiXAu/bJY/52c7g/pG9BpdSV6g="
+		},
+		"postgres-interval": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
+			"integrity": "sha512-OkuCi9t/3CZmeQreutGgx/OVNv9MKHGIT5jH8KldQ4NLYXkvmT9nDVxEuCENlNwhlGPE374oA/xMqn05G49pHA==",
+			"requires": {
+				"xtend": "4.0.1"
 			}
 		},
 		"prelude-ls": {
@@ -7671,6 +7760,14 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
 			"integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+		},
+		"split": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+			"integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+			"requires": {
+				"through": "2.3.8"
+			}
 		},
 		"split2": {
 			"version": "2.2.0",

--- a/packages/udaru-hapi-server/package.json
+++ b/packages/udaru-hapi-server/package.json
@@ -37,7 +37,8 @@
   "main": "index.js",
   "scripts": {
     "bench": "node ./bench/util/runner.js",
-    "bench-volume": "node ./bench/util/volumeRunner.js",
+    "bench:volume": "node ./bench/util/volumeRunner.js",
+    "bench:load-volume": "npm run pg:init-volume-db && node ./bench/util/volumeRunner.js",
     "coverage": "UDARU_SERVICE_logger_pino_level=silent lab -c -t 96 -r html -o coverage/coverage.html",
     "coveralls": "UDARU_SERVICE_logger_pino_level=silent lab -c -t 96 -r lcov | COVERALLS_REPO_TOKEN='?' coveralls",
     "depcheck": "npx depcheck  --ignores='@nearform/udaru-core'",
@@ -45,10 +46,10 @@
     "pg:init": "UDARU_SERVICE_local=true npx udaru-init && npm run pg:migrate",
     "pg:init-test-db": "npm run pg:init && npm run pg:load-test-data",
     "pg:load-test-data": "UDARU_SERVICE_local=true npx udaru-loadTestData",
+    "pg:init-volume-db": "npm run pg:init-test-db && ./bench/util/loadVolumeData.js",
     "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 96",
     "test:security": "node ./security/runner.js",
     "pretest:security": "napa sqlmapproject/sqlmap",
-    "pg:init-volume-db": "npm run pg:init && npx udaru-loadVolumeData",
     "pg:migrate": "npx udaru-migrate --version=max"
   },
   "dependencies": {
@@ -72,6 +73,7 @@
     "lab": "^14.3.2",
     "minimist": "1.2.0",
     "napa": "^2.3.0",
+    "pg": "^7.4.1",
     "npx": "10.0.1"
   }
 }

--- a/packages/udaru-test/utils.js
+++ b/packages/udaru-test/utils.js
@@ -33,6 +33,12 @@ function Statement (effect, action, resource) {
   }
 }
 
+function StatementWithCondition (effect, action, resource, condition) {
+  let statement = Statement(effect, action, resource)
+  statement.Statement[0].Condition = condition
+  return statement
+}
+
 function DenyStatement (action, resource) {
   return Statement('Deny', action, resource)
 }
@@ -45,6 +51,7 @@ module.exports = {
   requestOptions,
   findPick,
   Statement,
+  StatementWithCondition,
   AllowStatement,
   DenyStatement
 }


### PR DESCRIPTION
@dberesford @mihaidma 

I rebased this branch with master, the context stuff is in here and I added some testing around it, as well as tests around not allowing reserved keywords as variable names in policy instances.

Volume db and autocannon volume tests can be run now from hapi-server-plugin module too.