### PR TITLE
Deprecate Node v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - '6'
   - '8'
   - '10'
   - '12'

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -19,7 +19,7 @@ Udaru consists of 4 individual packages. While they are all published in their o
 
 Be mindful of these dependencies when publishing, i.e. if you publish a new version of `udaru-core` you need to bump all the other packages also.
 
-We are currently supporting node 6, 8, 10 and 12.
+We are currently supporting node 8, 10 and 12.
 
 1.  Review github issues, triage, close and merge issues related to the release.
 1.  Update the CHANGES.md file.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "url": "https://github.com/nearform/udaru/issues"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.9.0"
   },
   "keywords": [
     "access",

--- a/packages/udaru-core/package.json
+++ b/packages/udaru-core/package.json
@@ -91,7 +91,7 @@
     "url": "https://github.com/nearform/udaru/issues"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.9.0"
   },
   "keywords": [
     "access",

--- a/packages/udaru-hapi-16-plugin/package.json
+++ b/packages/udaru-hapi-16-plugin/package.json
@@ -92,7 +92,7 @@
     "url": "https://github.com/nearform/udaru/issues"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.9.0"
   },
   "keywords": [
     "access",
@@ -127,7 +127,7 @@
     "lodash": "^4.17.5"
   },
   "devDependencies": {
-    "code": "^4.0.0",
+    "code": "^5.2.4",
     "coveralls": "^3.0.0",
     "depcheck": "^0.8.1",
     "hapi": "^18.1.0",

--- a/packages/udaru-hapi-plugin/package.json
+++ b/packages/udaru-hapi-plugin/package.json
@@ -115,9 +115,7 @@
     "pg:init": "udaru-init && npm run pg:migrate",
     "pg:init-test-db": "npm run pg:init && udaru-loadTestData",
     "pg:migrate": "udaru-migrate --version=max",
-    "test-6": "echo '\\033[33mudaru-hapi-plugin requires Node.js greater than 8.9.0. Exiting without errors.\\033[0m'",
-    "test-current": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab",
-    "test": "npm run test-$(node -v | grep '^v6' >> /dev/null && echo '6' || echo 'current')"
+    "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab"
   },
   "dependencies": {
     "@nearform/udaru-core": "^5.2.4",

--- a/packages/udaru-hapi-server/package.json
+++ b/packages/udaru-hapi-server/package.json
@@ -121,12 +121,10 @@
     "pg:init-volume-db": "npm run pg:init-test-db && ./bench/util/loadVolumeData.js",
     "pg:migrate": "udaru-migrate --version=max",
     "start": "node ./index.js",
-    "test": "npm run test:example-$(node -v | grep '^v6' >> /dev/null && echo '6' || echo 'current')",
+    "test": "npm run test:example",
     "pretest:security": "napa sqlmapproject/sqlmap",
     "test:security": "node ./security/runner.js",
-    "test:example-6": "echo '\\033[33mtest:example requires Node.js greater than 8.9.0. Exiting without errors.\\033[0m'",
-    "test:example-current": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -m 10000",
-    "test:example": "npm run test:example-$(node -v | grep '^v6' >> /dev/null && echo '6' || echo 'current')"
+    "test:example": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab -m 10000"
   },
   "remarkConfig": {
     "plugins": [

--- a/packages/udaru-hapi-server/package.json
+++ b/packages/udaru-hapi-server/package.json
@@ -95,7 +95,7 @@
     "udaru": "index.js"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.9.0"
   },
   "keywords": [
     "access",


### PR DESCRIPTION
Drops support for Node v6 by: 
- changing minimum version to v8
- upgrading dependencies
- change test commands
- updating docs