### PR TITLE
Config mono-repo greenkeeper

### DIFF
--- a/greenkeeper.json
+++ b/greenkeeper.json
@@ -1,0 +1,16 @@
+{
+  "groups": {
+    "core": {
+      "packages": [
+        "packages/udaru-core/package.json"
+      ]
+    },
+    "hapi": {
+      "packages": [
+        "packages/udaru-hapi-16-plugin/package.json",
+        "packages/udaru-hapi-plugin/package.json",
+        "packages/udaru-hapi-server/package.json"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The `greenkeeper.json` is needed to configure Greenkeeper for mono-repos.
Let's enable GK on this repo and see if config lands well.

See issue #511 