### PR TITLE
remove bin ref to non-existing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,9 +94,6 @@
   "bugs": {
     "url": "https://github.com/nearform/udaru/issues"
   },
-  "bin": {
-    "udaru": "packages/udaru-server/index.js"
-  },
   "engines": {
     "node": ">=6.0.0"
   },


### PR DESCRIPTION
Removes an invalid bin reference to a non-existent package as commented in issue #417.
Probably stayed there after v4.x => v5.x.