### PR TITLE
Audit packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "doc:lint": "remark .",
     "start": "node packages/udaru-hapi-server/index.js",
     "test": "lerna run test",
+    "test:audit": "lerna run audit",
     "test:example": "cd packages/udaru-hapi-server && npm run test:example",
     "test:commit-check": "npm run doc:lint && npm run lint && npm run depcheck && npm run test && npm run test:example",
     "test:security": "cd packages/udaru-hapi-server && npm run test:security",

--- a/packages/udaru-core/package.json
+++ b/packages/udaru-core/package.json
@@ -112,6 +112,7 @@
     "udaru-init": "./database/init.js"
   },
   "scripts": {
+    "audit": "npm i --package-lock-only && npm audit",
     "coverage": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -r html -o coverage/coverage.html",
     "coveralls": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -r lcov | coveralls",
     "depcheck": "depcheck",

--- a/packages/udaru-core/package.json
+++ b/packages/udaru-core/package.json
@@ -114,7 +114,7 @@
   "scripts": {
     "coverage": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -r html -o coverage/coverage.html",
     "coveralls": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -r lcov | coveralls",
-    "depcheck": "npx depcheck",
+    "depcheck": "depcheck",
     "pg:init": "node ./database/init.js && npm run pg:migrate",
     "pg:init-test-db": "npm run pg:init && node ./database/loadTestData.js",
     "pg:migrate": "node ./database/migrate.js --version=max",
@@ -140,7 +140,6 @@
     "depcheck": "^0.7.1",
     "lab": "^14.3.2",
     "minimist": "^1.2.0",
-    "npx": "^10.0.1",
     "sinon": "^7.1.1"
   },
   "publishConfig": {

--- a/packages/udaru-hapi-16-plugin/package.json
+++ b/packages/udaru-hapi-16-plugin/package.json
@@ -110,10 +110,10 @@
   "scripts": {
     "coverage": "UDARU_SERVICE_logger_pino_level=silent lab -r html -o coverage/coverage.html",
     "coveralls": "UDARU_SERVICE_logger_pino_level=silent lab -r lcov | COVERALLS_REPO_TOKEN='?' coveralls",
-    "depcheck": "npx depcheck",
-    "pg:init": "npx --no-install udaru-init && npm run pg:migrate",
-    "pg:init-test-db": "npm run pg:init && npx --no-install udaru-loadTestData",
-    "pg:migrate": "npx --no-install udaru-migrate --version=max",
+    "depcheck": "depcheck",
+    "pg:init": "udaru-init && npm run pg:migrate",
+    "pg:init-test-db": "npm run pg:init && udaru-loadTestData",
+    "pg:migrate": "udaru-migrate --version=max",
     "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab"
   },
   "dependencies": {
@@ -131,7 +131,6 @@
     "depcheck": "^0.7.1",
     "hapi": "^16.6.2",
     "lab": "^14.3.2",
-    "npx": "^10.2.0",
     "sinon": "^7.1.1",
     "uuid": "^3.2.1"
   },

--- a/packages/udaru-hapi-16-plugin/package.json
+++ b/packages/udaru-hapi-16-plugin/package.json
@@ -108,6 +108,7 @@
     "hapi"
   ],
   "scripts": {
+    "audit": "npm i --package-lock-only && npm audit",
     "coverage": "UDARU_SERVICE_logger_pino_level=silent lab -r html -o coverage/coverage.html",
     "coveralls": "UDARU_SERVICE_logger_pino_level=silent lab -r lcov | COVERALLS_REPO_TOKEN='?' coveralls",
     "depcheck": "depcheck",

--- a/packages/udaru-hapi-plugin/package.json
+++ b/packages/udaru-hapi-plugin/package.json
@@ -108,6 +108,7 @@
     "hapi"
   ],
   "scripts": {
+    "audit": "npm i --package-lock-only && npm audit",
     "coverage": "UDARU_SERVICE_logger_pino_level=silent lab -r html -o coverage/coverage.html",
     "coveralls": "UDARU_SERVICE_logger_pino_level=silent lab -r lcov | COVERALLS_REPO_TOKEN='?' coveralls",
     "depcheck": "depcheck",

--- a/packages/udaru-hapi-plugin/package.json
+++ b/packages/udaru-hapi-plugin/package.json
@@ -110,10 +110,10 @@
   "scripts": {
     "coverage": "UDARU_SERVICE_logger_pino_level=silent lab -r html -o coverage/coverage.html",
     "coveralls": "UDARU_SERVICE_logger_pino_level=silent lab -r lcov | COVERALLS_REPO_TOKEN='?' coveralls",
-    "depcheck": "npx depcheck",
-    "pg:init": "npx --no-install udaru-init && npm run pg:migrate",
-    "pg:init-test-db": "npm run pg:init && npx --no-install udaru-loadTestData",
-    "pg:migrate": "npx --no-install udaru-migrate --version=max",
+    "depcheck": "depcheck",
+    "pg:init": "udaru-init && npm run pg:migrate",
+    "pg:init-test-db": "npm run pg:init && udaru-loadTestData",
+    "pg:migrate": "udaru-migrate --version=max",
     "test-6": "echo '\\033[33mudaru-hapi-plugin requires Node.js greater than 8.9.0. Exiting without errors.\\033[0m'",
     "test-current": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab",
     "test": "npm run test-$(node -v | grep '^v6' >> /dev/null && echo '6' || echo 'current')"
@@ -131,7 +131,6 @@
     "coveralls": "^3.0.2",
     "depcheck": "^0.7.1",
     "lab": "^18.0.0",
-    "npx": "^10.2.0",
     "sinon": "^7.1.1",
     "uuid": "^3.3.2"
   },

--- a/packages/udaru-hapi-server/package.json
+++ b/packages/udaru-hapi-server/package.json
@@ -114,11 +114,11 @@
     "bench:volume": "node ./bench/util/volumeRunner.js",
     "bench:load-volume": "npm run pg:init-volume-db && node ./bench/util/volumeRunner.js",
     "coverage": "echo  ️",
-    "depcheck": "npx depcheck",
-    "pg:init": "npx --no-install udaru-init && npm run pg:migrate",
-    "pg:init-test-db": "npm run pg:init && npx --no-install udaru-loadTestData",
+    "depcheck": "depcheck",
+    "pg:init": "udaru-init && npm run pg:migrate",
+    "pg:init-test-db": "npm run pg:init && udaru-loadTestData",
     "pg:init-volume-db": "npm run pg:init-test-db && ./bench/util/loadVolumeData.js",
-    "pg:migrate": "npx --no-install udaru-migrate --version=max",
+    "pg:migrate": "udaru-migrate --version=max",
     "start": "node ./index.js",
     "test": "echo ",
     "pretest:security": "napa sqlmapproject/sqlmap",
@@ -156,7 +156,6 @@
     "lodash": "^4.17.5",
     "minimist": "^1.2.0",
     "napa": "^3.0.0",
-    "npx": "^10.0.1",
     "pg": "^7.4.1"
   },
   "standard": {

--- a/packages/udaru-hapi-server/package.json
+++ b/packages/udaru-hapi-server/package.json
@@ -110,6 +110,7 @@
     "acl"
   ],
   "scripts": {
+    "audit": "npm i --package-lock-only && npm audit",
     "bench": "node ./bench/util/runner.js",
     "bench:volume": "node ./bench/util/volumeRunner.js",
     "bench:load-volume": "npm run pg:init-volume-db && node ./bench/util/volumeRunner.js",


### PR DESCRIPTION
This removes `npx` from the dependencies since it is not needed.
Therefore also fixes about 43 vulnerability issues.

Also adds a new script to run `npm audit` for each package.

`npm run test:audit`

See issue #537 