### PR TITLE
allow underscores on id fields for backward compatibility

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,10 +34,10 @@ We are currently supporting node 6 and 8.
 8.  In the order of dependencies above, for each package:
     -   Run `npm install` and verify that root level and package dependencies correctly install.
     -   Run `npm test` to verify the tests run locally within their own context (something that's not done by CI)
-9. Run `npm run swagger-gen` to regenerate the Swagger documentation for the Udaru [documentation site][docs-site].
+9.  Run `npm run swagger-gen` to regenerate the Swagger documentation for the Udaru [documentation site][docs-site].
     -   Run `git add` and `git commit` to commit any version and documentation changes if there are any.
 10. Finally, from root, log in to npm using `npm login`, run `lerna publish` and choose the approriate version change type.  This will update each  package.json of modified packages as appropriate, create a new git commit and tag, and publish updated packages to npm.
-    - Update root package.json to the correct version number and commit
+    -   Update root package.json to the correct version number and commit
 11. Go to the [Github release page][Releases] and hit 'Draft a new release'.
 12. Paste the Changelog content for this release and add additional release notes.
 13. Choose the tag version and a title matching the release and publish.

--- a/docs/example.md
+++ b/docs/example.md
@@ -18,7 +18,6 @@ Note that it's also possible to follow the example below using the live Swagger 
 
 ```bash
 curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'authorization: ROOTid' -d '{"id":"WayneManor","name":"Wayne Manor","description":"Wayne Manor Organisation","user":{"id":"BruceWayne","name":"Bruce Wayne"}}' 'http://localhost:8080/authorization/organizations'
-
 ```
 
 Response:
@@ -44,10 +43,33 @@ This creates our Organization, and one super user, 'Bruce Wayne'. We can verify 
 curl -X GET --header 'Accept: application/json' --header 'authorization: ROOTid' 'http://localhost:8080/authorization/organizations'
 ```
 
+```javascript
+..
+  {
+      "name": "Wayne Manor",
+      "description": "Wayne Manor Organisation"
+  }
+..
+```
+
 and also verify our 'Bruce Wayne' user exists with:
 
 ```bash
-curl -X GET --header 'Accept: application/json' --header 'authorization: ROOTid' 'http://localhost:8080/authorization/users'
+curl -X GET --header 'Accept: application/json' --header 'authorization: BruceWayne' 'http://localhost:8080/authorization/users'
+```
+
+```javascript
+{
+  "page": 1,
+  "limit": 100,
+  "total": 1,
+  "data": [
+    {
+      "name": "Bruce Wayne",
+      "organizationId": "WayneManor"
+    }
+  ]
+}
 ```
 
 and that he is Admin:
@@ -66,7 +88,8 @@ curl -X GET --header 'Accept: application/json' --header 'authorization: BruceWa
     {
       "id": "132a2c88-3d00-43af-8318-540405874dfb",
       "name": "WayneManor admin",
-      "version": "1"
+      "version": "1",
+      "variables": {}
     }
   ]
 }
@@ -84,9 +107,28 @@ As Bruce Wayne, let's create some more users:
 
 ```shell
 curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'authorization: BruceWayne'  -d '{"id":"Alfred","name":"Alfred the butler"}' 'http://localhost:8080/authorization/users'
+```
 
+```javascript
+{
+  "name": "Alfred the butler",
+  "organizationId": "WayneManor",
+  "teams": [],
+  "policies": []
+}
+```
+
+```shell
 curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'authorization: BruceWayne'  -d '{"id":"Joker","name":"The Joker"}' 'http://localhost:8080/authorization/users'
+```
 
+```javascript
+{
+  "name": "The Joker",
+  "organizationId": "WayneManor",
+  "teams": [],
+  "policies": []
+}
 ```
 
 At this point, Alfred has been created, but is not in a team nor does he have any policies:
@@ -178,7 +220,8 @@ curl -X GET --header 'Accept: application/json' --header 'authorization: BruceWa
     {
       "id": "AccessBatCave",
       "name": "batcave",
-      "version": "1"
+      "version": "1",
+      "variables": {}
     }
   ]
 }
@@ -244,17 +287,20 @@ curl -X GET --header 'Accept: application/json' --header 'authorization: BruceWa
     {
       "id": "AccessBatCave",
       "name": "batcave",
-      "version": "1"
+      "version": "1",
+      "variables": {}
     },
     {
       "id": "DenyBatcomputer",
       "name": "batcomputer",
-      "version": "1"
+      "version": "1",
+      "variables": {}
     },
     {
       "id": "DriveBatmobile",
       "name": "batmobile",
-      "version": "1"
+      "version": "1",
+      "variables": {}
     }
   ]
 }
@@ -414,7 +460,7 @@ curl -X GET --header 'Accept: application/json' --header 'authorization: BruceWa
 Now let's create a policy that will allow access to the Amazons meeting room in the BatCave - note again as above, this is not the recommended way of creating policies!
 
 ```bash
-curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'authorization: ROOTid' --header 'org: WayneManor' -d '{"id":"AccessAmazonMeetingRoom","name":"amazon meeting room","version":"1","statements":{"Statement":[{"Effect":"Allow","Action":["enter","exit"],"Resource":["/waynemanor/batcave/amazon_meeting_room"],"Sid":"1","Condition":{}}]}}' 'http://localhost:8080/authorization/policies?sig=123456789'
+curl -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' --header 'authorization: ROOTid' --header 'org: WayneManor' -d '{"id":"AccessAmazonMeetingRoom","name":"amazon meeting room","version":"1","statements":{"Statement":[{"Effect":"Allow","Action":["enter","exit"],"Resource":["/waynemanor/batcave/amazon-meeting-room"],"Sid":"1","Condition":{}}]}}' 'http://localhost:8080/authorization/policies?sig=123456789'
 ```
 
 And let's add this policy to the `Amazons` team:
@@ -449,16 +495,16 @@ curl -X PUT --header 'Content-Type: application/json' --header 'Accept: applicat
 }
 ```
 
-Let's see what Actions `Wonder Woman` can perform on `/waynemanor/batcave/amazon_meeting_room`:
+Let's see what Actions `Wonder Woman` can perform on `/waynemanor/batcave/amazon-meeting-room`:
 
 ```bash
-curl -X GET --header 'Accept: application/json' --header 'authorization: ROOTid' --header 'org: WayneManor' 'http://localhost:8080/authorization/list/wonder-woman?resources=%2Fwaynemanor%2Fbatcave%2Famazon_meeting_room'
+curl -X GET --header 'Accept: application/json' --header 'authorization: ROOTid' --header 'org: WayneManor' 'http://localhost:8080/authorization/list/wonder-woman?resources=%2Fwaynemanor%2Fbatcave%2Famazon-meeting-room'
 ```
 
 ```js
 [
   {
-    "resource": "/waynemanor/batcave/amazon_meeting_room",
+    "resource": "/waynemanor/batcave/amazon-meeting-room",
     "actions": [
       "enter",
       "exit"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "udaru",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "A policy based authorization module",
   "license": "MIT",
   "author": "nearForm Ltd",

--- a/packages/udaru-core/database/migrations/009.do.sql
+++ b/packages/udaru-core/database/migrations/009.do.sql
@@ -1,4 +1,6 @@
-ALTER TABLE organizations ADD CONSTRAINT valid_chars CHECK (id SIMILAR TO '[A-Za-z0-9-]+');
-ALTER TABLE users ADD CONSTRAINT valid_chars CHECK (id SIMILAR TO '[A-Za-z0-9-]+');
-ALTER TABLE teams ADD CONSTRAINT valid_chars CHECK (id SIMILAR TO '[A-Za-z0-9-]+');
-ALTER TABLE policies ADD CONSTRAINT valid_chars CHECK (id SIMILAR TO '[A-Za-z0-9-]+');
+ALTER TABLE organizations ADD CONSTRAINT valid_chars CHECK (id SIMILAR TO '[A-Za-z0-9_-]+');
+ALTER TABLE users ADD CONSTRAINT valid_chars CHECK (id SIMILAR TO '[A-Za-z0-9_-]+');
+ALTER TABLE teams ADD CONSTRAINT valid_chars CHECK (id SIMILAR TO '[A-Za-z0-9_-]+');
+ALTER TABLE policies ADD CONSTRAINT valid_chars CHECK (id SIMILAR TO '[A-Za-z0-9_-]+');
+
+ALTER TABLE teams ADD CONSTRAINT unique_path UNIQUE (path);

--- a/packages/udaru-core/database/migrations/009.undo.sql
+++ b/packages/udaru-core/database/migrations/009.undo.sql
@@ -2,3 +2,5 @@ ALTER TABLE organizations DROP CONSTRAINT valid_chars;
 ALTER TABLE users DROP CONSTRAINT valid_chars;
 ALTER TABLE teams DROP CONSTRAINT valid_chars;
 ALTER TABLE policies DROP CONSTRAINT valid_chars;
+
+ALTER TABLE teams DROP CONSTRAINT unique_path;

--- a/packages/udaru-core/lib/mapping.js
+++ b/packages/udaru-core/lib/mapping.js
@@ -141,7 +141,7 @@ function mapNestedTeam (row) {
     name: row.name,
     description: row.description,
     parentId: row.parent_id,
-    path: row.path,
+    path: pathToId(row.path),
     organizationId: row.org_id,
     usersCount: parseInt(row.users_count, 10)
   }

--- a/packages/udaru-core/lib/ops/validation.js
+++ b/packages/udaru-core/lib/ops/validation.js
@@ -3,7 +3,7 @@
 const Joi = require('joi')
 
 const requiredString = Joi.string().required()
-const requiredStringId = Joi.string().regex(/^[A-Za-z0-9-]+$/).required().max(128)
+const requiredStringId = Joi.string().regex(/^[A-Za-z0-9_-]+$/).required().max(128)
 const MetaData = Joi.object().optional().description('Metadata').label('MetaData')
 
 const PolicyIdString = requiredStringId.description('Policy Id String').label('PolicyIdString')

--- a/packages/udaru-core/test/integration/organizationOps.test.js
+++ b/packages/udaru-core/test/integration/organizationOps.test.js
@@ -133,7 +133,7 @@ lab.experiment('OrganizationOps', () => {
     udaru.organizations.create(organizationData, { createOnly: true }, (err, result) => {
       expect(err).to.exist()
       expect(err.output.statusCode).to.equal(400)
-      expect(err.message).to.equal('child "id" fails because ["id" with value "invalid?id" fails to match the required pattern: /^[A-Za-z0-9-]+$/]')
+      expect(err.message).to.equal('child "id" fails because ["id" with value "invalid?id" fails to match the required pattern: /^[A-Za-z0-9_-]+$/]')
 
       done()
     })

--- a/packages/udaru-core/test/integration/policyOps.test.js
+++ b/packages/udaru-core/test/integration/policyOps.test.js
@@ -145,7 +145,7 @@ lab.experiment('PolicyOps', () => {
     udaru.policies.create(policyData, (err, policy) => {
       expect(err).to.exist()
       expect(err.output.statusCode).to.equal(400)
-      expect(err.message).to.equal('child "id" fails because ["id" with value "invalid?=id" fails to match the required pattern: /^[A-Za-z0-9-]+$/]')
+      expect(err.message).to.equal('child "id" fails because ["id" with value "invalid?=id" fails to match the required pattern: /^[A-Za-z0-9_-]+$/]')
 
       done()
     })

--- a/packages/udaru-core/test/integration/userOps.test.js
+++ b/packages/udaru-core/test/integration/userOps.test.js
@@ -136,7 +136,7 @@ lab.experiment('UserOps', () => {
     udaru.users.create(userData, (err, result) => {
       expect(err).to.exist()
       expect(err.output.statusCode).to.equal(400)
-      expect(err.message).to.equal('child "id" fails because ["id" with value "id & with \\ invalid $ chars" fails to match the required pattern: /^[A-Za-z0-9-]+$/]')
+      expect(err.message).to.equal('child "id" fails because ["id" with value "id & with \\ invalid $ chars" fails to match the required pattern: /^[A-Za-z0-9_-]+$/]')
 
       done()
     })


### PR DESCRIPTION
underscores now whitelisted in all fields to cater for backward compatibility for teams in particular (as underscores were previously enforced).  

Migration script updated with regex to cater for underscore and also validation.js in core updated too for all ids

As team paths only allow underscores and alphanumerics (ltree restriction), we must convert hyphens in ids to underscores in the path.  this may cause clashes and undesired behaviour so an extra constraint was added to ensure path is unique in migration script. 

a test case was added to ensure the database cannot contain two teams with the same path when ids with hypens and underscores convert to to the same path.

paths will be returned with hypens from a user perspective (for easier use of API when we eventually expose calls that use the path), as our default id separator is hyphen (a bug relating to this was fixed in nested teams)

Updated some formatting in overview, and fixed problems in example.md