### PR TITLE
node 10 check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - '6'
   - '8'
+  - '10'
 
 dist: trusty
 sudo: required

--- a/packages/udaru-core/.labrc.js
+++ b/packages/udaru-core/.labrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    coverage: true,
+    threshold: 90,
+    globals: 'URL,URLSearchParams' //ignoring for node 10 with lab 14 (not udaru test issue), remove when lab upgraded to 15
+}

--- a/packages/udaru-core/package.json
+++ b/packages/udaru-core/package.json
@@ -112,13 +112,13 @@
     "udaru-init": "./database/init.js"
   },
   "scripts": {
-    "coverage": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 90 -r html -o coverage/coverage.html",
-    "coveralls": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 90 -r lcov | coveralls",
+    "coverage": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -r html -o coverage/coverage.html",
+    "coveralls": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -r lcov | coveralls",
     "depcheck": "npx depcheck",
     "pg:init": "node ./database/init.js && npm run pg:migrate",
     "pg:init-test-db": "npm run pg:init && node ./database/loadTestData.js",
     "pg:migrate": "node ./database/migrate.js --version=max",
-    "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 90"
+    "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab"
   },
   "dependencies": {
     "@nearform/sql": "^1.0.1",

--- a/packages/udaru-hapi-16-plugin/.labrc.js
+++ b/packages/udaru-hapi-16-plugin/.labrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+    coverage: true,
+    threshold: 96,
+    globals: 'URL,URLSearchParams' //ignoring for node 10 with lab 14 (not udaru test issue), remove when lab upgraded to 15
+}

--- a/packages/udaru-hapi-16-plugin/package.json
+++ b/packages/udaru-hapi-16-plugin/package.json
@@ -108,13 +108,13 @@
     "hapi"
   ],
   "scripts": {
-    "coverage": "UDARU_SERVICE_logger_pino_level=silent lab -c -t 96 -r html -o coverage/coverage.html",
-    "coveralls": "UDARU_SERVICE_logger_pino_level=silent lab -c -t 96 -r lcov | COVERALLS_REPO_TOKEN='?' coveralls",
+    "coverage": "UDARU_SERVICE_logger_pino_level=silent lab -r html -o coverage/coverage.html",
+    "coveralls": "UDARU_SERVICE_logger_pino_level=silent lab -r lcov | COVERALLS_REPO_TOKEN='?' coveralls",
     "depcheck": "npx depcheck",
     "pg:init": "npx --no-install udaru-init && npm run pg:migrate",
     "pg:init-test-db": "npm run pg:init && npx --no-install udaru-loadTestData",
     "pg:migrate": "npx --no-install udaru-migrate --version=max",
-    "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 96"
+    "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab"
   },
   "dependencies": {
     "@nearform/udaru-core": "^5.0.1-beta.0",
@@ -131,7 +131,7 @@
     "depcheck": "^0.6.9",
     "hapi": "^16.6.2",
     "lab": "^14.3.2",
-    "npx": "^10.0.1",
+    "npx": "^10.2.0",
     "sinon": "^4.5.0",
     "uuid": "^3.2.1"
   }

--- a/packages/udaru-hapi-plugin/.labrc.js
+++ b/packages/udaru-hapi-plugin/.labrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+    coverage: true,
+    threshold: 96
+}

--- a/packages/udaru-hapi-plugin/package.json
+++ b/packages/udaru-hapi-plugin/package.json
@@ -108,14 +108,14 @@
     "hapi"
   ],
   "scripts": {
-    "coverage": "UDARU_SERVICE_logger_pino_level=silent lab -c -t 96 -r html -o coverage/coverage.html",
-    "coveralls": "UDARU_SERVICE_logger_pino_level=silent lab -c -t 96 -r lcov | COVERALLS_REPO_TOKEN='?' coveralls",
+    "coverage": "UDARU_SERVICE_logger_pino_level=silent lab -r html -o coverage/coverage.html",
+    "coveralls": "UDARU_SERVICE_logger_pino_level=silent lab -r lcov | COVERALLS_REPO_TOKEN='?' coveralls",
     "depcheck": "npx depcheck",
     "pg:init": "npx --no-install udaru-init && npm run pg:migrate",
     "pg:init-test-db": "npm run pg:init && npx --no-install udaru-loadTestData",
     "pg:migrate": "npx --no-install udaru-migrate --version=max",
     "test-6": "echo '\\033[33mudaru-hapi-plugin requires Node.js greater than 8.9.0. Exiting without errors.\\033[0m'",
-    "test-current": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -c -t 96",
+    "test-current": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab",
     "test": "npm run test-$(node -v | grep '^v6' >> /dev/null && echo '6' || echo 'current')"
   },
   "dependencies": {


### PR DESCRIPTION
I ran into issues here with global leaks in core and hapi-16-plugin, we don't have the issue when using lab15 with hapi 17. I tried upgrading dependencies etc, and I removed all tests and the leaks were still occurring so it doesn't seem to be a runtime udaru issue but rather some issue with node10/lab14/dependencies.  I've put in two globals for the items URL & URLSearchParams into .labrc.js files to bypass... these should be removed once lab is upgrade for core and hapi-16, they're not necessary for hapi 17 plugin, which uses lab 15+
I've taken the command line args from package.json lab entries (except for coverage docs) in favour of using labrc.js file for consistency (there's no point having global exclusions polluting package.json files)