### PR TITLE
replace nullable sql field params

### DIFF
--- a/packages/udaru-core/lib/ops/organizationOps.js
+++ b/packages/udaru-core/lib/ops/organizationOps.js
@@ -126,7 +126,7 @@ function buildOrganizationOps (db, config) {
         id, name, description, metadata
       )
       VALUES (
-        ${id}, ${name}, ${description}, ${metadata} 
+        ${id}, ${name}, ${description}, ${metadata || null} 
       )
       RETURNING id
     `
@@ -415,7 +415,7 @@ function buildOrganizationOps (db, config) {
           SET
             name = ${name},
             description = ${description},
-            metadata = ${metadata}
+            metadata = ${metadata || null}
           WHERE id = ${id}
         `
         db.query(sqlQuery, function (err, result) {

--- a/packages/udaru-core/lib/ops/teamOps.js
+++ b/packages/udaru-core/lib/ops/teamOps.js
@@ -50,8 +50,8 @@ function buildTeamOps (db, config) {
         ${teamId.toString()},
         ${job.params.name},
         ${job.params.description},
-        ${job.params.metadata},
-        ${job.params.parentId},
+        ${job.params.metadata || null},
+        ${job.params.parentId || null},
         ${job.params.organizationId},
       `
     if (job.params.parentId) {

--- a/packages/udaru-core/lib/ops/userOps.js
+++ b/packages/udaru-core/lib/ops/userOps.js
@@ -359,7 +359,7 @@ function buildUserOps (db, config) {
         const sqlQuery = SQL`
           UPDATE users
           SET name = ${name},
-          metadata = ${metadata}
+          metadata = ${metadata || null}
           WHERE id = ${id}
           AND org_id = ${organizationId}
         `
@@ -607,7 +607,7 @@ function buildUserOps (db, config) {
         INSERT INTO users (
           id, name, org_id, metadata
         ) VALUES (
-          ${id}, ${name}, ${organizationId}, ${metadata}
+          ${id}, ${name}, ${organizationId}, ${metadata || null}
         )
         RETURNING id
       `


### PR DESCRIPTION
Replace `undefined` params with `null` before constructing the `SQL` object.
This prevents throwing an error from inside `@nearform/sql` >= v1.3.1.

Fixes issue #565 