### PR TITLE
Organization & teams create callback handling

### DIFF
--- a/packages/udaru-core/lib/ops/organizationOps.js
+++ b/packages/udaru-core/lib/ops/organizationOps.js
@@ -306,8 +306,10 @@ function buildOrganizationOps (db, config) {
      * @param  {Function} cb
      */
     create: function create (params, opts, cb) {
-      if (!cb && typeof opts === 'function') {
+      if (!cb) {
         cb = opts
+      }
+      if (!opts || typeof opts === 'function') {
         opts = {}
       }
 

--- a/packages/udaru-core/lib/ops/organizationOps.js
+++ b/packages/udaru-core/lib/ops/organizationOps.js
@@ -306,7 +306,7 @@ function buildOrganizationOps (db, config) {
      * @param  {Function} cb
      */
     create: function create (params, opts, cb) {
-      if (!cb) {
+      if (!cb && typeof opts === 'function') {
         cb = opts
         opts = {}
       }

--- a/packages/udaru-core/lib/ops/teamOps.js
+++ b/packages/udaru-core/lib/ops/teamOps.js
@@ -434,7 +434,7 @@ function buildTeamOps (db, config) {
      * @param  {Function} cb
      */
     createTeam: function createTeam (params, opts, cb) {
-      if (!cb) {
+      if (!cb && typeof opts === 'function') {
         cb = opts
         opts = {}
       }

--- a/packages/udaru-core/lib/ops/teamOps.js
+++ b/packages/udaru-core/lib/ops/teamOps.js
@@ -434,8 +434,10 @@ function buildTeamOps (db, config) {
      * @param  {Function} cb
      */
     createTeam: function createTeam (params, opts, cb) {
-      if (!cb && typeof opts === 'function') {
+      if (!cb) {
         cb = opts
+      }
+      if (!opts || typeof opts === 'function') {
         opts = {}
       }
 

--- a/packages/udaru-core/test/integration/organizationOps.test.js
+++ b/packages/udaru-core/test/integration/organizationOps.test.js
@@ -103,6 +103,26 @@ lab.experiment('OrganizationOps', () => {
     })
   })
 
+  lab.test('create an organization (and delete it) with createOnly option and using promise', (done) => {
+    const organizationData = {
+      id: 'nearForm',
+      name: 'nearForm',
+      description: 'nearForm description'
+    }
+    udaru.organizations.create(organizationData, { createOnly: true }).then(result => {
+      expect(result.organization).to.exist()
+      expect(result.organization.name).to.equal('nearForm')
+
+      udaru.policies.list({organizationId: 'nearForm'}, (err, res) => {
+        expect(err).to.not.exist()
+        expect(res).to.exist()
+        expect(res).to.be.empty()
+
+        udaru.organizations.delete(result.organization.id, done)
+      })
+    })
+  })
+
   lab.test('create twice an organization with the same id should fail second time', (done) => {
     const organizationData = {
       id: 'nearForm',

--- a/packages/udaru-core/test/integration/teamOps.test.js
+++ b/packages/udaru-core/test/integration/teamOps.test.js
@@ -284,6 +284,31 @@ lab.experiment('TeamOps', () => {
     })
   })
 
+  lab.test('creating a team with createOnly option and using promise', (done) => {
+    let testTeam = {
+      name: 'test::teamOps:+only:' + randomId(),
+      description: 'description',
+      organizationId: 'WONKA'
+    }
+
+    udaru.teams.create(testTeam, { createOnly: true }).then(result => {
+      expect(result).to.exist()
+      expect(result.id).to.exist()
+      testTeam.id = result.id // afterEach will cleanup based on the ID
+
+      udaru.policies.list({ organizationId: 'WONKA' }, (err, policies) => {
+        udaru.teams.delete(testTeam, (err) => { if (err) throw err })
+        expect(err).to.not.exist()
+
+        const defaultPolicy = policies.find((p) => {
+          return p.name === 'Default Team Admin for ' + testTeam.id
+        })
+        expect(defaultPolicy).to.not.exist()
+        done()
+      })
+    })
+  })
+
   lab.test('creating a team with the same id should fail second time', (done) => {
     let testTeam = {
       id: 'nearForm',


### PR DESCRIPTION
Hi @mihaidma 

Just a small PR for Udaru.
I had a small issue where calling:
```
await udaru.organizations.create(organization, { createOnly: true })
```
would ignore my 2 param `{ createOnly: true }`.

My current working workaround is:
```
await udaru.organizations.create(organization, { createOnly: true }, true)
```
to skip the missing callback check.

But I thought I would contribute back to fix this small issue.
Let me know if you have any question.