### PR TITLE
Fix reconfig functions

### DIFF
--- a/packages/udaru-core/config.js
+++ b/packages/udaru-core/config.js
@@ -147,5 +147,9 @@ module.exports = (...amendments) => {
     }
   })
 
+  // fix auth resource functions (since v3.3.0 reconfig drops functions and replaces them with an empty object)
+  const resources = (reconfig._rawConfig.AuthConfig || {}).resources
+  if (resources) { reconfig._config.AuthConfig.resources = resources }
+
   return reconfig
 }

--- a/packages/udaru-core/package.json
+++ b/packages/udaru-core/package.json
@@ -132,7 +132,7 @@
     "pg": "^7.4.1",
     "pino": "^5.9.0",
     "postgrator": "^3.5.0",
-    "reconfig": "3.2.0",
+    "reconfig": "^3.3.0",
     "uuid": "^3.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Since v3.3.0 of reconfig, it drops functions that were passed into it. See issue #526.

Example:

```js
// template
{
  resources: {
    func1: function () {}
  }
}

// becomes
{
  resources: {
    func1: {}
  }
}
```

This was not the case in v3.2.0. Dependency was locked at the old version to prevent breaking Udaru. To still be able to upgrade to newer versions of the depencency, a fix is needed to restore the functions from `_rawConfig` => `_config`.

