### PR TITLE
Update udaru-hapi-plugin dependencies to the latest @hapi scope to fix a vulnerability issue

### DIFF
--- a/packages/udaru-hapi-plugin/lib/authentication.js
+++ b/packages/udaru-hapi-plugin/lib/authentication.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const Hoek = require('hoek')
-const Boom = require('boom')
+const Hoek = require('@hapi/hoek')
+const Boom = require('@hapi/boom')
 
 async function loadUser (job) {
   const { userId } = job

--- a/packages/udaru-hapi-plugin/lib/authorization.js
+++ b/packages/udaru-hapi-plugin/lib/authorization.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Boom = require('boom')
+const Boom = require('@hapi/boom')
 const getProperty = require('lodash/get')
 
 module.exports = function (config) {

--- a/packages/udaru-hapi-plugin/lib/routes/policies.js
+++ b/packages/udaru-hapi-plugin/lib/routes/policies.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Joi = require('@hapi/joi')
-const Boom = require('boom')
+const Boom = require('@hapi/boom')
 const pick = require('lodash/pick')
 const validation = require('@nearform/udaru-core/lib/ops/validation').policies
 const swagger = require('@nearform/udaru-core/lib/ops/validation').swagger

--- a/packages/udaru-hapi-plugin/package.json
+++ b/packages/udaru-hapi-plugin/package.json
@@ -118,18 +118,18 @@
     "test": "npm run pg:init-test-db && UDARU_SERVICE_logger_pino_level=silent lab"
   },
   "dependencies": {
+    "@hapi/boom": "^8.0.1",
+    "@hapi/hoek": "^8.3.0",
     "@hapi/joi": "^15.1.0",
     "@nearform/udaru-core": "^5.2.4",
-    "boom": "^7.2.2",
-    "hapi": "^18.1.0",
-    "hoek": "^6.1.3",
     "lodash": "^4.17.11"
   },
   "devDependencies": {
-    "code": "^5.2.4",
+    "@hapi/code": "^6.0.0",
+    "@hapi/hapi": "^18.4.0",
+    "@hapi/lab": "^20.4.0",
     "coveralls": "^3.0.2",
     "depcheck": "^0.8.1",
-    "lab": "^18.0.2",
     "sinon": "^7.1.1",
     "uuid": "^3.3.2"
   },

--- a/packages/udaru-hapi-plugin/test/authorization/authorization.test.js
+++ b/packages/udaru-hapi-plugin/test/authorization/authorization.test.js
@@ -1,4 +1,4 @@
-const Lab = require('lab')
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 
 const server = require('../test-server')

--- a/packages/udaru-hapi-plugin/test/authorization/organizations.test.js
+++ b/packages/udaru-hapi-plugin/test/authorization/organizations.test.js
@@ -1,4 +1,4 @@
-const Lab = require('lab')
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 
 const server = require('../test-server')

--- a/packages/udaru-hapi-plugin/test/authorization/policies.test.js
+++ b/packages/udaru-hapi-plugin/test/authorization/policies.test.js
@@ -1,4 +1,4 @@
-const Lab = require('lab')
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 
 const server = require('../test-server')

--- a/packages/udaru-hapi-plugin/test/authorization/teams.test.js
+++ b/packages/udaru-hapi-plugin/test/authorization/teams.test.js
@@ -1,4 +1,4 @@
-const Lab = require('lab')
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 const server = require('../test-server')
 const Factory = require('@nearform/udaru-core/test/factory')

--- a/packages/udaru-hapi-plugin/test/authorization/users.test.js
+++ b/packages/udaru-hapi-plugin/test/authorization/users.test.js
@@ -1,5 +1,5 @@
 
-const Lab = require('lab')
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 
 const server = require('../test-server')

--- a/packages/udaru-hapi-plugin/test/edgeCases.test.js
+++ b/packages/udaru-hapi-plugin/test/edgeCases.test.js
@@ -1,7 +1,7 @@
-const Lab = require('lab')
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
-const Hapi = require('hapi')
-const expect = require('code').expect
+const Hapi = require('@hapi/hapi')
+const expect = require('@hapi/code').expect
 const sinon = require('sinon')
 
 const server = require('./test-server')

--- a/packages/udaru-hapi-plugin/test/endToEnd/authorization.test.js
+++ b/packages/udaru-hapi-plugin/test/endToEnd/authorization.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const expect = require('code').expect
-const Lab = require('lab')
+const expect = require('@hapi/code').expect
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 const utils = require('@nearform/udaru-core/test/testUtils')
 const serverFactory = require('../test-server')

--- a/packages/udaru-hapi-plugin/test/endToEnd/fullOrgStructure.test.js
+++ b/packages/udaru-hapi-plugin/test/endToEnd/fullOrgStructure.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const expect = require('code').expect
-const Lab = require('lab')
+const expect = require('@hapi/code').expect
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 
 const config = require('../../lib/config')()

--- a/packages/udaru-hapi-plugin/test/endToEnd/monitor.test.js
+++ b/packages/udaru-hapi-plugin/test/endToEnd/monitor.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const expect = require('code').expect
-const Lab = require('lab')
+const expect = require('@hapi/code').expect
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 const serverFactory = require('../test-server')
 

--- a/packages/udaru-hapi-plugin/test/endToEnd/organizations.test.js
+++ b/packages/udaru-hapi-plugin/test/endToEnd/organizations.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const expect = require('code').expect
-const Lab = require('lab')
+const expect = require('@hapi/code').expect
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 const utils = require('@nearform/udaru-core/test/testUtils')
 const uuid = require('uuid/v4')

--- a/packages/udaru-hapi-plugin/test/endToEnd/policies.test.js
+++ b/packages/udaru-hapi-plugin/test/endToEnd/policies.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const _ = require('lodash')
-const expect = require('code').expect
-const Lab = require('lab')
+const expect = require('@hapi/code').expect
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 const utils = require('@nearform/udaru-core/test/testUtils')
 const serverFactory = require('../test-server')

--- a/packages/udaru-hapi-plugin/test/endToEnd/teams.test.js
+++ b/packages/udaru-hapi-plugin/test/endToEnd/teams.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const expect = require('code').expect
-const Lab = require('lab')
+const expect = require('@hapi/code').expect
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 const utils = require('@nearform/udaru-core/test/testUtils')
 const serverFactory = require('../test-server')

--- a/packages/udaru-hapi-plugin/test/endToEnd/users.test.js
+++ b/packages/udaru-hapi-plugin/test/endToEnd/users.test.js
@@ -1,8 +1,8 @@
 'use strict'
 
 const _ = require('lodash')
-const expect = require('code').expect
-const Lab = require('lab')
+const expect = require('@hapi/code').expect
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 const config = require('../../lib/config')()
 const utils = require('@nearform/udaru-core/test/testUtils')

--- a/packages/udaru-hapi-plugin/test/security/sqlinjection.test.js
+++ b/packages/udaru-hapi-plugin/test/security/sqlinjection.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const expect = require('code').expect
-const Lab = require('lab')
+const expect = require('@hapi/code').expect
+const Lab = require('@hapi/lab')
 const lab = exports.lab = Lab.script()
 const utils = require('@nearform/udaru-core/test/testUtils')
 const udaru = require('@nearform/udaru-core')()

--- a/packages/udaru-hapi-plugin/test/test-server.js
+++ b/packages/udaru-hapi-plugin/test/test-server.js
@@ -1,6 +1,6 @@
 const config = require('../lib/config')()
 const Action = config.get('AuthConfig.Action')
-const Hapi = require('hapi')
+const Hapi = require('@hapi/hapi')
 
 let server = null
 

--- a/packages/udaru-hapi-plugin/test/testBuilder.js
+++ b/packages/udaru-hapi-plugin/test/testBuilder.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const _ = require('lodash')
-const { expect } = require('code')
+const { expect } = require('@hapi/code')
 const udaru = require('@nearform/udaru-core')()
 const utils = require('@nearform/udaru-core/test/testUtils')
 


### PR DESCRIPTION
When running `npm audit` on my node project I received:

```
                       === npm audit security report ===

┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Denial of Service                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ subtext                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ No patch available                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @nearform/udaru-hapi-plugin                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @nearform/udaru-hapi-plugin > hapi > subtext                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1168                            │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 1 high severity vulnerability in 3627 scanned packages
  1 vulnerability requires manual review. See the full report for details.
```

There are no way to fix this issue on my own, because `hapi` and `subtext` dependencies are not maintained (they moved to `@hapi/hapi` and `@hapi/subtext`), therefore the `npm audit fix` command couldn't solve the issue. The only way to fix it is to update the `@nearform/udaru-hapi-plugin` dependencies.

In this PR I've updated the following dependencies:
- `"boom": "^7.2.2"` -> `"@hapi/boom": "^8.0.1"`
- `"hoek": "^6.1.3"` -> `"@hapi/hoek": "^8.3.0"`

And I noticed that the `hapi` package was only used in tests and not in the main code, so I moved `"hapi": "^18.1.0"` to `devDependencies` as `"@hapi/hapi": "^18.4.0"`.

I've also updated the `devDependencies`:
- `"code": "^5.2.4"` -> `"@hapi/code": "^6.0.0"`
- `"lab": "^18.0.2"` -> `"@hapi/lab": "^20.4.0"`

Let me know if anything else is needed in order to merge this PR.