### PR TITLE
 Updated contributors in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       "url": "https://github.com/irelandm"
     },
     {
-      "name": "ron litzenberger",
+      "name": "Ron Litzenberger",
       "url": "https://github.com/litzenberger"
     },
     {
@@ -74,7 +74,7 @@
       "url": "https://github.com/bcameron"
     },
     {
-      "name": "Shogun",
+      "name": "Paolo Insogna",
       "url": "https://github.com/ShogunPanda"
     },
     {

--- a/package.json
+++ b/package.json
@@ -5,23 +5,84 @@
   "license": "MIT",
   "author": "nearForm Ltd",
   "contributors": [
-    "Andrew Cashmore (https://github.com/andrewcashmore)",
-    "Damian Beresford (https://github.com/dberesford)",
-    "Dean McDonnell (https://github.com/mcdonnelldean)",
-    "Filippo De Santis (https://github.com/p16)",
-    "Florian Traverse (https://github.com/temsa)",
-    "Mihai Dima (https://github.com/mihaidma)",
-    "Paolo Chiodi (https://github.com/paolochiodi)",
-    "Paolo Insogna (https://github.com/ShogunPanda)",
-    "Paul Negrutiu (https://github.com/floridemai)",
-    "Mark Ireland (https://github.com/irelandm)",
-    "Michael O'Brien (https://github.com/mobri3n)",
-    "Michele Capra (https://github.com/piccoloaiutante)",
-    "Nicolas Herment (https://github.com/nherment)",
-    "Salman Mitha (https://github.com/salmanm)",
-    "William Riley-Land (https://github.com/wprl)"
+    {
+      "name": "Jimmy Mintzer",
+      "url": "https://github.com/jimmymintzer"
+    },
+    {
+      "name": "Nicolas Herment",
+      "url": "https://github.com/nherment"
+    },
+    {
+      "name": "Damian Beresford",
+      "url": "https://github.com/dberesford"
+    },
+    {
+      "name": "Mark Ireland",
+      "url": "https://github.com/irelandm"
+    },
+    {
+      "name": "ron litzenberger",
+      "url": "https://github.com/litzenberger"
+    },
+    {
+      "name": "Cian Foley",
+      "url": "https://github.com/cianfoley-nearform"
+    },
+    {
+      "name": "Dara Hayes",
+      "url": "https://github.com/darahayes"
+    },
+    {
+      "name": "Andrew Cashmore",
+      "url": "https://github.com/andrewcashmore"
+    },
+    {
+      "name": "Dean McDonnell",
+      "url": "https://github.com/mcdonnelldean"
+    },
+    {
+      "name": "Paul Negrutiu",
+      "url": "https://github.com/floridemai"
+    },
+    {
+      "name": "Salman Mitha",
+      "url": "https://github.com/salmanm"
+    },
+    {
+      "name": "Michael O'Brien",
+      "url": "https://github.com/mobri3n"
+    },
+    {
+      "name": "Michele Capra",
+      "url": "https://github.com/piccoloaiutante"
+    },
+    {
+      "name": "Filippo De Santis",
+      "url": "https://github.com/p16"
+    },
+    {
+      "name": "Mihai Dima",
+      "url": "https://github.com/mihaidma"
+    },
+    {
+      "name": "Paolo Chiodi",
+      "url": "https://github.com/paolochiodi"
+    },
+    {
+      "name": "Brian Cameron",
+      "url": "https://github.com/bcameron"
+    },
+    {
+      "name": "Shogun",
+      "url": "https://github.com/ShogunPanda"
+    },
+    {
+      "name": "William Riley-Land",
+      "url": "https://github.com/ShogunPanda"
+    }
   ],
-  "homepage": "https://github.com/nearform/udaru#readme",
+  "homepage": "https://nearform.github.io/udaru",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nearform/udaru.git"

--- a/packages/udaru-core/package.json
+++ b/packages/udaru-core/package.json
@@ -22,7 +22,7 @@
       "url": "https://github.com/irelandm"
     },
     {
-      "name": "ron litzenberger",
+      "name": "Ron Litzenberger",
       "url": "https://github.com/litzenberger"
     },
     {

--- a/packages/udaru-core/package.json
+++ b/packages/udaru-core/package.json
@@ -5,23 +5,84 @@
   "author": "nearForm Ltd",
   "license": "MIT",
   "contributors": [
-    "Andrew Cashmore (https://github.com/andrewcashmore)",
-    "Damian Beresford (https://github.com/dberesford)",
-    "Dean McDonnell (https://github.com/mcdonnelldean)",
-    "Filippo De Santis (https://github.com/p16)",
-    "Florian Traverse (https://github.com/temsa)",
-    "Mihai Dima (https://github.com/mihaidma)",
-    "Paolo Chiodi (https://github.com/paolochiodi)",
-    "Paolo Insogna (https://github.com/ShogunPanda)",
-    "Paul Negrutiu (https://github.com/floridemai)",
-    "Mark Ireland (https://github.com/irelandm)",
-    "Michael O'Brien (https://github.com/mobri3n)",
-    "Michele Capra (https://github.com/piccoloaiutante)",
-    "Nicolas Herment (https://github.com/nherment)",
-    "Salman Mitha (https://github.com/salmanm)",
-    "William Riley-Land (https://github.com/wprl)"
+    {
+      "name": "Jimmy Mintzer",
+      "url": "https://github.com/jimmymintzer"
+    },
+    {
+      "name": "Nicolas Herment",
+      "url": "https://github.com/nherment"
+    },
+    {
+      "name": "Damian Beresford",
+      "url": "https://github.com/dberesford"
+    },
+    {
+      "name": "Mark Ireland",
+      "url": "https://github.com/irelandm"
+    },
+    {
+      "name": "ron litzenberger",
+      "url": "https://github.com/litzenberger"
+    },
+    {
+      "name": "Cian Foley",
+      "url": "https://github.com/cianfoley-nearform"
+    },
+    {
+      "name": "Dara Hayes",
+      "url": "https://github.com/darahayes"
+    },
+    {
+      "name": "Andrew Cashmore",
+      "url": "https://github.com/andrewcashmore"
+    },
+    {
+      "name": "Dean McDonnell",
+      "url": "https://github.com/mcdonnelldean"
+    },
+    {
+      "name": "Paul Negrutiu",
+      "url": "https://github.com/floridemai"
+    },
+    {
+      "name": "Salman Mitha",
+      "url": "https://github.com/salmanm"
+    },
+    {
+      "name": "Michael O'Brien",
+      "url": "https://github.com/mobri3n"
+    },
+    {
+      "name": "Michele Capra",
+      "url": "https://github.com/piccoloaiutante"
+    },
+    {
+      "name": "Filippo De Santis",
+      "url": "https://github.com/p16"
+    },
+    {
+      "name": "Mihai Dima",
+      "url": "https://github.com/mihaidma"
+    },
+    {
+      "name": "Paolo Chiodi",
+      "url": "https://github.com/paolochiodi"
+    },
+    {
+      "name": "Brian Cameron",
+      "url": "https://github.com/bcameron"
+    },
+    {
+      "name": "Paolo Insogna",
+      "url": "https://github.com/ShogunPanda"
+    },
+    {
+      "name": "William Riley-Land",
+      "url": "https://github.com/ShogunPanda"
+    }
   ],
-  "homepage": "https://github.com/nearform/udaru#readme",
+  "homepage": "https://nearform.github.io/udaru",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nearform/udaru.git"

--- a/packages/udaru-hapi-16-plugin/package.json
+++ b/packages/udaru-hapi-16-plugin/package.json
@@ -23,7 +23,7 @@
       "url": "https://github.com/irelandm"
     },
     {
-      "name": "ron litzenberger",
+      "name": "Ron Litzenberger",
       "url": "https://github.com/litzenberger"
     },
     {

--- a/packages/udaru-hapi-16-plugin/package.json
+++ b/packages/udaru-hapi-16-plugin/package.json
@@ -6,23 +6,84 @@
   "author": "nearForm Ltd",
   "license": "MIT",
   "contributors": [
-    "Andrew Cashmore (https://github.com/andrewcashmore)",
-    "Damian Beresford (https://github.com/dberesford)",
-    "Dean McDonnell (https://github.com/mcdonnelldean)",
-    "Filippo De Santis (https://github.com/p16)",
-    "Florian Traverse (https://github.com/temsa)",
-    "Mihai Dima (https://github.com/mihaidma)",
-    "Paolo Chiodi (https://github.com/paolochiodi)",
-    "Paolo Insogna (https://github.com/ShogunPanda)",
-    "Paul Negrutiu (https://github.com/floridemai)",
-    "Mark Ireland (https://github.com/irelandm)",
-    "Michael O'Brien (https://github.com/mobri3n)",
-    "Michele Capra (https://github.com/piccoloaiutante)",
-    "Nicolas Herment (https://github.com/nherment)",
-    "Salman Mitha (https://github.com/salmanm)",
-    "William Riley-Land (https://github.com/wprl)"
+    {
+      "name": "Jimmy Mintzer",
+      "url": "https://github.com/jimmymintzer"
+    },
+    {
+      "name": "Nicolas Herment",
+      "url": "https://github.com/nherment"
+    },
+    {
+      "name": "Damian Beresford",
+      "url": "https://github.com/dberesford"
+    },
+    {
+      "name": "Mark Ireland",
+      "url": "https://github.com/irelandm"
+    },
+    {
+      "name": "ron litzenberger",
+      "url": "https://github.com/litzenberger"
+    },
+    {
+      "name": "Cian Foley",
+      "url": "https://github.com/cianfoley-nearform"
+    },
+    {
+      "name": "Dara Hayes",
+      "url": "https://github.com/darahayes"
+    },
+    {
+      "name": "Andrew Cashmore",
+      "url": "https://github.com/andrewcashmore"
+    },
+    {
+      "name": "Dean McDonnell",
+      "url": "https://github.com/mcdonnelldean"
+    },
+    {
+      "name": "Paul Negrutiu",
+      "url": "https://github.com/floridemai"
+    },
+    {
+      "name": "Salman Mitha",
+      "url": "https://github.com/salmanm"
+    },
+    {
+      "name": "Michael O'Brien",
+      "url": "https://github.com/mobri3n"
+    },
+    {
+      "name": "Michele Capra",
+      "url": "https://github.com/piccoloaiutante"
+    },
+    {
+      "name": "Filippo De Santis",
+      "url": "https://github.com/p16"
+    },
+    {
+      "name": "Mihai Dima",
+      "url": "https://github.com/mihaidma"
+    },
+    {
+      "name": "Paolo Chiodi",
+      "url": "https://github.com/paolochiodi"
+    },
+    {
+      "name": "Brian Cameron",
+      "url": "https://github.com/bcameron"
+    },
+    {
+      "name": "Paolo Insogna",
+      "url": "https://github.com/ShogunPanda"
+    },
+    {
+      "name": "William Riley-Land",
+      "url": "https://github.com/ShogunPanda"
+    }
   ],
-  "homepage": "https://github.com/nearform/udaru#readme",
+  "homepage": "https://nearform.github.io/udaru",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nearform/udaru.git"

--- a/packages/udaru-hapi-plugin/package.json
+++ b/packages/udaru-hapi-plugin/package.json
@@ -23,7 +23,7 @@
       "url": "https://github.com/irelandm"
     },
     {
-      "name": "ron litzenberger",
+      "name": "Ron Litzenberger",
       "url": "https://github.com/litzenberger"
     },
     {

--- a/packages/udaru-hapi-plugin/package.json
+++ b/packages/udaru-hapi-plugin/package.json
@@ -6,23 +6,84 @@
   "author": "nearForm Ltd",
   "license": "MIT",
   "contributors": [
-    "Andrew Cashmore (https://github.com/andrewcashmore)",
-    "Damian Beresford (https://github.com/dberesford)",
-    "Dean McDonnell (https://github.com/mcdonnelldean)",
-    "Filippo De Santis (https://github.com/p16)",
-    "Florian Traverse (https://github.com/temsa)",
-    "Mihai Dima (https://github.com/mihaidma)",
-    "Paolo Chiodi (https://github.com/paolochiodi)",
-    "Paolo Insogna (https://github.com/ShogunPanda)",
-    "Paul Negrutiu (https://github.com/floridemai)",
-    "Mark Ireland (https://github.com/irelandm)",
-    "Michael O'Brien (https://github.com/mobri3n)",
-    "Michele Capra (https://github.com/piccoloaiutante)",
-    "Nicolas Herment (https://github.com/nherment)",
-    "Salman Mitha (https://github.com/salmanm)",
-    "William Riley-Land (https://github.com/wprl)"
+    {
+      "name": "Jimmy Mintzer",
+      "url": "https://github.com/jimmymintzer"
+    },
+    {
+      "name": "Nicolas Herment",
+      "url": "https://github.com/nherment"
+    },
+    {
+      "name": "Damian Beresford",
+      "url": "https://github.com/dberesford"
+    },
+    {
+      "name": "Mark Ireland",
+      "url": "https://github.com/irelandm"
+    },
+    {
+      "name": "ron litzenberger",
+      "url": "https://github.com/litzenberger"
+    },
+    {
+      "name": "Cian Foley",
+      "url": "https://github.com/cianfoley-nearform"
+    },
+    {
+      "name": "Dara Hayes",
+      "url": "https://github.com/darahayes"
+    },
+    {
+      "name": "Andrew Cashmore",
+      "url": "https://github.com/andrewcashmore"
+    },
+    {
+      "name": "Dean McDonnell",
+      "url": "https://github.com/mcdonnelldean"
+    },
+    {
+      "name": "Paul Negrutiu",
+      "url": "https://github.com/floridemai"
+    },
+    {
+      "name": "Salman Mitha",
+      "url": "https://github.com/salmanm"
+    },
+    {
+      "name": "Michael O'Brien",
+      "url": "https://github.com/mobri3n"
+    },
+    {
+      "name": "Michele Capra",
+      "url": "https://github.com/piccoloaiutante"
+    },
+    {
+      "name": "Filippo De Santis",
+      "url": "https://github.com/p16"
+    },
+    {
+      "name": "Mihai Dima",
+      "url": "https://github.com/mihaidma"
+    },
+    {
+      "name": "Paolo Chiodi",
+      "url": "https://github.com/paolochiodi"
+    },
+    {
+      "name": "Brian Cameron",
+      "url": "https://github.com/bcameron"
+    },
+    {
+      "name": "Paolo Insogna",
+      "url": "https://github.com/ShogunPanda"
+    },
+    {
+      "name": "William Riley-Land",
+      "url": "https://github.com/ShogunPanda"
+    }
   ],
-  "homepage": "https://github.com/nearform/udaru#readme",
+  "homepage": "https://nearform.github.io/udaru",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nearform/udaru.git"

--- a/packages/udaru-hapi-server/package.json
+++ b/packages/udaru-hapi-server/package.json
@@ -23,7 +23,7 @@
       "url": "https://github.com/irelandm"
     },
     {
-      "name": "ron litzenberger",
+      "name": "Ron Litzenberger",
       "url": "https://github.com/litzenberger"
     },
     {

--- a/packages/udaru-hapi-server/package.json
+++ b/packages/udaru-hapi-server/package.json
@@ -6,23 +6,84 @@
   "author": "nearForm Ltd",
   "license": "MIT",
   "contributors": [
-    "Andrew Cashmore (https://github.com/andrewcashmore)",
-    "Damian Beresford (https://github.com/dberesford)",
-    "Dean McDonnell (https://github.com/mcdonnelldean)",
-    "Filippo De Santis (https://github.com/p16)",
-    "Florian Traverse (https://github.com/temsa)",
-    "Mihai Dima (https://github.com/mihaidma)",
-    "Paolo Chiodi (https://github.com/paolochiodi)",
-    "Paolo Insogna (https://github.com/ShogunPanda)",
-    "Paul Negrutiu (https://github.com/floridemai)",
-    "Mark Ireland (https://github.com/irelandm)",
-    "Michael O'Brien (https://github.com/mobri3n)",
-    "Michele Capra (https://github.com/piccoloaiutante)",
-    "Nicolas Herment (https://github.com/nherment)",
-    "Salman Mitha (https://github.com/salmanm)",
-    "William Riley-Land (https://github.com/wprl)"
+    {
+      "name": "Jimmy Mintzer",
+      "url": "https://github.com/jimmymintzer"
+    },
+    {
+      "name": "Nicolas Herment",
+      "url": "https://github.com/nherment"
+    },
+    {
+      "name": "Damian Beresford",
+      "url": "https://github.com/dberesford"
+    },
+    {
+      "name": "Mark Ireland",
+      "url": "https://github.com/irelandm"
+    },
+    {
+      "name": "ron litzenberger",
+      "url": "https://github.com/litzenberger"
+    },
+    {
+      "name": "Cian Foley",
+      "url": "https://github.com/cianfoley-nearform"
+    },
+    {
+      "name": "Dara Hayes",
+      "url": "https://github.com/darahayes"
+    },
+    {
+      "name": "Andrew Cashmore",
+      "url": "https://github.com/andrewcashmore"
+    },
+    {
+      "name": "Dean McDonnell",
+      "url": "https://github.com/mcdonnelldean"
+    },
+    {
+      "name": "Paul Negrutiu",
+      "url": "https://github.com/floridemai"
+    },
+    {
+      "name": "Salman Mitha",
+      "url": "https://github.com/salmanm"
+    },
+    {
+      "name": "Michael O'Brien",
+      "url": "https://github.com/mobri3n"
+    },
+    {
+      "name": "Michele Capra",
+      "url": "https://github.com/piccoloaiutante"
+    },
+    {
+      "name": "Filippo De Santis",
+      "url": "https://github.com/p16"
+    },
+    {
+      "name": "Mihai Dima",
+      "url": "https://github.com/mihaidma"
+    },
+    {
+      "name": "Paolo Chiodi",
+      "url": "https://github.com/paolochiodi"
+    },
+    {
+      "name": "Brian Cameron",
+      "url": "https://github.com/bcameron"
+    },
+    {
+      "name": "Paolo Insogna",
+      "url": "https://github.com/ShogunPanda"
+    },
+    {
+      "name": "William Riley-Land",
+      "url": "https://github.com/ShogunPanda"
+    }
   ],
-  "homepage": "https://github.com/nearform/udaru#readme",
+  "homepage": "https://nearform.github.io/udaru",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nearform/udaru.git"


### PR DESCRIPTION
Also updated the `homepage` links. 
Note this list was authgenerated using https://www.npmjs.com/package/contributor.

Would be much easier to maintain going forward to just have a `contributors.md` file in the root package. 